### PR TITLE
Stronghold

### DIFF
--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -179,6 +179,7 @@ def configure_django():
                     'django.contrib.auth',
                     'django.contrib.contenttypes',
                     'django.contrib.messages',
+                    'stronghold',
                     'plinth']
     applications += module_loader.get_modules_to_load()
     sessions_directory = os.path.join(cfg.data_dir, 'sessions')
@@ -207,6 +208,7 @@ def configure_django():
             'django.contrib.auth.middleware.AuthenticationMiddleware',
             'django.contrib.messages.middleware.MessageMiddleware',
             'django.middleware.clickjacking.XFrameOptionsMiddleware',
+            'stronghold.middleware.LoginRequiredMiddleware',
             'plinth.modules.first_boot.middleware.FirstBootMiddleware',
         ),
         ROOT_URLCONF='plinth.urls',
@@ -214,6 +216,7 @@ def configure_django():
         SESSION_ENGINE='django.contrib.sessions.backends.file',
         SESSION_FILE_PATH=sessions_directory,
         STATIC_URL='/'.join([cfg.server_dir, 'static/']).replace('//', '/'),
+        STRONGHOLD_PUBLIC_NAMED_URLS=('lib:login',),
         TEMPLATE_CONTEXT_PROCESSORS=context_processors,
         USE_X_FORWARDED_HOST=bool(cfg.use_x_forwarded_host))
     django.setup()

--- a/plinth/modules/config/config.py
+++ b/plinth/modules/config/config.py
@@ -21,7 +21,6 @@ Plinth module for configuring timezone, hostname etc.
 
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.core import validators
 from django.template.response import TemplateResponse
 from gettext import gettext as _
@@ -98,7 +97,6 @@ def init():
     menu.add_urlname(_('Configure'), 'glyphicon-cog', 'config:index', 10)
 
 
-@login_required
 def index(request):
     """Serve the configuration form"""
     status = get_status()

--- a/plinth/modules/diagnostics/diagnostics.py
+++ b/plinth/modules/diagnostics/diagnostics.py
@@ -19,7 +19,6 @@
 Plinth module for running diagnostics
 """
 
-from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from gettext import gettext as _
 
@@ -34,14 +33,12 @@ def init():
     menu.add_urlname("Diagnostics", "glyphicon-screenshot", "diagnostics:index", 30)
 
 
-@login_required
 def index(request):
     """Serve the index page"""
     return TemplateResponse(request, 'diagnostics.html',
                             {'title': _('System Diagnostics')})
 
 
-@login_required
 def test(request):
     """Run diagnostics and the output page"""
     output = ''

--- a/plinth/modules/expert_mode/expert_mode.py
+++ b/plinth/modules/expert_mode/expert_mode.py
@@ -17,7 +17,6 @@
 
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from gettext import gettext as _
 
@@ -37,7 +36,6 @@ def init():
     menu.add_urlname(_('Expert Mode'), 'glyphicon-wrench', 'expert_mode:index', 10)
 
 
-@login_required
 def index(request):
     """Serve the configuration form"""
     status = get_status(request)

--- a/plinth/modules/firewall/firewall.py
+++ b/plinth/modules/firewall/firewall.py
@@ -19,7 +19,6 @@
 Plinth module to configure a firewall
 """
 
-from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from gettext import gettext as _
 import logging
@@ -41,7 +40,6 @@ def init():
     service_enabled.connect(on_service_enabled)
 
 
-@login_required
 def index(request):
     """Serve introcution page"""
     if not get_installed_status():

--- a/plinth/modules/first_boot/urls.py
+++ b/plinth/modules/first_boot/urls.py
@@ -20,13 +20,14 @@ URLs for the First Boot module
 """
 
 from django.conf.urls import patterns, url
+from stronghold.decorators import public
 from .views import State0View
 
 
 urlpatterns = patterns(  # pylint: disable-msg=C0103
     'plinth.modules.first_boot.views',
     # Take care of the firstboot middleware when changing URLs
-    url(r'^firstboot/$', State0View.as_view(), name='index'),
-    url(r'^firstboot/state0/$', State0View.as_view(), name='state0'),
+    url(r'^firstboot/$', public(State0View.as_view()), name='index'),
+    url(r'^firstboot/state0/$', public(State0View.as_view()), name='state0'),
     url(r'^firstboot/state10/$', 'state10', name='state10'),
     )

--- a/plinth/modules/help/help.py
+++ b/plinth/modules/help/help.py
@@ -19,6 +19,7 @@ import os
 from gettext import gettext as _
 from django.http import Http404
 from django.template.response import TemplateResponse
+from stronghold.decorators import public
 
 from plinth import cfg
 
@@ -38,18 +39,21 @@ def init():
     menu.add_urlname(_('About'), 'glyphicon-star', 'help:about', 100)
 
 
+@public
 def index(request):
     """Serve the index page"""
     return TemplateResponse(request, 'help.html',
                             {'title': _('Documentation and FAQ')})
 
 
+@public
 def about(request):
     """Serve the about page"""
     title = _('About the {box_name}').format(box_name=cfg.box_name)
     return TemplateResponse(request, 'about.html', {'title': title})
 
 
+@public
 def helppage(request, page):
     """Serve a help page from the 'doc' directory"""
     try:

--- a/plinth/modules/owncloud/owncloud.py
+++ b/plinth/modules/owncloud/owncloud.py
@@ -17,7 +17,6 @@
 
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from gettext import gettext as _
 
@@ -46,7 +45,6 @@ def init():
                               is_external=True, enabled=status['enabled'])
 
 
-@login_required
 def index(request):
     """Serve the ownCloud configuration page"""
     status = get_status()

--- a/plinth/modules/packages/packages.py
+++ b/plinth/modules/packages/packages.py
@@ -17,7 +17,6 @@
 
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from gettext import gettext as _
 import os
@@ -60,7 +59,6 @@ def init():
     menu.add_urlname('Package Manager', 'glyphicon-gift', 'packages:index', 20)
 
 
-@login_required
 def index(request):
     """Serve the form"""
     status = get_status()

--- a/plinth/modules/pagekite/pagekite.py
+++ b/plinth/modules/pagekite/pagekite.py
@@ -21,7 +21,6 @@ Plinth module for configuring PageKite service
 
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.core import validators
 from django.core.urlresolvers import reverse_lazy
 from django.template import RequestContext
@@ -44,7 +43,6 @@ def init():
                      'pagekite:index', 50)
 
 
-@login_required
 def index(request):
     """Serve introdution page"""
     menu = {'title': _('PageKite'),
@@ -104,7 +102,6 @@ for your account if no secret is set on the kite'))
 https://pagekite.net/wiki/Howto/SshOverPageKite/">instructions</a>'))
 
 
-@login_required
 def configure(request):
     """Serve the configuration form"""
     status = get_status()

--- a/plinth/modules/tor/tor.py
+++ b/plinth/modules/tor/tor.py
@@ -21,7 +21,6 @@ Plinth module for configuring Tor
 
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.template.response import TemplateResponse
 from gettext import gettext as _
 
@@ -42,7 +41,6 @@ def init():
     menu.add_urlname('Tor', 'glyphicon-eye-close', 'tor:index', 30)
 
 
-@login_required
 def index(request):
     """Service the index page"""
     status = get_status()

--- a/plinth/modules/users/users.py
+++ b/plinth/modules/users/users.py
@@ -17,7 +17,6 @@
 
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core import validators
 from django.core.urlresolvers import reverse_lazy
@@ -40,7 +39,6 @@ def init():
     menu.add_urlname(_('Users and Groups'), 'glyphicon-user', 'users:index', 15)
 
 
-@login_required
 def index(request):
     """Return a rendered users page"""
     menu = {'title': _('Users and Groups'),
@@ -74,7 +72,6 @@ and alphabet'),
     email = forms.EmailField(label=_('Email'), required=False)
 
 
-@login_required
 def add(request):
     """Serve the form"""
     form = None
@@ -119,7 +116,6 @@ class UserEditForm(forms.Form):  # pylint: disable-msg=W0232
             self.fields['delete_user_' + user.username] = field
 
 
-@login_required
 def edit(request):
     """Serve the edit form"""
     form = None

--- a/plinth/modules/xmpp/xmpp.py
+++ b/plinth/modules/xmpp/xmpp.py
@@ -17,7 +17,6 @@
 
 from django import forms
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse_lazy
 from django.template import RequestContext
 from django.template.loader import render_to_string
@@ -64,7 +63,6 @@ def init():
         enabled=True)
 
 
-@login_required
 def index(request):
     """Serve XMPP page"""
     is_installed = actions.superuser_run(
@@ -91,7 +89,6 @@ class ConfigureForm(forms.Form):  # pylint: disable-msg=W0232
 allowed to register an account through an XMPP client'))
 
 
-@login_required
 def configure(request):
     """Serve the configuration form"""
     status = get_status()
@@ -157,7 +154,6 @@ class RegisterForm(forms.Form):  # pylint: disable-msg=W0232
         label=_('Password'), widget=forms.PasswordInput())
 
 
-@login_required
 def register(request):
     """Serve the registration form"""
     form = None


### PR DESCRIPTION
Instead of #19 use `django-stronghold` (https://github.com/mgrouchy/django-stronghold) for plinth authentication handling (to replace the `@login_required` decorators).

I tested this with the current plinth master, python3, django1.7-2 and django-stronghold==0.2.6, installed via pip3.

`setup.py` and `INSTALL` should be updated before merging this pull request, @SunilMohanAdapa please tell me when the packages (or names) for the debian stronghold package are ready.