### PR TITLE
dynamicdns

### DIFF
--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -34,41 +34,41 @@ doGetOpt()
 	ignoreCertError=0
 	
     while getopts ":s:d:u:p:I:U:c:b:" opt; do
-        case $opt in
+        case ${opt} in
             s)
-                server=$OPTARG
+                server=${OPTARG}
             ;;
             d)
-                host=$OPTARG
+                host=${OPTARG}
             ;;
             u)
-                user=$OPTARG
+                user=${OPTARG}
             ;;
             p)
-                pass=$OPTARG
+                pass=${OPTARG}
             ;;
             I)
-                if [ "$OPTARG" != "$EMPTYSTRING" ];then
-                    ipurl=$OPTARG
+                if [ "${OPTARG}" != "${EMPTYSTRING}" ];then
+                    ipurl=${OPTARG}
                 else
                     ipurl=""
                 fi
             ;;
             U)
-                if [ "$OPTARG" != "$EMPTYSTRING" ];then
-                    updateurl=$OPTARG
+                if [ "${OPTARG}" != "${EMPTYSTRING}" ];then
+                    updateurl=${OPTARG}
                 else
                     updateurl=""
                 fi
             ;;
             b)
-                basicauth=$OPTARG
+                basicauth=${OPTARG}
             ;;
             c)
-                ignoreCertError=$OPTARG
+                ignoreCertError=${OPTARG}
             ;;            
             \?)
-                echo "Invalid option: -$OPTARG" >&2
+                echo "Invalid option: -${OPTARG}" >&2
                 exit 1
             ;;
         esac
@@ -77,53 +77,53 @@ doGetOpt()
 
 doWriteCFG()
 {
-    mkdir $CFGDIR 2> /dev/null
+    mkdir ${CFGDIR} 2> /dev/null
     #always write to the inactive config - needs to be enabled via "start" command later
-    file=$CFG_disabled
+    local out_file=${CFG_disabled}
 
     #reset the last update time
-    echo 0 > $LASTUPDATE
+    echo 0 > ${LASTUPDATE}
 
     #reset the last updated IP
-    echo "0.0.0.0" > $IPFILE
+    echo "0.0.0.0" > ${IPFILE}
 
     #reset last update (if there is one)
-    rm $STATUSFILE 2> /dev/null
+    rm ${STATUSFILE} 2> /dev/null
 
     #find the interface (always the default gateway interface)
     default_interface=`ip route |grep default |awk '{print $5}'`
 
     #store the given options in ez-ipupdate compatible config file
-    echo "host=$host" > $file
-    echo "server=$server" >> $file
-    echo "user=${user}:${pass}" >> $file
-    echo "service-type=gnudip" >> $file
-    echo "retrys=3" >> $file
-    echo "wildcard" >> $file
+    echo "host=${host}" > ${out_file}
+    echo "server=${server}" >> ${out_file}
+    echo "user=${user}:${pass}" >> ${out_file}
+    echo "service-type=gnudip" >> ${out_file}
+    echo "retrys=3" >> ${out_file}
+    echo "wildcard" >> ${out_file}
     
     #store UPDATE URL params
-    echo "POSTURL $updateurl" > $HELPERCFG
-    echo "POSTAUTH $basicauth" >> $HELPERCFG
-    echo "POSTSSLIGNORE $ignoreCertError" >> $HELPERCFG
+    echo "POSTURL ${updateurl}" > ${HELPERCFG}
+    echo "POSTAUTH ${basicauth}" >> ${HELPERCFG}
+    echo "POSTSSLIGNORE ${ignoreCertError}" >> ${HELPERCFG}
     
     #check if we are behind a NAT Router
-    echo "IPURL $ipurl" >> $HELPERCFG
-    if [ -z $ipurl ];then
-        echo "NAT unknown" >> $HELPERCFG
+    echo "IPURL ${ipurl}" >> ${HELPERCFG}
+    if [ -z ${ipurl} ];then
+        echo "NAT unknown" >> ${HELPERCFG}
     else 
         doGetWANIP
-        ISGLOBAL=`ip addr ls $default_interface | grep $wanip`
-        if [ -z $ISGLOBAL ];then
+        ISGLOBAL=`ip addr ls ${default_interface} | grep ${wanip}`
+        if [ -z ${ISGLOBAL} ];then
             #we are behind NAT
-            echo "NAT yes" >> $HELPERCFG
+            echo "NAT yes" >> ${HELPERCFG}
         else
             #we are directly connected
-            echo "NAT no" >> $HELPERCFG
+            echo "NAT no" >> ${HELPERCFG}
             #if this file is added ez-ipupdate will take ip form this interface
-            echo "interface=$default_interface" >> $file
+            echo "interface=${default_interface}" >> ${out_file}
             #if this line is added to config file, ez-ipupdate will be launched on startup via init.d
-            echo "daemon" >> $file
-            echo "execute=$0 success" >> $file
+            echo "daemon" >> ${out_file}
+            echo "execute=${0} success" >> ${out_file}
         fi
     fi
 }
@@ -135,72 +135,69 @@ doReadCFG()
     user=""
     pass=""
     ipurl=""
-    file=""
-    [ -f $CFG_disabled ] && file=$CFG_disabled
-    [ -f $CFG ] && file=$CFG
 
-    if [ ! -z $file ];then
-        host=`cat $file 2> /dev/null |grep host |cut -d = -f 2`
-        server=`cat $file 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\'`
-        user=`cat $file 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1 `
-        pass=`cat $file 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 2`
+    if [ ! -z ${cfgfile} ];then
+        host=`cat ${cfgfile} 2> /dev/null |grep host |cut -d = -f 2`
+        server=`cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\'`
+        user=`cat ${cfgfile} 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1 `
+        pass=`cat ${cfgfile} 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 2`
     fi
 
-    if [ ! -z $HELPERCFG ];then
-        ipurl=`cat $HELPERCFG 2> /dev/null |grep ^IPURL |awk '{print $2}' |grep -v ^\'\'`
-        updateurl=`cat $HELPERCFG 2> /dev/null |grep POSTURL |awk '{print $2}' |grep -v ^\'\'`
-        basicauth=`cat $HELPERCFG 2> /dev/null |grep POSTAUTH |awk '{print $2}' |grep -v ^\'\'`
-        ignoreCertError=`cat $HELPERCFG 2> /dev/null |grep POSTSSLIGNORE |awk '{print $2}' |grep -v ^\'\'`
+    if [ ! -z ${HELPERCFG} ];then
+        ipurl=`cat ${HELPERCFG} 2> /dev/null |grep ^IPURL |awk '{print $2}' |grep -v ^\'\'`
+        updateurl=`cat ${HELPERCFG} 2> /dev/null |grep POSTURL |awk '{print $2}' |grep -v ^\'\'`
+        basicauth=`cat ${HELPERCFG} 2> /dev/null |grep POSTAUTH |awk '{print $2}' |grep -v ^\'\'`
+        ignoreCertError=`cat ${HELPERCFG} 2> /dev/null |grep POSTSSLIGNORE |awk '{print $2}' |grep -v ^\'\'`
     fi  
 }
 
 doStatus()
 {
 	PROC=`pgrep ${TOOLNAME}`
-	if [ -f $CRONJOB ];then
+	if [ -f ${CRONJOB} ];then
 	     echo enabled 
-	elif [ ! -z $PROC ];then 
+	elif [ ! -z ${PROC} ];then
 	    echo enabled
 	else
 	    echo disabled
 	fi
-		if [ ! -z $server ];then
-		echo $server
+		if [ ! -z ${server} ];then
+			echo ${server}
 		else
 			echo disabled
 		fi
-	if [ ! -z $host  ];then 
-		echo $host
+	if [ ! -z ${host}  ];then
+		echo ${host}
 		else
 			echo disabled
 		fi
-		if [ ! -z $user ];then
-		echo $user
+		if [ ! -z ${user} ];then
+			echo ${user}
 		else
 			echo disabled
 		fi
-	if [ ! -z $pass  ];then 
-		echo $pass
+	if [ ! -z ${pass}  ];then
+		echo ${pass}
 		else
 			echo disabled
 		fi        
-		if [ ! -z $ipurl ];then
-		echo $ipurl
+		if [ ! -z ${ipurl} ];then
+		echo ${ipurl}
 		else
 			echo disabled
 		fi
-	if [ ! -z $updateurl  ];then 
-		echo $updateurl
+	if [ ! -z ${updateurl}  ];then
+		echo ${updateurl}
 		else
 			echo disabled
 		fi  
-	if [ ! -z $basicauth ];then
-		echo $basicauth
+	if [ ! -z ${basicauth} ];then
+		echo ${basicauth}
 	else
 			echo disabled
 	fi		
-	if [ ! -z $ignoreCertError ];then
-		echo $ignoreCertError 
+	if [ ! -z ${ignoreCertError} ];then
+		echo ${ignoreCertError}
 	else
 		echo disabled
 	fi	
@@ -208,12 +205,12 @@ doStatus()
 
 doGetWANIP()
 {
-    if [ ! -z $ipurl ];then
-        outfile=`mktemp`
-        $WGET $WGETOPTIONS -O $outfile $ipurl
-        wanip=`cat $outfile`
-        rm $outfile
-        [ -z $wanip ] && wanip=${NOIP}
+    if [ ! -z ${ipurl} ];then
+        outfile=$(mktemp)
+		${WGET} ${WGETOPTIONS} -O ${outfile} ${ipurl}
+        wanip=$(cat ${outfile})
+		rm ${outfile}
+    [ -z ${wanip} ] && wanip=${NOIP}
     else
         #no WAN IP found because of missing check URL
         wanip=${NOIP}
@@ -222,30 +219,33 @@ doGetWANIP()
 
 doUpdate()
 {
-	if [ ! -z $server ];then 
-		start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c $file	
+	if [ ! -z ${server} ];then
+		start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c ${cfgfile}
 	fi
 	
-	if [ ! -z $updateurl ];then
+	if [ ! -z ${updateurl} ];then
 		echo "todo"	
 	fi
 }
 
-cmd=$1
+cmd=${1}
 shift
-case $cmd in
+cfgfile="/tmp/none"
+[ -f ${CFG_disabled} ] && cfgfile=${CFG_disabled}
+[ -f ${CFG} ] && cfgfile=${CFG}
+case ${cmd} in
     configure)
-        doGetOpt $@
+        doGetOpt ${@}
         doWriteCFG
     ;;
     start)
         if [ "$(cat $HELPERCFG |grep ^NAT | awk '{print $2}')" = "no" ];then
-        	if [ -f $CFG -a ! -z $(cat $file 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then
-            	mv $CFG_disabled $CFG
+			if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then
+				mv ${CFG_disabled} ${CFG}
             	/etc/init.d/${TOOLNAME} start        		
 			fi
 			if [ ! -z $(cat $HELPERCFG |grep ^POSTURL | awk '{print $2}') ];then
-				echo "*/${UPDATEMINUTES} * * * * root $0 update" > $CRONJOB
+				echo "*/${UPDATEMINUTES} * * * * root $0 update" > ${CRONJOB}
             	$0 update
 			fi
         else
@@ -255,20 +255,17 @@ case $cmd in
     ;;
     get-nat)
         NAT=`cat $HELPERCFG 2> /dev/null |grep ^NAT | awk '{print $2}'`
-        [ -z $NAT ] && NAT="unknown"
-        echo $NAT
+        [ -z ${NAT} ] && NAT="unknown"
+        echo ${NAT}
     ;;
     update)
         doReadCFG
-        oldip=`cat $IPFILE`
+        oldip=`cat ${IPFILE}`
         doGetWANIP
-        echo $wanip > $IPFILE
-        cfgfile="/tmp/none"
-        [ -f $CFG_disabled ] && cfgfile=$CFG_disabled
-        [ -f $CFG ] && cfgfile=$CFG
-        cat $file |grep -v execute > ${cfgfile}.tmp
+        echo ${wanip} > ${IPFILE}
+        cat ${cfgfile} |grep -v execute > ${cfgfile}.tmp
         mv ${cfgfile}.tmp ${cfgfile}
-        echo "execute=$0 success ${wanip}" >> $cfgfile
+        echo "execute=${0} success ${wanip}" >> ${cfgfile}
         #if we know our WAN IP, only update if IP changes
         if [ "${oldip}" != "${wanip}" -a "${wanip}" != ${NOIP} ];then
             doUpdate
@@ -277,39 +274,39 @@ case $cmd in
         if [ "${wanip}" = ${NOIP} ];then
             uptime=`cat /proc/uptime |cut -d . -f 1`
             LAST=0
-            [ -f ${LASTUPDATE} ] && LAST=`cat $LASTUPDATE`
-            diff=`expr $uptime - $LAST`
-            if [ $diff -gt $UPDATEMINUTESUNKNOWN ];then
+            [ -f ${LASTUPDATE} ] && LAST=`cat ${LASTUPDATE}`
+            diff=`expr ${uptime} - ${LAST}`
+            if [ ${diff} -gt ${UPDATEMINUTESUNKNOWN} ];then
                 doUpdate
             fi
         fi
     ;;
     stop)
-        rm $CRONJOB 2> /dev/null
+        rm ${CRONJOB} 2> /dev/null
         /etc/init.d/${TOOLNAME} stop
         kill $(cat ${PIDFILE}) 2> /dev/null
-        mv $CFG $CFG_disabled
+        mv ${CFG} ${CFG_disabled}
     ;;
     success)
         date=`date`
-        echo "last update done ($date)" > $STATUSFILE
-        cat /proc/uptime |awk '{print $1}' |cut -d . -f 1 > $LASTUPDATE
+        echo "last update done (${date})" > ${STATUSFILE}
+        cat /proc/uptime |awk '{print $1}' |cut -d . -f 1 > ${LASTUPDATE}
         #if called from cronjob, the current IP is given as parameter
         if [ $# -eq 1 ];then
-          echo $1 > $IPFILE
+			echo ${1} > ${IPFILE}
         else
-          #if called from ez-ipupdate daemon, no WAN IP is given as parameter
-          doGetWANIP
-          echo $wanip > $IPFILE
+			#if called from ez-ipupdate daemon, no WAN IP is given as parameter
+			doGetWANIP
+			echo ${wanip} > ${IPFILE}
         fi
     ;;
     failed)
         date=`date`
-        echo "last update failed ($date)" > $STATUSFILE
+        echo "last update failed (${date})" > ${STATUSFILE}
     ;;    
     get-last-success)
-        if [ -f $STATUSFILE ];then
-            cat $STATUSFILE
+        if [ -f ${STATUSFILE} ];then
+            cat ${STATUSFILE}
         else
             echo "no successful update recorded since last config change"
         fi
@@ -319,11 +316,11 @@ case $cmd in
 		doStatus			
     ;;
     get-timer)
-        echo $UPDATEMINUTES
+		echo ${UPDATEMINUTES}
     ;;
     clean)
         rm ${CFGDIR}/*
-        rm $CRONJOB
+        rm ${CRONJOB}
     ;;
     *)
         echo "usage: status|configure <options>|start|stop|update|get-nat|clean|success [updated IP]|failed"

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -54,7 +54,11 @@ doGetOpt()
     while getopts ":s:d:u:p:I:U:c:b:" opt; do
         case ${opt} in
             s)
-                server=${OPTARG}
+                if [ "${OPTARG}" != "${EMPTYSTRING}" ];then
+                    server=${OPTARG}
+                else
+                    server=""
+                fi
             ;;
             d)
                 host=${OPTARG}

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -357,7 +357,7 @@ case ${cmd} in
     ;;
     update)
         doReadCFG
-        local dnsentry=$(nslookup "${host}"|tail -n2|grep A|sed s/[^0-9.]//g)
+        dnsentry=$(nslookup "${host}"|tail -n2|grep A|sed s/[^0-9.]//g)
         doGetWANIP
         echo  ${IPFILE}
         echo ${wanip} > ${IPFILE}

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -325,7 +325,7 @@ case ${cmd} in
         doGetWANIP
         if [ "$(cat $HELPERCFG |grep ^NAT | awk '{print $2}')" = "no" ];then
             #if we are not behind a NAT device and we use gnudip, start the daemon tool
-            if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then
+        if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\') ];then
                 mv ${CFG_disabled} ${CFG}
                 /etc/init.d/${TOOLNAME} start
             fi

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -351,7 +351,7 @@ case ${cmd} in
         fi
     ;;
     get-nat)
-        NAT=$(grep ^NAT $HELPERCFG 2> /dev/null | awk '{print $2')
+        NAT=$(grep ^NAT $HELPERCFG 2> /dev/null | awk '{print $2}')
         [ -z "${NAT}" ] && NAT="unknown"
         echo ${NAT}
     ;;

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -132,19 +132,19 @@ doWriteCFG()
 
     # store the given options in ez-ipupdate compatible config file
     {
-        "host=${host}"
-        "server=${server}"
-        "user=${user}:${pass}"
-        "service-type=gnudip"
-        "retrys=3"
-        "wildcard"
+        echo "host=${host}"
+        echo "server=${server}"
+        echo "user=${user}:${pass}"
+        echo "service-type=gnudip"
+        echo "retrys=3"
+        echo "wildcard"
     } > ${out_file}
     
     # store UPDATE URL params
     {
-        "POSTURL ${updateurl}"
-        "POSTAUTH ${basicauth}"
-        "POSTSSLIGNORE ${ignoreCertError}"
+        echo "POSTURL ${updateurl}"
+        echo "POSTAUTH ${basicauth}"
+        echo "POSTSSLIGNORE ${ignoreCertError}"
     } > ${HELPERCFG}
     
     # check if we are behind a NAT Router
@@ -275,7 +275,8 @@ doGetWANIP()
 {
     if [ ! -z "${ipurl}" ];then
         outfile=$(mktemp)
-        "${WGET}" "${WGETOPTIONS}" -O "${outfile}" "${ipurl}"
+        local cmd="${WGET} ${WGETOPTIONS} -O ${outfile} ${ipurl}"
+        $cmd
         wanip=$(sed s/[^0-9.]//g "${outfile}")
         rm "${outfile}"
         [ -z "${wanip}" ] && wanip=${NOIP}
@@ -304,8 +305,8 @@ doUpdate()
         if [ "${ignoreCertError}" = "enabled" ];then
             local wgetoptions=" --no-check-certificate "
         fi
-
-        "${WGET}" "${wgetoptions}" "${updateurl}"
+        local cmd="${WGET} ${wgetoptions} ${updateurl}"
+        $cmd
         # ToDo: check the returning text from WEB Server. User need to give expected string.
         if [ ${?} -eq 0 ];then
             ${0} success ${wanip}

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -153,6 +153,16 @@ doReadCFG()
     fi  
 }
 
+doReplaceVars()
+{
+    local url=`echo ${updateurl} | sed "s/<Ip>/${wanip}/g"`
+    url=`echo ${url} | sed "s/<Domain>/${host}/g"`
+	url=`echo ${url} | sed "s/<User>/${user}/g"`
+    url=`echo ${url} | sed "s/<Pass>/${pass}/g"`
+    url=`echo ${url} | sed "s/'//g"`
+	updateurl=$url
+}
+
 doStatus()
 {
 	PROC=$(pgrep ${TOOLNAME})
@@ -226,7 +236,16 @@ doUpdate()
 	fi
 	
 	if [ ! -z ${updateurl} ];then
-		echo "todo"	
+		doReplaceVars
+
+		if [ "${basicauth}" = "enabled" ];then
+			wgetoptions=" --user $user --password $pass "
+		fi
+        if [ "${ignoreCertError}" = "enabled" ];then
+			wgetoptions=" --no-check-certificate "
+		fi
+
+		$WGET ${wgetoptions} ${updateurl}
 	fi
 }
 
@@ -241,6 +260,7 @@ case ${cmd} in
         doWriteCFG
     ;;
     start)
+		doGetWANIP
         if [ "$(cat $HELPERCFG |grep ^NAT | awk '{print $2}')" = "no" ];then
 			#if we are not behind a NAT device and we use gnudip, start the daemon tool
 			if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -240,13 +240,13 @@ doUpdate()
 		doReplaceVars
 
 		if [ "${basicauth}" = "enabled" ];then
-			wgetoptions=" --user $user --password $pass "
+			local wgetoptions=" --user $user --password $pass "
 		fi
-        if [ "${ignoreCertError}" = "enabled" ];then
-			wgetoptions=" --no-check-certificate "
+		if [ "${ignoreCertError}" = "enabled" ];then
+			local wgetoptions=" --no-check-certificate "
 		fi
 
-		$WGET ${wgetoptions} ${updateurl}
+		$WGET ${wgetoptions} "${updateurl}"
 		[ $? -eq 0 ] && ${0} success
 	fi
 }

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -204,11 +204,11 @@ doReadCFG()
 # as plinth will add them
 doReplaceVars()
 {
-    local url="${updateurl//<Ip>/${wanip}}"
-    url="${url//<Domain>/${host}}"
-    url="${url//<User>/${user}}"
-    url="${url//<Pass>/${pass}}"
-    url="${url//\'/""}"
+    local url=$(echo "${updateurl}" | sed "s/<Ip>/${wanip}/g")
+    url=$(echo "${url}" | sed "s/<Domain>/${host}/g")
+    url=$(echo "${url}" | sed "s/<User>/${user}/g")
+    url=$(echo "${url}" | sed "s/<Pass>/${pass}/g")
+    url=$(echo "${url}" | sed "s/'//g")
     updateurl=${url}
     logger "expanded update URL as ${url}"
 }

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -1,22 +1,36 @@
 #!/bin/bash
-################################################################
-#                                                              #
-# The script is part of Freedombox                             #
-#                                                              #
-# This script is a wrapper around ez-ipupdate and/or wget      #
-# to update a Dynamic DNS account. The script is used as an    #
-# interface between plinth and ez-ipupdate                     #
-# the script will store configuration, return configuration    #
-# to plinth UI and do a dynamic DNS update. The script will    #
-# also determe if we are behind a NAT device, if we can use    #
-# ez-ipupdate tool or if we need to do some wget magic         #
-#                                                              #
-# Todo: IPv6                                                   #
-# Todo: GET WAN IP from Router via UPnP if supported           #
-# Todo: licence string?                                        #
-# author: Daniel Steglich <steglich@datasystems24.de>          #
-#                                                              #
-################################################################
+############################################################################
+#                                                                          #
+# This file is part of Plinth.                                             #
+#                                                                          #
+# This program is free software: you can redistribute it and/or modify     #
+# it under the terms of the GNU Affero General Public License as           #
+# published by the Free Software Foundation, either version 3 of the       #
+# License, or (at your option) any later version.                          #
+#                                                                          #
+# This program is distributed in the hope that it will be useful,          #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of           #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            #
+# GNU Affero General Public License for more details.                      #
+#                                                                          #
+# You should have received a copy of the GNU Affero General Public License #
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.    #
+#                                                                          #
+#                                                                          #
+# This script is a wrapper around ez-ipupdate and/or wget                  #
+# to update a Dynamic DNS account. The script is used as an                #
+# interface between plinth and ez-ipupdate                                 #
+# the script will store configuration, return configuration                #
+# to plinth UI and do a dynamic DNS update. The script will                #
+# also determe if we are behind a NAT device, if we can use                #
+# ez-ipupdate tool or if we need to do some wget magic                     #
+#                                                                          #
+# Todo: IPv6                                                               #
+# Todo: GET WAN IP from Router via UPnP if supported                       #
+# Todo: licence string?                                                    #
+# author: Daniel Steglich <steglich@datasystems24.de>                      #
+#                                                                          #
+############################################################################
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -269,7 +269,7 @@ doGetWANIP()
 # this function is called via cronjob
 doUpdate()
 {
-    dnsentry=$(nslookup ${host}|tail -n2|grep A|sed s/[^0-9.]//g)
+    local dnsentry=$(nslookup ${host}|tail -n2|grep A|sed s/[^0-9.]//g)
     if [ "${dnsentry}" =  "${wanip}" ];then
         return
     fi
@@ -335,7 +335,7 @@ case ${cmd} in
     ;;
     update)
         doReadCFG
-        oldip=$(cat ${IPFILE})
+        local dnsentry=$(nslookup ${host}|tail -n2|grep A|sed s/[^0-9.]//g)
         doGetWANIP
         echo  ${IPFILE}
         echo ${wanip} > ${IPFILE}
@@ -343,7 +343,7 @@ case ${cmd} in
         mv ${cfgfile}.tmp ${cfgfile}
         echo "execute=${0} success ${wanip}" >> ${cfgfile}
         # if we know our WAN IP, only update if IP changes
-        if [ "${oldip}" != "${wanip}" -a "${wanip}" != ${NOIP} ];then
+        if [ "${dnsentry}" != "${wanip}" -a "${wanip}" != ${NOIP} ];then
             doUpdate
         fi
         # if we don't know our WAN IP do a blind update once a hour

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -1,25 +1,40 @@
 #!/bin/bash
-#Todo: IPv6
-#Todo: Other service types than gnudip (generic update URL)
-#Todo: GET WAN IP from Router via UPnP if supported
+################################################################
+#                                                              #
+# The script is part of Freedombox                             #
+#                                                              #
+# This script is a wrapper around ez-ipupdate and/or wget      #
+# to update a Dynamic DNS account. The script is used as an    #
+# interface between plinth and ez-ipupdate                     #
+# the script will store configuration, return configuration    #
+# to plinth UI and do a dynamic DNS update. The script will    #
+# also determe if we are behind a NAT device, if we can use    #
+# ez-ipupdate tool or if we need to do some wget magic         #
+#                                                              #
+# Todo: IPv6                                                   #
+# Todo: GET WAN IP from Router via UPnP if supported           #
+# Todo: licence string?                                        #
+# author: Daniel Steglich <steglich@datasystems24.de>          #
+#                                                              #
+################################################################
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-#static values
+# static values
 WGET=$(which wget)
 WGETOPTIONS="-4 -o /dev/null -t 3 -T 3"
 EMPTYSTRING="none"
 NOIP="0.0.0.0"
-#how often do we poll for IP changes if we are behind a NAT?
+# how often do we poll for IP changes if we are behind a NAT?
 UPDATEMINUTES=5
-#if we do not have a IP check URL, how often should we do a "blind" update
+# if we do not have a IP check URL, how often should we do a "blind" update
 UPDATEMINUTESUNKNOWN=3600
 TOOLNAME=ez-ipupdate
 UPDATE_TOOL=$(which ${TOOLNAME})
 DISABLED_STRING='disabled'
 ENABLED_STRING='enabled'
 
-#Dirs and filenames
+# Dirs and filenames
 CFGDIR="/etc/${TOOLNAME}/"
 CFG="${CFGDIR}${TOOLNAME}.conf"
 CFG_disabled="${CFGDIR}${TOOLNAME}.inactive"
@@ -30,6 +45,7 @@ HELPERCFG="${CFGDIR}${TOOLNAME}-plinth.cfg"
 CRONJOB="/etc/cron.d/${TOOLNAME}"
 PIDFILE="/var/run/ez-ipupdate.pid"
 
+# this function will parse commandline options
 doGetOpt()
 {
     basicauth=0
@@ -77,25 +93,26 @@ doGetOpt()
     done
 }
 
+# this function will write a persistent config file to disk
 doWriteCFG()
 {
     mkdir ${CFGDIR} 2> /dev/null
-    #always write to the inactive config - needs to be enabled via "start" command later
+    # always write to the inactive config - needs to be enabled via "start" command later
     local out_file=${CFG_disabled}
 
-    #reset the last update time
+    # reset the last update time
     echo 0 > ${LASTUPDATE}
 
-    #reset the last updated IP
+    # reset the last updated IP
     echo "0.0.0.0" > ${IPFILE}
 
-    #reset last update (if there is one)
+    # reset last update (if there is one)
     rm ${STATUSFILE} 2> /dev/null
 
-    #find the interface (always the default gateway interface)
+    # find the interface (always the default gateway interface)
     default_interface=$(ip route |grep default |awk '{print $5}')
 
-    #store the given options in ez-ipupdate compatible config file
+    # store the given options in ez-ipupdate compatible config file
     echo "host=${host}" > ${out_file}
     echo "server=${server}" >> ${out_file}
     echo "user=${user}:${pass}" >> ${out_file}
@@ -103,12 +120,12 @@ doWriteCFG()
     echo "retrys=3" >> ${out_file}
     echo "wildcard" >> ${out_file}
     
-    #store UPDATE URL params
+    # store UPDATE URL params
     echo "POSTURL ${updateurl}" > ${HELPERCFG}
     echo "POSTAUTH ${basicauth}" >> ${HELPERCFG}
     echo "POSTSSLIGNORE ${ignoreCertError}" >> ${HELPERCFG}
     
-    #check if we are behind a NAT Router
+    # check if we are behind a NAT Router
     echo "IPURL ${ipurl}" >> ${HELPERCFG}
     if [ -z ${ipurl} ];then
         echo "NAT unknown" >> ${HELPERCFG}
@@ -116,20 +133,24 @@ doWriteCFG()
         doGetWANIP
         ISGLOBAL=$(ip addr ls ${default_interface} | grep ${wanip})
         if [ -z ${ISGLOBAL} ];then
-            #we are behind NAT
+            # we are behind NAT
             echo "NAT yes" >> ${HELPERCFG}
         else
-            #we are directly connected
+            # we are directly connected
             echo "NAT no" >> ${HELPERCFG}
-            #if this file is added ez-ipupdate will take ip form this interface
+            # if this file is added ez-ipupdate will take ip form this interface
             echo "interface=${default_interface}" >> ${out_file}
-            #if this line is added to config file, ez-ipupdate will be launched on startup via init.d
+            # if this line is added to config file, ez-ipupdate will be launched on startup via init.d
             echo "daemon" >> ${out_file}
             echo "execute=${0} success" >> ${out_file}
         fi
     fi
 }
 
+# this function will read the config file from disk
+# special treatment for empty strings is done here:
+# plinth will give empty strings like: ''
+# but we don't want this single quotes to be used
 doReadCFG()
 { 
     host=""
@@ -153,6 +174,10 @@ doReadCFG()
     fi  
 }
 
+# replace vars from url: i.e.:
+# https://example.com/update.php?domain=<Domain>&User=<User>&Pass=<Pass>
+# also this function will remove the surounding single quotes from the URL string
+# as plinth will add them
 doReplaceVars()
 {
     local url=`echo ${updateurl} | sed "s/<Ip>/${wanip}/g"`
@@ -163,6 +188,10 @@ doReplaceVars()
     updateurl=$url
 }
 
+# doReadCFG() needs to be run before this
+# this function will return all configured parameters in a way that
+# plinth will understand (plinth know the order of
+# parameters this function will return)
 doStatus()
 {
     PROC=$(pgrep ${TOOLNAME})
@@ -216,6 +245,8 @@ doStatus()
     fi
 }
 
+# ask a public WEB Server for the WAN IP we are comming from
+# and store this ip within $wanip
 doGetWANIP()
 {
     if [ ! -z ${ipurl} ];then
@@ -225,11 +256,13 @@ doGetWANIP()
         rm ${outfile}
         [ -z ${wanip} ] && wanip=${NOIP}
     else
-        #no WAN IP found because of missing check URL
+        # no WAN IP found because of missing check URL
         wanip=${NOIP}
     fi
 }
 
+# actualy do the update (using wget or ez-ipupdate or even both)
+# this function is called via cronjob
 doUpdate()
 {
     if [ ! -z ${server} ];then
@@ -238,7 +271,6 @@ doUpdate()
 
     if [ ! -z ${updateurl} ];then
         doReplaceVars
-
         if [ "${basicauth}" = "enabled" ];then
             local wgetoptions=" --user $user --password $pass "
         fi
@@ -247,7 +279,7 @@ doUpdate()
         fi
 
         $WGET ${wgetoptions} "${updateurl}"
-        #ToDo: check the returning text from WEB Server. User need to give expected string.
+        # ToDo: check the returning text from WEB Server. User need to give expected string.
         if [ $? -eq 0 ];then
             ${0} success $wanip
         else
@@ -258,9 +290,12 @@ doUpdate()
 
 cmd=${1}
 shift
+# decide which config to use
 cfgfile="/tmp/none"
 [ -f ${CFG_disabled} ] && cfgfile=${CFG_disabled}
 [ -f ${CFG} ] && cfgfile=${CFG}
+
+# check what action is requested
 case ${cmd} in
     configure)
         doGetOpt ${@}
@@ -274,14 +309,14 @@ case ${cmd} in
                 mv ${CFG_disabled} ${CFG}
                 /etc/init.d/${TOOLNAME} start
             fi
-            #if we are not behind a NAT device and we use update-URL, add a cronjob
-            #(daemon tool does not support update-URL feature)
+            # if we are not behind a NAT device and we use update-URL, add a cronjob
+            # (daemon tool does not support update-URL feature)
             if [ ! -z $(cat $HELPERCFG |grep ^POSTURL | awk '{print $2}') ];then
                 echo "*/${UPDATEMINUTES} * * * * root $0 update" > ${CRONJOB}
                 $0 update
             fi
         else
-            #if we are behind a NAT device, add a cronjob (daemon tool cannot monitor WAN IP changes)
+            # if we are behind a NAT device, add a cronjob (daemon tool cannot monitor WAN IP changes)
             echo "*/${UPDATEMINUTES} * * * * root $0 update" > $CRONJOB
             $0 update
         fi
@@ -300,11 +335,11 @@ case ${cmd} in
         cat ${cfgfile} |grep -v execute > ${cfgfile}.tmp
         mv ${cfgfile}.tmp ${cfgfile}
         echo "execute=${0} success ${wanip}" >> ${cfgfile}
-        #if we know our WAN IP, only update if IP changes
+        # if we know our WAN IP, only update if IP changes
         if [ "${oldip}" != "${wanip}" -a "${wanip}" != ${NOIP} ];then
             doUpdate
         fi
-        #if we don't know our WAN IP do a blind update once a hour
+        # if we don't know our WAN IP do a blind update once a hour
         if [ "${wanip}" = ${NOIP} ];then
             uptime=$(cat /proc/uptime |cut -d . -f 1)
             LAST=0
@@ -325,11 +360,11 @@ case ${cmd} in
         date=$(date)
         echo "last update done (${date})" > ${STATUSFILE}
         cat /proc/uptime |awk '{print $1}' |cut -d . -f 1 > ${LASTUPDATE}
-        #if called from cronjob, the current IP is given as parameter
+        # if called from cronjob, the current IP is given as parameter
         if [ $# -eq 1 ];then
             echo ${1} > ${IPFILE}
         else
-            #if called from ez-ipupdate daemon, no WAN IP is given as parameter
+            # if called from ez-ipupdate daemon, no WAN IP is given as parameter
             doGetWANIP
             echo ${wanip} > ${IPFILE}
         fi

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -300,12 +300,12 @@ doUpdate()
     if [ ! -z "${updateurl}" ];then
         doReplaceVars
         if [ "${basicauth}" = "enabled" ];then
-            local wgetoptions=" --user ${user} --password ${pass} "
+            WGETOPTIONS="${WGETOPTIONS} --user ${user} --password ${pass} "
         fi
         if [ "${ignoreCertError}" = "enabled" ];then
-            local wgetoptions=" --no-check-certificate "
+            WGETOPTIONS="${WGETOPTIONS} --no-check-certificate "
         fi
-        local cmd="${WGET} ${wgetoptions} ${updateurl}"
+        local cmd="${WGET} ${WGETOPTIONS} ${updateurl}"
         $cmd
         # ToDo: check the returning text from WEB Server. User need to give expected string.
         if [ ${?} -eq 0 ];then

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -247,6 +247,7 @@ doUpdate()
 		fi
 
 		$WGET ${wgetoptions} ${updateurl}
+		[ $? -eq 0 ] && ${0} success
 	fi
 }
 

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -199,7 +199,8 @@ doStatus()
 			echo $DISABLED_STRING
 		fi
 	if [ ! -z ${updateurl}  ];then
-		echo ${updateurl}
+		local url=`echo ${updateurl} | sed "s/'//g"`
+		echo ${url}
 		else
 			echo $DISABLED_STRING
 		fi  

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -246,8 +246,7 @@ doStatus()
         echo $DISABLED_STRING
     fi
     if [ ! -z ${updateurl}  ];then
-        local url=`echo ${updateurl} | sed "s/'//g"`
-        echo ${url}
+        echo ${updateurl}
     else
         echo $DISABLED_STRING
     fi

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -16,6 +16,8 @@ UPDATEMINUTES=5
 UPDATEMINUTESUNKNOWN=3600
 TOOLNAME=ez-ipupdate
 UPDATE_TOOL=$(which ${TOOLNAME})
+DISABLED_STRING='disabled'
+ENABLED_STRING='enabled'
 
 #Dirs and filenames
 CFGDIR="/etc/${TOOLNAME}/"
@@ -155,51 +157,51 @@ doStatus()
 {
 	PROC=$(pgrep ${TOOLNAME})
 	if [ -f ${CRONJOB} ];then
-	     echo enabled 
+	     echo $ENABLED_STRING 
 	elif [ ! -z ${PROC} ];then
-	    echo enabled
+	    echo $ENABLED_STRING
 	else
-	    echo disabled
+	    echo $DISABLED_STRING
 	fi
 		if [ ! -z ${server} ];then
 			echo ${server}
 		else
-			echo disabled
+			echo $DISABLED_STRING
 		fi
 	if [ ! -z ${host}  ];then
 		echo ${host}
 		else
-			echo disabled
+			echo $DISABLED_STRING
 		fi
 		if [ ! -z ${user} ];then
 			echo ${user}
 		else
-			echo disabled
+			echo $DISABLED_STRING
 		fi
 	if [ ! -z ${pass}  ];then
 		echo ${pass}
 		else
-			echo disabled
+			echo $DISABLED_STRING
 		fi        
 		if [ ! -z ${ipurl} ];then
 		echo ${ipurl}
 		else
-			echo disabled
+			echo $DISABLED_STRING
 		fi
 	if [ ! -z ${updateurl}  ];then
 		echo ${updateurl}
 		else
-			echo disabled
+			echo $DISABLED_STRING
 		fi  
 	if [ ! -z ${basicauth} ];then
 		echo ${basicauth}
 	else
-			echo disabled
+			echo $DISABLED_STRING
 	fi		
 	if [ ! -z ${ignoreCertError} ];then
 		echo ${ignoreCertError}
 	else
-		echo disabled
+		echo $DISABLED_STRING
 	fi	
 }
 

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -91,7 +91,7 @@ doWriteCFG()
     rm ${STATUSFILE} 2> /dev/null
 
     #find the interface (always the default gateway interface)
-    default_interface=`ip route |grep default |awk '{print $5}'`
+    default_interface=$(ip route |grep default |awk '{print $5}')
 
     #store the given options in ez-ipupdate compatible config file
     echo "host=${host}" > ${out_file}
@@ -112,7 +112,7 @@ doWriteCFG()
         echo "NAT unknown" >> ${HELPERCFG}
     else 
         doGetWANIP
-        ISGLOBAL=`ip addr ls ${default_interface} | grep ${wanip}`
+        ISGLOBAL=$(ip addr ls ${default_interface} | grep ${wanip})
         if [ -z ${ISGLOBAL} ];then
             #we are behind NAT
             echo "NAT yes" >> ${HELPERCFG}
@@ -137,23 +137,23 @@ doReadCFG()
     ipurl=""
 
     if [ ! -z ${cfgfile} ];then
-        host=`cat ${cfgfile} 2> /dev/null |grep host |cut -d = -f 2`
-        server=`cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\'`
-        user=`cat ${cfgfile} 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1 `
-        pass=`cat ${cfgfile} 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 2`
+        host=$(cat ${cfgfile} 2> /dev/null |grep host |cut -d = -f 2)
+        server=$(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')
+        user=$(cat ${cfgfile} 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1 )
+        pass=$(cat ${cfgfile} 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 2)
     fi
 
     if [ ! -z ${HELPERCFG} ];then
-        ipurl=`cat ${HELPERCFG} 2> /dev/null |grep ^IPURL |awk '{print $2}' |grep -v ^\'\'`
-        updateurl=`cat ${HELPERCFG} 2> /dev/null |grep POSTURL |awk '{print $2}' |grep -v ^\'\'`
-        basicauth=`cat ${HELPERCFG} 2> /dev/null |grep POSTAUTH |awk '{print $2}' |grep -v ^\'\'`
-        ignoreCertError=`cat ${HELPERCFG} 2> /dev/null |grep POSTSSLIGNORE |awk '{print $2}' |grep -v ^\'\'`
+        ipurl=$(cat ${HELPERCFG} 2> /dev/null |grep ^IPURL |awk '{print $2}' |grep -v ^\'\')
+        updateurl=$(cat ${HELPERCFG} 2> /dev/null |grep POSTURL |awk '{print $2}' |grep -v ^\'\')
+        basicauth=$(cat ${HELPERCFG} 2> /dev/null |grep POSTAUTH |awk '{print $2}' |grep -v ^\'\')
+        ignoreCertError=$(cat ${HELPERCFG} 2> /dev/null |grep POSTSSLIGNORE |awk '{print $2}' |grep -v ^\'\')
     fi  
 }
 
 doStatus()
 {
-	PROC=`pgrep ${TOOLNAME}`
+	PROC=$(pgrep ${TOOLNAME})
 	if [ -f ${CRONJOB} ];then
 	     echo enabled 
 	elif [ ! -z ${PROC} ];then
@@ -254,13 +254,13 @@ case ${cmd} in
         fi
     ;;
     get-nat)
-        NAT=`cat $HELPERCFG 2> /dev/null |grep ^NAT | awk '{print $2}'`
+        NAT=$(cat $HELPERCFG 2> /dev/null |grep ^NAT | awk '{print $2}')
         [ -z ${NAT} ] && NAT="unknown"
         echo ${NAT}
     ;;
     update)
         doReadCFG
-        oldip=`cat ${IPFILE}`
+        oldip=$(cat ${IPFILE})
         doGetWANIP
         echo ${wanip} > ${IPFILE}
         cat ${cfgfile} |grep -v execute > ${cfgfile}.tmp
@@ -272,10 +272,10 @@ case ${cmd} in
         fi
         #if we don't know our WAN IP do a blind update once a hour
         if [ "${wanip}" = ${NOIP} ];then
-            uptime=`cat /proc/uptime |cut -d . -f 1`
+            uptime=$(cat /proc/uptime |cut -d . -f 1)
             LAST=0
-            [ -f ${LASTUPDATE} ] && LAST=`cat ${LASTUPDATE}`
-            diff=`expr ${uptime} - ${LAST}`
+            [ -f ${LASTUPDATE} ] && LAST=$(cat ${LASTUPDATE})
+            diff=$(expr ${uptime} - ${LAST})
             if [ ${diff} -gt ${UPDATEMINUTESUNKNOWN} ];then
                 doUpdate
             fi
@@ -288,7 +288,7 @@ case ${cmd} in
         mv ${CFG} ${CFG_disabled}
     ;;
     success)
-        date=`date`
+        date=$(date)
         echo "last update done (${date})" > ${STATUSFILE}
         cat /proc/uptime |awk '{print $1}' |cut -d . -f 1 > ${LASTUPDATE}
         #if called from cronjob, the current IP is given as parameter
@@ -301,7 +301,7 @@ case ${cmd} in
         fi
     ;;
     failed)
-        date=`date`
+        date=$(date)
         echo "last update failed (${date})" > ${STATUSFILE}
     ;;    
     get-last-success)

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -131,17 +131,21 @@ doWriteCFG()
     default_interface=$(ip route |grep default |awk '{print $5}')
 
     # store the given options in ez-ipupdate compatible config file
-    echo "host=${host}" > ${out_file}
-    echo "server=${server}" >> ${out_file}
-    echo "user=${user}:${pass}" >> ${out_file}
-    echo "service-type=gnudip" >> ${out_file}
-    echo "retrys=3" >> ${out_file}
-    echo "wildcard" >> ${out_file}
+    {
+        "host=${host}"
+        "server=${server}"
+        "user=${user}:${pass}"
+        "service-type=gnudip"
+        "retrys=3"
+        "wildcard"
+    } > ${out_file}
     
     # store UPDATE URL params
-    echo "POSTURL ${updateurl}" > ${HELPERCFG}
-    echo "POSTAUTH ${basicauth}" >> ${HELPERCFG}
-    echo "POSTSSLIGNORE ${ignoreCertError}" >> ${HELPERCFG}
+    {
+        "POSTURL ${updateurl}"
+        "POSTAUTH ${basicauth}"
+        "POSTSSLIGNORE ${ignoreCertError}"
+    } > ${HELPERCFG}
     
     # check if we are behind a NAT Router
     echo "IPURL ${ipurl}" >> ${HELPERCFG}
@@ -149,18 +153,20 @@ doWriteCFG()
         echo "NAT unknown" >> ${HELPERCFG}
     else 
         doGetWANIP
-        ISGLOBAL=$(ip addr ls ${default_interface} | grep ${wanip})
-        if [ -z ${ISGLOBAL} ];then
+        ISGLOBAL=$(ip addr ls "${default_interface}" | grep "${wanip}")
+        if [ -z "${ISGLOBAL}" ];then
             # we are behind NAT
             echo "NAT yes" >> ${HELPERCFG}
         else
             # we are directly connected
             echo "NAT no" >> ${HELPERCFG}
             # if this file is added ez-ipupdate will take ip form this interface
-            echo "interface=${default_interface}" >> ${out_file}
-            # if this line is added to config file, ez-ipupdate will be launched on startup via init.d
-            echo "daemon" >> ${out_file}
-            echo "execute=${0} success" >> ${out_file}
+            {
+                "interface=${default_interface}"
+                # if this line is added to config file, ez-ipupdate will be launched on startup via init.d
+                "daemon"
+                "execute=${0} success"
+            } > ${out_file}
         fi
     fi
 }
@@ -177,18 +183,18 @@ doReadCFG()
     pass=""
     ipurl=""
 
-    if [ ! -z ${cfgfile} ];then
-        host=$(cat ${cfgfile} 2> /dev/null |grep host |cut -d = -f 2)
-        server=$(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')
-        user=$(cat ${cfgfile} 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1 )
-        pass=$(cat ${cfgfile} 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 2)
+    if [ ! -z "${cfgfile}" ];then
+        host=$(grep host "${cfgfile}" 2> /dev/null |cut -d = -f 2)
+        server=$(grep server "${cfgfile}" 2> /dev/null |cut -d = -f 2 |grep -v ^\'\')
+        user=$(grep user "${cfgfile}" 2> /dev/null |cut -d = -f 2 |cut -d : -f 1 )
+        pass=$(grep user "${cfgfile}" 2> /dev/null |cut -d = -f 2 |cut -d : -f 2)
     fi
 
     if [ ! -z ${HELPERCFG} ];then
-        ipurl=$(cat ${HELPERCFG} 2> /dev/null |grep ^IPURL |awk '{print $2}' |grep -v ^\'\')
-        updateurl=$(cat ${HELPERCFG} 2> /dev/null |grep POSTURL |awk '{print $2}' |grep -v ^\'\')
-        basicauth=$(cat ${HELPERCFG} 2> /dev/null |grep POSTAUTH |awk '{print $2}' |grep -v ^\'\')
-        ignoreCertError=$(cat ${HELPERCFG} 2> /dev/null |grep POSTSSLIGNORE |awk '{print $2}' |grep -v ^\'\')
+        ipurl=$(grep ^IPURL "${HELPERCFG}" 2> /dev/null |awk '{print $2}' |grep -v ^\'\')
+        updateurl=$(grep POSTURL "${HELPERCFG}" 2> /dev/null |awk '{print $2}' |grep -v ^\'\')
+        basicauth=$(grep POSTAUTH "${HELPERCFG}" 2> /dev/null |awk '{print $2}' |grep -v ^\'\')
+        ignoreCertError=$(grep POSTSSLIGNORE "${HELPERCFG}" 2> /dev/null |awk '{print $2}' |grep -v ^\'\')
     fi  
 }
 
@@ -198,12 +204,13 @@ doReadCFG()
 # as plinth will add them
 doReplaceVars()
 {
-    local url=`echo ${updateurl} | sed "s/<Ip>/${wanip}/g"`
-    url=`echo ${url} | sed "s/<Domain>/${host}/g"`
-    url=`echo ${url} | sed "s/<User>/${user}/g"`
-    url=`echo ${url} | sed "s/<Pass>/${pass}/g"`
-    url=`echo ${url} | sed "s/'//g"`
-    updateurl=$url
+    local url="${updateurl//<Ip>/${wanip}}"
+    url="${url//<Domain>/${host}}"
+    url="${url//<User>/${user}}"
+    url="${url//<Pass>/${pass}}"
+    url="${url//\'/""}"
+    updateurl=${url}
+    logger "expanded update URL as ${url}"
 }
 
 # doReadCFG() needs to be run before this
@@ -213,52 +220,52 @@ doReplaceVars()
 doStatus()
 {
     PROC=$(pgrep ${TOOLNAME})
-    if [ -f ${CRONJOB} ];then
-         echo $ENABLED_STRING
-    elif [ ! -z ${PROC} ];then
-        echo $ENABLED_STRING
+    if [ -f "${CRONJOB}" ];then
+        echo "${ENABLED_STRING}"
+    elif [ ! -z "${PROC}" ];then
+        echo "${ENABLED_STRING}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
-    if [ ! -z ${server} ];then
-        echo ${server}
+    if [ ! -z "${server}" ];then
+        echo "${server}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
-    if [ ! -z ${host}  ];then
-        echo ${host}
+    if [ ! -z "${host}"  ];then
+        echo "${host}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
-    if [ ! -z ${user} ];then
-        echo ${user}
+    if [ ! -z "${user}" ];then
+        echo "${user}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
-    if [ ! -z ${pass}  ];then
-        echo ${pass}
+    if [ ! -z "${pass}"  ];then
+        echo "${pass}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
-    if [ ! -z ${ipurl} ];then
-       echo ${ipurl}
+    if [ ! -z "${ipurl}" ];then
+        echo "${ipurl}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
-    if [ ! -z ${updateurl}  ];then
-        echo ${updateurl}
+    if [ ! -z "${updateurl}"  ];then
+        echo "${updateurl}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
-    if [ ! -z ${basicauth} ];then
-        echo ${basicauth}
+    if [ ! -z "${basicauth}" ];then
+        echo "${basicauth}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
-    if [ ! -z ${ignoreCertError} ];then
-        echo ${ignoreCertError}
+    if [ ! -z "${ignoreCertError}" ];then
+        echo "${ignoreCertError}"
     else
-        echo $DISABLED_STRING
+        echo "${DISABLED_STRING}"
     fi
 }
 
@@ -266,12 +273,12 @@ doStatus()
 # and store this ip within $wanip
 doGetWANIP()
 {
-    if [ ! -z ${ipurl} ];then
+    if [ ! -z "${ipurl}" ];then
         outfile=$(mktemp)
-        ${WGET} ${WGETOPTIONS} -O ${outfile} ${ipurl}
-        wanip=$(cat ${outfile}|sed s/[^0-9.]//g)
-        rm ${outfile}
-        [ -z ${wanip} ] && wanip=${NOIP}
+        "${WGET}" "${WGETOPTIONS}" -O "${outfile}" "${ipurl}"
+        wanip=$(sed s/[^0-9.]//g "${outfile}")
+        rm "${outfile}"
+        [ -z "${wanip}" ] && wanip=${NOIP}
     else
         # no WAN IP found because of missing check URL
         wanip=${NOIP}
@@ -282,14 +289,14 @@ doGetWANIP()
 # this function is called via cronjob
 doUpdate()
 {
-    local dnsentry=$(nslookup ${host}|tail -n2|grep A|sed s/[^0-9.]//g)
+    local dnsentry=$(nslookup "${host}"|tail -n2|grep A|sed s/[^0-9.]//g)
     if [ "${dnsentry}" =  "${wanip}" ];then
         return
     fi
-    if [ ! -z ${server} ];then
-        start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c ${cfgfile}
+    if [ ! -z "${server}" ];then
+        start-stop-daemon -S -x "${UPDATE_TOOL}" -m -p "${PIDFILE}" -- -c "${cfgfile}"
     fi
-    if [ ! -z ${updateurl} ];then
+    if [ ! -z "${updateurl}" ];then
         doReplaceVars
         if [ "${basicauth}" = "enabled" ];then
             local wgetoptions=" --user ${user} --password ${pass} "
@@ -298,7 +305,7 @@ doUpdate()
             local wgetoptions=" --no-check-certificate "
         fi
 
-        ${WGET} ${wgetoptions} "${updateurl}"
+        "${WGET}" "${wgetoptions}" "${updateurl}"
         # ToDo: check the returning text from WEB Server. User need to give expected string.
         if [ ${?} -eq 0 ];then
             ${0} success ${wanip}
@@ -318,41 +325,42 @@ cfgfile="/tmp/none"
 # check what action is requested
 case ${cmd} in
     configure)
-        doGetOpt ${@}
+        doGetOpt "${@}"
         doWriteCFG
     ;;
     start)
         doGetWANIP
-        if [ "$(cat $HELPERCFG |grep ^NAT | awk '{print $2}')" = "no" ];then
+        if [ "$(grep ^NAT ${HELPERCFG} | awk '{print $2}')" = "no" ];then
             #if we are not behind a NAT device and we use gnudip, start the daemon tool
-        if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\') ];then
+            local gnudipServer=$(grep server ${cfgfile} 2> /dev/null |cut -d = -f 2 |grep -v ^\'\')
+            if [ -f ${CFG} -a ! -z "${gnudipServer}" ];then
                 mv ${CFG_disabled} ${CFG}
                 /etc/init.d/${TOOLNAME} start
             fi
             # if we are not behind a NAT device and we use update-URL, add a cronjob
             # (daemon tool does not support update-URL feature)
-            if [ ! -z $(cat $HELPERCFG |grep ^POSTURL | awk '{print $2}') ];then
-                echo "*/${UPDATEMINUTES} * * * * root $0 update" > ${CRONJOB}
+            if [ ! -z "$(grep ^POSTURL $HELPERCFG | awk '{print $2}')" ];then
+                echo "*/${UPDATEMINUTES} * * * * root ${0} update" > ${CRONJOB}
                 $0 update
             fi
         else
             # if we are behind a NAT device, add a cronjob (daemon tool cannot monitor WAN IP changes)
-            echo "*/${UPDATEMINUTES} * * * * root $0 update" > $CRONJOB
+            echo "*/${UPDATEMINUTES} * * * * root ${0} update" > $CRONJOB
             $0 update
         fi
     ;;
     get-nat)
-        NAT=$(cat $HELPERCFG 2> /dev/null |grep ^NAT | awk '{print $2}')
-        [ -z ${NAT} ] && NAT="unknown"
+        NAT=$(grep ^NAT $HELPERCFG 2> /dev/null | awk '{print $2')
+        [ -z "${NAT}" ] && NAT="unknown"
         echo ${NAT}
     ;;
     update)
         doReadCFG
-        local dnsentry=$(nslookup ${host}|tail -n2|grep A|sed s/[^0-9.]//g)
+        local dnsentry=$(nslookup "${host}"|tail -n2|grep A|sed s/[^0-9.]//g)
         doGetWANIP
         echo  ${IPFILE}
         echo ${wanip} > ${IPFILE}
-        cat ${cfgfile} |grep -v execute > ${cfgfile}.tmp
+        grep -v execute ${cfgfile} > ${cfgfile}.tmp
         mv ${cfgfile}.tmp ${cfgfile}
         echo "execute=${0} success ${wanip}" >> ${cfgfile}
         # if we know our WAN IP, only update if IP changes
@@ -361,10 +369,10 @@ case ${cmd} in
         fi
         # if we don't know our WAN IP do a blind update once a hour
         if [ "${wanip}" = ${NOIP} ];then
-            uptime=$(cat /proc/uptime |cut -d . -f 1)
+            uptime=$(cut -d . -f 1 /proc/uptime)
             LAST=0
             [ -f ${LASTUPDATE} ] && LAST=$(cat ${LASTUPDATE})
-            diff=$(expr ${uptime} - ${LAST})
+            diff=$((uptime - LAST))
             if [ ${diff} -gt ${UPDATEMINUTESUNKNOWN} ];then
                 doUpdate
             fi
@@ -373,16 +381,16 @@ case ${cmd} in
     stop)
         rm ${CRONJOB} 2> /dev/null
         /etc/init.d/${TOOLNAME} stop
-        kill $(cat ${PIDFILE}) 2> /dev/null
+        kill "$(cat ${PIDFILE})" 2> /dev/null
         mv ${CFG} ${CFG_disabled}
     ;;
     success)
         date=$(date)
         echo "last update done (${date})" > ${STATUSFILE}
-        cat /proc/uptime |awk '{print $1}' |cut -d . -f 1 > ${LASTUPDATE}
+        awk '{print $1}' /proc/uptime |cut -d . -f 1 > ${LASTUPDATE}
         # if called from cronjob, the current IP is given as parameter
         if [ $# -eq 1 ];then
-            echo ${1} > ${IPFILE}
+            echo "${1}" > ${IPFILE}
         else
             # if called from ez-ipupdate daemon, no WAN IP is given as parameter
             doGetWANIP

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -421,7 +421,7 @@ case ${cmd} in
         rm ${CRONJOB}
     ;;
     *)
-        echo "usage: status|configure <options>|start|stop|update|get-nat|clean|success [updated IP]|failed"
+        echo "usage: status|configure <options>|start|stop|update|get-nat|clean|success [updated IP]|failed|get-last-success"
         echo ""
         echo "options are:"
         echo "-s <server>             Gnudip Server address"
@@ -438,6 +438,7 @@ case ${cmd} in
         echo "success                 store update success and optional the updated IP"
         echo "failed                  store update failure"
         echo "get-nat                 return the detected nat type"
+        echo "get-last-success        return date of last successful update"
     ;;
 esac
 exit 0

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -240,15 +240,19 @@ case ${cmd} in
     ;;
     start)
         if [ "$(cat $HELPERCFG |grep ^NAT | awk '{print $2}')" = "no" ];then
+			#if we are not behind a NAT device and we use gnudip, start the daemon tool
 			if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then
 				mv ${CFG_disabled} ${CFG}
             	/etc/init.d/${TOOLNAME} start        		
 			fi
+			#if we are not behind a NAT device and we use update-URL, add a cronjob 
+			#(daemon tool does not support update-URL feature)
 			if [ ! -z $(cat $HELPERCFG |grep ^POSTURL | awk '{print $2}') ];then
 				echo "*/${UPDATEMINUTES} * * * * root $0 update" > ${CRONJOB}
             	$0 update
 			fi
         else
+			#if we are behind a NAT device, add a cronjob (daemon tool cannot monitor WAN IP changes)
             echo "*/${UPDATEMINUTES} * * * * root $0 update" > $CRONJOB
             $0 update
         fi

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -359,7 +359,6 @@ case ${cmd} in
         doReadCFG
         dnsentry=$(nslookup "${host}"|tail -n2|grep A|sed s/[^0-9.]//g)
         doGetWANIP
-        echo  ${IPFILE}
         echo ${wanip} > ${IPFILE}
         grep -v execute ${cfgfile} > ${cfgfile}.tmp
         mv ${cfgfile}.tmp ${cfgfile}

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -256,7 +256,7 @@ doGetWANIP()
     if [ ! -z ${ipurl} ];then
         outfile=$(mktemp)
         ${WGET} ${WGETOPTIONS} -O ${outfile} ${ipurl}
-        wanip=$(cat ${outfile})
+        wanip=$(cat ${outfile}|sed s/[^0-9.]//g)
         rm ${outfile}
         [ -z ${wanip} ] && wanip=${NOIP}
     else

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -32,8 +32,8 @@ PIDFILE="/var/run/ez-ipupdate.pid"
 
 doGetOpt()
 {
-	basicauth=0
-	ignoreCertError=0
+    basicauth=0
+    ignoreCertError=0
 	
     while getopts ":s:d:u:p:I:U:c:b:" opt; do
         case ${opt} in
@@ -220,9 +220,9 @@ doGetWANIP()
 {
     if [ ! -z ${ipurl} ];then
         outfile=$(mktemp)
-		${WGET} ${WGETOPTIONS} -O ${outfile} ${ipurl}
+	${WGET} ${WGETOPTIONS} -O ${outfile} ${ipurl}
         wanip=$(cat ${outfile})
-		rm ${outfile}
+	rm ${outfile}
     [ -z ${wanip} ] && wanip=${NOIP}
     else
         #no WAN IP found because of missing check URL
@@ -247,7 +247,12 @@ doUpdate()
 		fi
 
 		$WGET ${wgetoptions} "${updateurl}"
-		[ $? -eq 0 ] && ${0} success
+                #ToDo: check the returning text from WEB Server. User need to give expected string.
+		if [ $? -eq 0 ];then
+                    ${0} success $wanip
+                else
+                    ${0} failed
+                fi
 	fi
 }
 
@@ -267,13 +272,13 @@ case ${cmd} in
 			#if we are not behind a NAT device and we use gnudip, start the daemon tool
 			if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then
 				mv ${CFG_disabled} ${CFG}
-            	/etc/init.d/${TOOLNAME} start        		
+		/etc/init.d/${TOOLNAME} start
 			fi
 			#if we are not behind a NAT device and we use update-URL, add a cronjob 
 			#(daemon tool does not support update-URL feature)
 			if [ ! -z $(cat $HELPERCFG |grep ^POSTURL | awk '{print $2}') ];then
 				echo "*/${UPDATEMINUTES} * * * * root $0 update" > ${CRONJOB}
-            	$0 update
+		$0 update
 			fi
         else
 			#if we are behind a NAT device, add a cronjob (daemon tool cannot monitor WAN IP changes)
@@ -290,6 +295,7 @@ case ${cmd} in
         doReadCFG
         oldip=$(cat ${IPFILE})
         doGetWANIP
+        echo  ${IPFILE}
         echo ${wanip} > ${IPFILE}
         cat ${cfgfile} |grep -v execute > ${cfgfile}.tmp
         mv ${cfgfile}.tmp ${cfgfile}

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -28,31 +28,11 @@ HELPERCFG="${CFGDIR}${TOOLNAME}-plinth.cfg"
 CRONJOB="/etc/cron.d/${TOOLNAME}"
 PIDFILE="/var/run/ez-ipupdate.pid"
 
-doReadCFG()
-{ 
-    host=""
-    server=""
-    user=""
-    pass=""
-    IPURL=""
-    FILE=""
-    [ -f $CFG_disabled ] && FILE=$CFG_disabled
-    [ -f $CFG ] && FILE=$CFG
-
-    if [ ! -z $FILE ];then
-        host=`cat $FILE 2> /dev/null |grep host |cut -d = -f 2`
-        server=`cat $FILE 2> /dev/null |grep server |cut -d = -f 2`
-        user=`cat $FILE 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1`
-        pass=`cat $FILE 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 2`
-    fi
-
-    if [ ! -z $HELPERCFG ];then
-        IPURL=`cat $HELPERCFG 2> /dev/null |grep URL |awk '{print $2}'`
-    fi  
-}
-
 doGetOpt()
 {
+	basicauth=0
+	ignoreCertError=0
+	
     while getopts ":s:d:u:p:I:" opt; do
         case $opt in
             s)
@@ -69,11 +49,24 @@ doGetOpt()
             ;;
             I)
                 if [ "$OPTARG" != "$EMPTYSTRING" ];then
-                    IPURL=$OPTARG
+                    ipurl=$OPTARG
                 else
-                    IPURL=""    
+                    ipurl=""
                 fi
             ;;
+            U)
+                if [ "$OPTARG" != "$EMPTYSTRING" ];then
+                    updateurl=$OPTARG
+                else
+                    updateurl=""
+                fi
+            ;;
+            b)
+                basicauth=$OPTARG
+            ;;
+            c)
+                ignoreCertError=$OPTARG
+            ;;            
             \?)
                 echo "Invalid option: -$OPTARG" >&2
                 exit 1
@@ -85,8 +78,8 @@ doGetOpt()
 doWriteCFG()
 {
     mkdir $CFGDIR 2> /dev/null
-    #always write to the inactive config - needs to be enabled vi "start" command later
-    FILE=$CFG_disabled
+    #always write to the inactive config - needs to be enabled via "start" command later
+    file=$CFG_disabled
 
     #reset the last update time
     echo 0 > $LASTUPDATE
@@ -98,23 +91,28 @@ doWriteCFG()
     rm $STATUSFILE 2> /dev/null
 
     #find the interface (always the default gateway interface)
-    DEFAULT=`ip route |grep default |awk '{print $5}'`
+    default_interface=`ip route |grep default |awk '{print $5}'`
 
     #store the given options in ez-ipupdate compatible config file
-    echo "host=$host" > $FILE
-    echo "server=$server" >> $FILE
-    echo "user=${user}:${pass}" >> $FILE
-    echo "service-type=gnudip" >> $FILE
-    echo "retrys=3" >> $FILE
-    echo "wildcard" >> $FILE
+    echo "host=$host" > $file
+    echo "server=$server" >> $file
+    echo "user=${user}:${pass}" >> $file
+    echo "service-type=gnudip" >> $file
+    echo "retrys=3" >> $file
+    echo "wildcard" >> $file
+    
+    #store UPDATE URL params
+    echo "POSTURL $updateurl" > $HELPERCFG
+    echo "POSTAUTH $basicauth" >> $HELPERCFG
+    echo "POSTSSLIGNORE $ignoreCertError" >> $HELPERCFG
     
     #check if we are behind a NAT Router
-    echo "IPURL $IPURL" > $HELPERCFG
-    if [ -z $IPURL ];then
+    echo "IPURL $ipurl" >> $HELPERCFG
+    if [ -z $ipurl ];then
         echo "NAT unknown" >> $HELPERCFG
     else 
         doGetWANIP
-        ISGLOBAL=`ip addr ls $DEFAULT | grep $WANIP`
+        ISGLOBAL=`ip addr ls $default_interface | grep $wanip`
         if [ -z $ISGLOBAL ];then
             #we are behind NAT
             echo "NAT yes" >> $HELPERCFG
@@ -122,25 +120,62 @@ doWriteCFG()
             #we are directly connected
             echo "NAT no" >> $HELPERCFG
             #if this file is added ez-ipupdate will take ip form this interface
-            echo "interface=$DEFAULT" >> $FILE
+            echo "interface=$default_interface" >> $file
             #if this line is added to config file, ez-ipupdate will be launched on startup via init.d
-            echo "daemon" >> $FILE
-            echo "execute=$0 success" >> $FILE
+            echo "daemon" >> $file
+            echo "execute=$0 success" >> $file
         fi
     fi
 }
 
+doReadCFG()
+{ 
+    host=""
+    server=""
+    user=""
+    pass=""
+    ipurl=""
+    file=""
+    [ -f $CFG_disabled ] && file=$CFG_disabled
+    [ -f $CFG ] && file=$CFG
+
+    if [ ! -z $file ];then
+        host=`cat $file 2> /dev/null |grep host |cut -d = -f 2`
+        server=`cat $file 2> /dev/null |grep server |cut -d = -f 2`
+        user=`cat $file 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1`
+        pass=`cat $file 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 2`
+    fi
+
+    if [ ! -z $HELPERCFG ];then
+        ipurl=`cat $HELPERCFG 2> /dev/null |grep ^URL |awk '{print $2}'`
+        updateurl=`cat $HELPERCFG 2> /dev/null |grep POSTURL |awk '{print $2}'`
+        basicauth=`cat $HELPERCFG 2> /dev/null |grep POSTAUTH |awk '{print $2}'`
+        ignoreCertError=`cat $HELPERCFG 2> /dev/null |grep POSTSSLIGNORE |awk '{print $2}'`
+    fi  
+}
+
 doGetWANIP()
 {
-    if [ ! -z $IPURL ];then
-        OUTFILE=`mktemp`
-        $WGET $WGETOPTIONS -O $OUTFILE $IPURL
-        WANIP=`cat $OUTFILE`
-        rm $OUTFILE
+    if [ ! -z $ipurl ];then
+        outfile=`mktemp`
+        $WGET $WGETOPTIONS -O $outfile $ipurl
+        wanip=`cat $outfile`
+        rm $outfile
     else
         #no WAN IP found because of missing check URL
-        WANIP=${NOIP}
+        wanip=${NOIP}
     fi
+}
+
+doUpdate()
+{
+	if [ ! -z $server ];then 
+		start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c $file	
+	fi
+	
+	if [ ! -z $updateurl ];then
+		echo "todo"	
+	fi
 }
 
 cmd=$1
@@ -166,27 +201,27 @@ case $cmd in
     ;;
     update)
         doReadCFG
-        OLDIP=`cat $IPFILE`
+        oldip=`cat $IPFILE`
         doGetWANIP
-        echo $WANIP > $IPFILE
-        FILE="/tmp/none"
-        [ -f $CFG_disabled ] && FILE=$CFG_disabled
-        [ -f $CFG ] && FILE=$CFG
-        cat $FILE |grep -v execute > ${FILE}.tmp
-        mv ${FILE}.tmp ${FILE}
-        echo "execute=$0 success ${WANIP}" >> $FILE
+        echo $wanip > $IPFILE
+        cfgfile="/tmp/none"
+        [ -f $CFG_disabled ] && cfgfile=$CFG_disabled
+        [ -f $CFG ] && cfgfile=$CFG
+        cat $file |grep -v execute > ${cfgfile}.tmp
+        mv ${cfgfile}.tmp ${cfgfile}
+        echo "execute=$0 success ${wanip}" >> $cfgfile
         #if we know our WAN IP, only update if IP changes
-        if [ "${OLDIP}" != "${WANIP}" -a "${WANIP}" != ${NOIP} ];then
-            start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c $FILE
+        if [ "${oldip}" != "${wanip}" -a "${wanip}" != ${NOIP} ];then
+            doUpdate
         fi
         #if we don't know our WAN IP do a blind update once a hour
-        if [ "${WANIP}" = ${NOIP} ];then
-            UPTIME=`cat /proc/uptime |cut -d . -f 1`
+        if [ "${wanip}" = ${NOIP} ];then
+            uptime=`cat /proc/uptime |cut -d . -f 1`
             LAST=0
             [ -f ${LASTUPDATE} ] && LAST=`cat $LASTUPDATE`
-            DIFF=`expr $UPTIME - $LAST`
-            if [ $DIFF -gt $UPDATEMINUTESUNKNOWN ];then
-                start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c $FILE
+            diff=`expr $uptime - $LAST`
+            if [ $diff -gt $UPDATEMINUTESUNKNOWN ];then
+                doUpdate
             fi
         fi
     ;;
@@ -197,8 +232,8 @@ case $cmd in
         mv $CFG $CFG_disabled
     ;;
     success)
-        DATE=`date`
-        echo "last update done ($DATE)" > $STATUSFILE
+        date=`date`
+        echo "last update done ($date)" > $STATUSFILE
         cat /proc/uptime |awk '{print $1}' |cut -d . -f 1 > $LASTUPDATE
         #if called from cronjob, the current IP is given as parameter
         if [ $# -eq 1 ];then
@@ -206,12 +241,12 @@ case $cmd in
         else
           #if called from ez-ipupdate daemon, no WAN IP is given as parameter
           doGetWANIP
-          echo $WANIP > $IPFILE
+          echo $wanip > $IPFILE
         fi
     ;;
     failed)
-        DATE=`date`
-        echo "last update failed ($DATE)" > $STATUSFILE
+        date=`date`
+        echo "last update failed ($date)" > $STATUSFILE
     ;;    
     get-last-success)
         if [ -f $STATUSFILE ];then
@@ -234,7 +269,10 @@ case $cmd in
         echo $host
         echo $user
         echo $pass
-        echo $IPURL
+        echo $ipurl
+        echo $updateurl
+        echo $basicauth
+        echo $ignoreCertError
     ;;
     get-timer)
         echo $UPDATEMINUTES
@@ -251,6 +289,9 @@ case $cmd in
         echo "-u <user>               Account username"
         echo "-p <password>           Account Password"
         echo "-I <IP check URL>       A URL which returns the IP of the client who is requesting"
+        echo "-U <update URL>         The update URL (a HTTP GET on this URL will be done)"
+        echo "-c <1|0>                disable SSL check on Update URL"
+        echo "-b <1|0>                use HTTP basic auth on Update URL"
         echo ""
         echo "update                  do a one time update"
         echo "clean                   delete configuration"

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -33,7 +33,7 @@ doGetOpt()
 	basicauth=0
 	ignoreCertError=0
 	
-    while getopts ":s:d:u:p:I:" opt; do
+    while getopts ":s:d:u:p:I:U:c:b:" opt; do
         case $opt in
             s)
                 server=$OPTARG
@@ -141,17 +141,69 @@ doReadCFG()
 
     if [ ! -z $file ];then
         host=`cat $file 2> /dev/null |grep host |cut -d = -f 2`
-        server=`cat $file 2> /dev/null |grep server |cut -d = -f 2`
-        user=`cat $file 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1`
+        server=`cat $file 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\'`
+        user=`cat $file 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 1 `
         pass=`cat $file 2> /dev/null |grep user |cut -d = -f 2 |cut -d : -f 2`
     fi
 
     if [ ! -z $HELPERCFG ];then
-        ipurl=`cat $HELPERCFG 2> /dev/null |grep ^URL |awk '{print $2}'`
-        updateurl=`cat $HELPERCFG 2> /dev/null |grep POSTURL |awk '{print $2}'`
-        basicauth=`cat $HELPERCFG 2> /dev/null |grep POSTAUTH |awk '{print $2}'`
-        ignoreCertError=`cat $HELPERCFG 2> /dev/null |grep POSTSSLIGNORE |awk '{print $2}'`
+        ipurl=`cat $HELPERCFG 2> /dev/null |grep ^IPURL |awk '{print $2}' |grep -v ^\'\'`
+        updateurl=`cat $HELPERCFG 2> /dev/null |grep POSTURL |awk '{print $2}' |grep -v ^\'\'`
+        basicauth=`cat $HELPERCFG 2> /dev/null |grep POSTAUTH |awk '{print $2}' |grep -v ^\'\'`
+        ignoreCertError=`cat $HELPERCFG 2> /dev/null |grep POSTSSLIGNORE |awk '{print $2}' |grep -v ^\'\'`
     fi  
+}
+
+doStatus()
+{
+	PROC=`pgrep ${TOOLNAME}`
+	if [ -f $CRONJOB ];then
+	     echo enabled 
+	elif [ ! -z $PROC ];then 
+	    echo enabled
+	else
+	    echo disabled
+	fi
+		if [ ! -z $server ];then
+		echo $server
+		else
+			echo disabled
+		fi
+	if [ ! -z $host  ];then 
+		echo $host
+		else
+			echo disabled
+		fi
+		if [ ! -z $user ];then
+		echo $user
+		else
+			echo disabled
+		fi
+	if [ ! -z $pass  ];then 
+		echo $pass
+		else
+			echo disabled
+		fi        
+		if [ ! -z $ipurl ];then
+		echo $ipurl
+		else
+			echo disabled
+		fi
+	if [ ! -z $updateurl  ];then 
+		echo $updateurl
+		else
+			echo disabled
+		fi  
+	if [ ! -z $basicauth ];then
+		echo $basicauth
+	else
+			echo disabled
+	fi		
+	if [ ! -z $ignoreCertError ];then
+		echo $ignoreCertError 
+	else
+		echo disabled
+	fi	
 }
 
 doGetWANIP()
@@ -161,6 +213,7 @@ doGetWANIP()
         $WGET $WGETOPTIONS -O $outfile $ipurl
         wanip=`cat $outfile`
         rm $outfile
+        [ -z $wanip ] && wanip=${NOIP}
     else
         #no WAN IP found because of missing check URL
         wanip=${NOIP}
@@ -187,8 +240,14 @@ case $cmd in
     ;;
     start)
         if [ "$(cat $HELPERCFG |grep ^NAT | awk '{print $2}')" = "no" ];then
-            mv $CFG_disabled $CFG
-            /etc/init.d/${TOOLNAME} start
+        	if [ -f $CFG -a ! -z $(cat $file 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then
+            	mv $CFG_disabled $CFG
+            	/etc/init.d/${TOOLNAME} start        		
+			fi
+			if [ ! -z $(cat $HELPERCFG |grep ^POSTURL | awk '{print $2}') ];then
+				echo "*/${UPDATEMINUTES} * * * * root $0 update" > $CRONJOB
+            	$0 update
+			fi
         else
             echo "*/${UPDATEMINUTES} * * * * root $0 update" > $CRONJOB
             $0 update
@@ -257,28 +316,14 @@ case $cmd in
     ;;
     status)
         doReadCFG
-        PROC=`pgrep ${TOOLNAME}`
-        if [ -f $CRONJOB ];then
-             echo enabled 
-        elif [ ! -z $PROC ];then 
-            echo enabled
-        else
-            echo disabled
-        fi
-        echo $server
-        echo $host
-        echo $user
-        echo $pass
-        echo $ipurl
-        echo $updateurl
-        echo $basicauth
-        echo $ignoreCertError
+		doStatus			
     ;;
     get-timer)
         echo $UPDATEMINUTES
     ;;
     clean)
         rm ${CFGDIR}/*
+        rm $CRONJOB
     ;;
     *)
         echo "usage: status|configure <options>|start|stop|update|get-nat|clean|success [updated IP]|failed"

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -269,23 +269,26 @@ doGetWANIP()
 # this function is called via cronjob
 doUpdate()
 {
+    dnsentry=$(nslookup ${host}|tail -n2|grep A|sed s/[^0-9.]//g)
+    if [ "${dnsentry}" =  "${wanip}" ];then
+        return
+    fi
     if [ ! -z ${server} ];then
         start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c ${cfgfile}
     fi
-
     if [ ! -z ${updateurl} ];then
         doReplaceVars
         if [ "${basicauth}" = "enabled" ];then
-            local wgetoptions=" --user $user --password $pass "
+            local wgetoptions=" --user ${user} --password ${pass} "
         fi
         if [ "${ignoreCertError}" = "enabled" ];then
             local wgetoptions=" --no-check-certificate "
         fi
 
-        $WGET ${wgetoptions} "${updateurl}"
+        ${WGET} ${wgetoptions} "${updateurl}"
         # ToDo: check the returning text from WEB Server. User need to give expected string.
-        if [ $? -eq 0 ];then
-            ${0} success $wanip
+        if [ ${?} -eq 0 ];then
+            ${0} success ${wanip}
         else
             ${0} failed
         fi

--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -34,7 +34,7 @@ doGetOpt()
 {
     basicauth=0
     ignoreCertError=0
-	
+
     while getopts ":s:d:u:p:I:U:c:b:" opt; do
         case ${opt} in
             s)
@@ -157,73 +157,73 @@ doReplaceVars()
 {
     local url=`echo ${updateurl} | sed "s/<Ip>/${wanip}/g"`
     url=`echo ${url} | sed "s/<Domain>/${host}/g"`
-	url=`echo ${url} | sed "s/<User>/${user}/g"`
+    url=`echo ${url} | sed "s/<User>/${user}/g"`
     url=`echo ${url} | sed "s/<Pass>/${pass}/g"`
     url=`echo ${url} | sed "s/'//g"`
-	updateurl=$url
+    updateurl=$url
 }
 
 doStatus()
 {
-	PROC=$(pgrep ${TOOLNAME})
-	if [ -f ${CRONJOB} ];then
-	     echo $ENABLED_STRING 
-	elif [ ! -z ${PROC} ];then
-	    echo $ENABLED_STRING
-	else
-	    echo $DISABLED_STRING
-	fi
-		if [ ! -z ${server} ];then
-			echo ${server}
-		else
-			echo $DISABLED_STRING
-		fi
-	if [ ! -z ${host}  ];then
-		echo ${host}
-		else
-			echo $DISABLED_STRING
-		fi
-		if [ ! -z ${user} ];then
-			echo ${user}
-		else
-			echo $DISABLED_STRING
-		fi
-	if [ ! -z ${pass}  ];then
-		echo ${pass}
-		else
-			echo $DISABLED_STRING
-		fi        
-		if [ ! -z ${ipurl} ];then
-		echo ${ipurl}
-		else
-			echo $DISABLED_STRING
-		fi
-	if [ ! -z ${updateurl}  ];then
-		local url=`echo ${updateurl} | sed "s/'//g"`
-		echo ${url}
-		else
-			echo $DISABLED_STRING
-		fi  
-	if [ ! -z ${basicauth} ];then
-		echo ${basicauth}
-	else
-			echo $DISABLED_STRING
-	fi		
-	if [ ! -z ${ignoreCertError} ];then
-		echo ${ignoreCertError}
-	else
-		echo $DISABLED_STRING
-	fi	
+    PROC=$(pgrep ${TOOLNAME})
+    if [ -f ${CRONJOB} ];then
+         echo $ENABLED_STRING
+    elif [ ! -z ${PROC} ];then
+        echo $ENABLED_STRING
+    else
+        echo $DISABLED_STRING
+    fi
+    if [ ! -z ${server} ];then
+        echo ${server}
+    else
+        echo $DISABLED_STRING
+    fi
+    if [ ! -z ${host}  ];then
+        echo ${host}
+    else
+        echo $DISABLED_STRING
+    fi
+    if [ ! -z ${user} ];then
+        echo ${user}
+    else
+        echo $DISABLED_STRING
+    fi
+    if [ ! -z ${pass}  ];then
+        echo ${pass}
+    else
+        echo $DISABLED_STRING
+    fi
+    if [ ! -z ${ipurl} ];then
+       echo ${ipurl}
+    else
+        echo $DISABLED_STRING
+    fi
+    if [ ! -z ${updateurl}  ];then
+        local url=`echo ${updateurl} | sed "s/'//g"`
+        echo ${url}
+    else
+        echo $DISABLED_STRING
+    fi
+    if [ ! -z ${basicauth} ];then
+        echo ${basicauth}
+    else
+        echo $DISABLED_STRING
+    fi
+    if [ ! -z ${ignoreCertError} ];then
+        echo ${ignoreCertError}
+    else
+        echo $DISABLED_STRING
+    fi
 }
 
 doGetWANIP()
 {
     if [ ! -z ${ipurl} ];then
         outfile=$(mktemp)
-	${WGET} ${WGETOPTIONS} -O ${outfile} ${ipurl}
+        ${WGET} ${WGETOPTIONS} -O ${outfile} ${ipurl}
         wanip=$(cat ${outfile})
-	rm ${outfile}
-    [ -z ${wanip} ] && wanip=${NOIP}
+        rm ${outfile}
+        [ -z ${wanip} ] && wanip=${NOIP}
     else
         #no WAN IP found because of missing check URL
         wanip=${NOIP}
@@ -232,28 +232,28 @@ doGetWANIP()
 
 doUpdate()
 {
-	if [ ! -z ${server} ];then
-		start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c ${cfgfile}
-	fi
-	
-	if [ ! -z ${updateurl} ];then
-		doReplaceVars
+    if [ ! -z ${server} ];then
+        start-stop-daemon -S -x ${UPDATE_TOOL} -m -p ${PIDFILE} -- -c ${cfgfile}
+    fi
 
-		if [ "${basicauth}" = "enabled" ];then
-			local wgetoptions=" --user $user --password $pass "
-		fi
-		if [ "${ignoreCertError}" = "enabled" ];then
-			local wgetoptions=" --no-check-certificate "
-		fi
+    if [ ! -z ${updateurl} ];then
+        doReplaceVars
 
-		$WGET ${wgetoptions} "${updateurl}"
-                #ToDo: check the returning text from WEB Server. User need to give expected string.
-		if [ $? -eq 0 ];then
-                    ${0} success $wanip
-                else
-                    ${0} failed
-                fi
-	fi
+        if [ "${basicauth}" = "enabled" ];then
+            local wgetoptions=" --user $user --password $pass "
+        fi
+        if [ "${ignoreCertError}" = "enabled" ];then
+            local wgetoptions=" --no-check-certificate "
+        fi
+
+        $WGET ${wgetoptions} "${updateurl}"
+        #ToDo: check the returning text from WEB Server. User need to give expected string.
+        if [ $? -eq 0 ];then
+            ${0} success $wanip
+        else
+            ${0} failed
+        fi
+    fi
 }
 
 cmd=${1}
@@ -267,21 +267,21 @@ case ${cmd} in
         doWriteCFG
     ;;
     start)
-		doGetWANIP
+        doGetWANIP
         if [ "$(cat $HELPERCFG |grep ^NAT | awk '{print $2}')" = "no" ];then
-			#if we are not behind a NAT device and we use gnudip, start the daemon tool
-			if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then
-				mv ${CFG_disabled} ${CFG}
-		/etc/init.d/${TOOLNAME} start
-			fi
-			#if we are not behind a NAT device and we use update-URL, add a cronjob 
-			#(daemon tool does not support update-URL feature)
-			if [ ! -z $(cat $HELPERCFG |grep ^POSTURL | awk '{print $2}') ];then
-				echo "*/${UPDATEMINUTES} * * * * root $0 update" > ${CRONJOB}
-		$0 update
-			fi
+            #if we are not behind a NAT device and we use gnudip, start the daemon tool
+            if [ -f ${CFG} -a ! -z $(cat ${cfgfile} 2> /dev/null |grep server |cut -d = -f 2 |grep -v ^\'\')];then
+                mv ${CFG_disabled} ${CFG}
+                /etc/init.d/${TOOLNAME} start
+            fi
+            #if we are not behind a NAT device and we use update-URL, add a cronjob
+            #(daemon tool does not support update-URL feature)
+            if [ ! -z $(cat $HELPERCFG |grep ^POSTURL | awk '{print $2}') ];then
+                echo "*/${UPDATEMINUTES} * * * * root $0 update" > ${CRONJOB}
+                $0 update
+            fi
         else
-			#if we are behind a NAT device, add a cronjob (daemon tool cannot monitor WAN IP changes)
+            #if we are behind a NAT device, add a cronjob (daemon tool cannot monitor WAN IP changes)
             echo "*/${UPDATEMINUTES} * * * * root $0 update" > $CRONJOB
             $0 update
         fi
@@ -327,11 +327,11 @@ case ${cmd} in
         cat /proc/uptime |awk '{print $1}' |cut -d . -f 1 > ${LASTUPDATE}
         #if called from cronjob, the current IP is given as parameter
         if [ $# -eq 1 ];then
-			echo ${1} > ${IPFILE}
+            echo ${1} > ${IPFILE}
         else
-			#if called from ez-ipupdate daemon, no WAN IP is given as parameter
-			doGetWANIP
-			echo ${wanip} > ${IPFILE}
+            #if called from ez-ipupdate daemon, no WAN IP is given as parameter
+            doGetWANIP
+            echo ${wanip} > ${IPFILE}
         fi
     ;;
     failed)
@@ -347,10 +347,10 @@ case ${cmd} in
     ;;
     status)
         doReadCFG
-		doStatus			
+        doStatus
     ;;
     get-timer)
-		echo ${UPDATEMINUTES}
+        echo ${UPDATEMINUTES}
     ;;
     clean)
         rm ${CFGDIR}/*

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -71,19 +71,22 @@ class TrimmedCharField(forms.CharField):
 class ConfigureForm(forms.Form):
     """Form to configure the dynamic DNS client"""
     enabled = forms.BooleanField(label=_('Enable Dynamic DNS'),
-                                 required=False,widget=forms.CheckboxInput
+                                 required=False, widget=forms.CheckboxInput
                                 (attrs={'onclick': 'mod_form();'}))
 
-    dynamicdns_service = forms.ChoiceField(label=_('Service type'),
-       help_text=_('Please choose a update protocol according to your provider.\
-                   We recommend the GnudIP protocol. If your provider does not \
-                   support the GnudIP protocol or your provider is not listed \
-                   you may use the update URL of your provider.'),
-                   choices=(('1', 'GnuDIP'), 
-                            ('2', 'noip.com'),
-                            ('3', 'selfhost.bz'),
-                            ('4', 'other Update URL')),
-                   widget=forms.Select(attrs={'onChange':'dropdown()'}))
+    service_type = forms.ChoiceField(label=_('Service type'),
+                                     help_text=_('Please choose a update\
+                                     protocol according to your \
+                                     provider. If your provider does not\
+                                     support the GnudIP protocol or your\
+                                     provider is not listed you may use\
+                                     the update URL of your provider.'),
+                                     choices=(('1', 'GnuDIP'),
+                                             ('2', 'noip.com'),
+                                             ('3', 'selfhost.bz'),
+                                             ('4', 'other Update URL')),
+                                     widget=forms.Select(attrs={'onChange':
+                                                                'dropdown()'}))
 
     dynamicdns_server = TrimmedCharField(
         label=_('GnudIP Server Address'),
@@ -92,23 +95,24 @@ class ConfigureForm(forms.Form):
         validators=[
             validators.RegexValidator(r'^[\w-]{1,63}(\.[\w-]{1,63})*$',
                                       _('Invalid server name'))])
-    
-    dynamicdns_update_url = TrimmedCharField(
-         label=_('Update URL'),
-         required=False,
-         help_text=_('The Variables $User, $Pass, $IP, $Domain may be used \
-                within this URL.</br> Example URL: </br> \
-                https://some.tld/up.php?us=$User&pw=$Pass&ip=$IP&dom=$Domain'))
-    
-    disable_SSL_cert_check = forms.BooleanField(
-                            label=_('accept all SSL certificates'),
-                            help_text=_('use this option if your provider uses\
-                            self signed certificates'),
-                            required=False)
-    
-    use_http_basic_auth = forms.BooleanField(
-                            label=_('use HTTP basic authentication'),
-                            required=False)
+
+    dynamicdns_update_url = TrimmedCharField(label=_('Update URL'),
+                                             required=False,
+                                             help_text=_('The Variables $User\
+                                                         , $Pass, $IP, $Domain\
+                                                          may be used'))
+
+    disable_SSL_cert_check = forms.BooleanField(label=_('accept all SSL \
+                                                        certificates'),
+                                                help_text=_('use this option \
+                                                             if your provider \
+                                                             uses self signed\
+                                                             certificates'),
+                                                required=False)
+
+    use_http_basic_auth = forms.BooleanField(label=_('use HTTP basic \
+                                                      authentication'),
+                                             required=False)
 
     dynamicdns_domain = TrimmedCharField(
         label=_('Domain Name'),
@@ -210,7 +214,7 @@ def get_status():
     output = actions.run('dynamicdns', 'status')
     details = output.split()
     status['enabled'] = (output.split()[0] == 'enabled')
-    
+
     if len(details) > 1:
         if details[1] == 'disabled':
             status['dynamicdns_server'] = ''
@@ -250,7 +254,7 @@ def get_status():
             status['dynamicdns_ipurl'] = details[5]
     else:
         status['dynamicdns_ipurl'] = ''
-        
+
     if len(details) > 6:
         if details[6] == 'disabled':
             status['dynamicdns_update_url'] = ''
@@ -258,23 +262,23 @@ def get_status():
             status['dynamicdns_update_url'] = details[6]
     else:
         status['dynamicdns_update_url'] = ''
-        
+
     if len(details) > 7:
         status['disable_SSL_cert_check'] = (output.split()[7] == 'enabled')
     else:
         status['disable_SSL_cert_check'] = False
-        
+
     if len(details) > 8:
         status['use_http_basic_auth'] = (output.split()[8] == 'enabled')
     else:
         status['use_http_basic_auth'] = False
-        
+
     if not status['dynamicdns_server'] and not status['dynamicdns_update_url']:
-            status['dynamicdns_service'] = '1'
+            status['service_type'] = '1'
     elif not status['dynamicdns_server'] and status['dynamicdns_update_url']:
-            status['dynamicdns_service'] = '4'  
+            status['service_type'] = '4'
     else:
-        status['dynamicdns_service'] = '1'
+        status['service_type'] = '1'
 
     return status
 
@@ -309,15 +313,15 @@ def _apply_changes(request, old_status, new_status):
        old_status['enabled'] != \
        new_status['enabled']:
 
-        disable_ssl_check="disabled"
-        use_http_basic_auth="disabled"
-        
+        disable_ssl_check = "disabled"
+        use_http_basic_auth = "disabled"
+
         if new_status['disable_SSL_cert_check']:
             disable_ssl_check = "enabled"
-            
+
         if new_status['use_http_basic_auth']:
             use_http_basic_auth = "enabled"
-            
+
         _run(['configure', '-s', new_status['dynamicdns_server'],
               '-d', new_status['dynamicdns_domain'],
               '-u', new_status['dynamicdns_user'],

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -168,16 +168,19 @@ class ConfigureForm(forms.Form):
         service_type = cleaned_data.get('service_type')
         old_dynamicdns_secret = self.initial['dynamicdns_secret']
 
+        """clear the fields which are not in use"""
         if service_type == '1':
             dynamicdns_update_url = ""
         else:
             dynamicdns_server = ""
 
+        """check if gnudip server or update URL is filled"""
         if not dynamicdns_update_url and not dynamicdns_server:
             raise forms.ValidationError('please give update URL or \
                                          a GnuDIP Server')
             LOGGER.info('no server address given')
 
+        """check if a password was set before or a password is set now"""
         if not dynamicdns_secret and not old_dynamicdns_secret:
             raise forms.ValidationError('please give a password')
             LOGGER.info('no password given')

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -30,6 +30,13 @@ from plinth import package
 
 LOGGER = logging.getLogger(__name__)
 EMPTYSTRING = 'none'
+SERVICE = {
+            "GnuDIP": "1",
+            "noip": "2",
+            "selfhost": "3",
+            "freedns": "4",
+            "other": "5",
+}
 
 subsubmenu = [{'url': reverse_lazy('dynamicdns:index'),
                'text': _('About')},
@@ -52,11 +59,9 @@ def init():
 def index(request):
     """Serve dynamic DNS  page"""
 
-    index_subsubmenu = subsubmenu
-
     return TemplateResponse(request, 'dynamicdns.html',
                             {'title': _('dynamicdns'),
-                             'subsubmenu': index_subsubmenu})
+                             'subsubmenu': subsubmenu})
 
 
 class TrimmedCharField(forms.CharField):
@@ -182,7 +187,7 @@ class ConfigureForm(forms.Form):
         old_dynamicdns_secret = self.initial['dynamicdns_secret']
 
         """clear the fields which are not in use"""
-        if service_type == '1':
+        if service_type == SERVICE['GnuDIP']:
             dynamicdns_update_url = ""
         else:
             dynamicdns_server = ""
@@ -215,13 +220,13 @@ def configure(request):
     form = None
 
     if request.method == 'POST':
-        form = ConfigureForm(request.POST, initial=status, prefix='dynamicdns')
+        form = ConfigureForm(request.POST, initial=status)
         if form.is_valid():
             _apply_changes(request, status, form.cleaned_data)
             status = get_status()
-            form = ConfigureForm(initial=status, prefix='dynamicdns')
+            form = ConfigureForm(initial=status)
     else:
-        form = ConfigureForm(initial=status, prefix='dynamicdns')
+        form = ConfigureForm(initial=status)
 
     return TemplateResponse(request, 'dynamicdns_configure.html',
                             {'title': _('Configure dynamicdns Client'),
@@ -323,11 +328,11 @@ def get_status():
         status['use_http_basic_auth'] = False
 
     if not status['dynamicdns_server'] and not status['dynamicdns_update_url']:
-            status['service_type'] = '1'
+            status['service_type'] = SERVICE['GnuDIP']
     elif not status['dynamicdns_server'] and status['dynamicdns_update_url']:
-            status['service_type'] = '5'
+            status['service_type'] = SERVICE['other']
     else:
-        status['service_type'] = '1'
+        status['service_type'] = SERVICE['GnuDIP']
 
     return status
 
@@ -349,7 +354,7 @@ def _apply_changes(request, old_status, new_status):
     if new_status['dynamicdns_server'] == '':
         new_status['dynamicdns_server'] = EMPTYSTRING
 
-    if new_status['service_type'] == '1':
+    if new_status['service_type'] == SERVICE['GnuDIP']:
         new_status['dynamicdns_update_url'] = EMPTYSTRING
     else:
         new_status['dynamicdns_server'] = EMPTYSTRING

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -30,13 +30,6 @@ from plinth import package
 
 LOGGER = logging.getLogger(__name__)
 EMPTYSTRING = 'none'
-SERVICE = {
-            "GnuDIP": "1",
-            "noip": "2",
-            "selfhost": "3",
-            "freedns": "4",
-            "other": "5",
-}
 
 subsubmenu = [{'url': reverse_lazy('dynamicdns:index'),
                'text': _('About')},
@@ -113,11 +106,11 @@ class ConfigureForm(forms.Form):
 
     """ToDo: sync this list with the html template file"""
     provider_choices = (
-                       ('1', 'GnuDIP'),
-                       ('2', 'noip.com'),
-                       ('3', 'selfhost.bz'),
-                       ('4', 'freedns.afraid.org'),
-                       ('5', 'other update URL'))
+                       ('GnuDIP', 'GnuDIP'),
+                       ('noip', 'noip.com'),
+                       ('selfhost', 'selfhost.bz'),
+                       ('freedns', 'freedns.afraid.org'),
+                       ('other', 'other update URL'))
 
     enabled = forms.BooleanField(label=_('Enable Dynamic DNS'),
                                  required=False)
@@ -187,7 +180,7 @@ class ConfigureForm(forms.Form):
         old_dynamicdns_secret = self.initial['dynamicdns_secret']
 
         """clear the fields which are not in use"""
-        if service_type == SERVICE['GnuDIP']:
+        if service_type == 'GnuDIP':
             dynamicdns_update_url = ""
         else:
             dynamicdns_server = ""
@@ -328,11 +321,11 @@ def get_status():
         status['use_http_basic_auth'] = False
 
     if not status['dynamicdns_server'] and not status['dynamicdns_update_url']:
-            status['service_type'] = SERVICE['GnuDIP']
+        status['service_type'] = 'GnuDIP'
     elif not status['dynamicdns_server'] and status['dynamicdns_update_url']:
-            status['service_type'] = SERVICE['other']
+        status['service_type'] = 'other'
     else:
-        status['service_type'] = SERVICE['GnuDIP']
+        status['service_type'] = 'GnuDIP'
 
     return status
 
@@ -354,7 +347,7 @@ def _apply_changes(request, old_status, new_status):
     if new_status['dynamicdns_server'] == '':
         new_status['dynamicdns_server'] = EMPTYSTRING
 
-    if new_status['service_type'] == SERVICE['GnuDIP']:
+    if new_status['service_type'] == 'GnuDIP':
         new_status['dynamicdns_update_url'] = EMPTYSTRING
     else:
         new_status['dynamicdns_server'] = EMPTYSTRING

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -98,9 +98,10 @@ class ConfigureForm(forms.Form):
 
     dynamicdns_update_url = TrimmedCharField(label=_('Update URL'),
                                              required=False,
-                                             help_text=_('The Variables $User\
-                                                         , $Pass, $IP, $Domain\
-                                                          may be used'))
+                                             help_text=_('The Variables <User>\
+                                                         , <Pass>, <IP>, \
+                                                         <Domain> may be \
+                                                         used'))
 
     disable_SSL_cert_check = forms.BooleanField(label=_('accept all SSL \
                                                         certificates'),

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -137,12 +137,14 @@ class ConfigureForm(forms.Form):
     dynamicdns_domain = TrimmedCharField(
         label=_('Domain Name'),
         help_text=_('Example: hostname.sds-ip.de'),
+        required=False,
         validators=[
             validators.RegexValidator(r'^[\w-]{1,63}(\.[\w-]{1,63})*$',
                                       _('Invalid domain name'))])
 
     dynamicdns_user = TrimmedCharField(
         label=_('Username'),
+        required=False,
         help_text=_(hlp_user))
 
     dynamicdns_secret = TrimmedCharField(
@@ -164,6 +166,8 @@ class ConfigureForm(forms.Form):
         cleaned_data = super(ConfigureForm, self).clean()
         dynamicdns_secret = cleaned_data.get('dynamicdns_secret')
         dynamicdns_update_url = cleaned_data.get('dynamicdns_update_url')
+        dynamicdns_user = cleaned_data.get('dynamicdns_user')
+        dynamicdns_domain = cleaned_data.get('dynamicdns_domain')
         dynamicdns_server = cleaned_data.get('dynamicdns_server')
         service_type = cleaned_data.get('service_type')
         old_dynamicdns_secret = self.initial['dynamicdns_secret']
@@ -181,8 +185,15 @@ class ConfigureForm(forms.Form):
                                              a GnuDIP Server')
                 LOGGER.info('no server address given')
 
+            if dynamicdns_server and not dynamicdns_user:
+                raise forms.ValidationError('please give GnuDIP username')
+
+            if dynamicdns_server and not dynamicdns_domain:
+                raise forms.ValidationError('please give GnuDIP domain')
+
             """check if a password was set before or a password is set now"""
-            if not dynamicdns_secret and not old_dynamicdns_secret:
+            if (dynamicdns_server and not dynamicdns_secret
+               and not old_dynamicdns_secret):
                 raise forms.ValidationError('please give a password')
                 LOGGER.info('no password given')
 
@@ -247,7 +258,7 @@ def get_status():
         if details[1] == 'disabled':
             status['dynamicdns_server'] = ''
         else:
-            status['dynamicdns_server'] = details[1]
+            status['dynamicdns_server'] = details[1].replace("'", "")
     else:
         status['dynamicdns_server'] = ''
 
@@ -256,6 +267,7 @@ def get_status():
             status['dynamicdns_domain'] = ''
         else:
             status['dynamicdns_domain'] = details[2]
+            status['dynamicdns_domain'] = details[2].replace("'", "")
     else:
         status['dynamicdns_domain'] = ''
 
@@ -263,7 +275,7 @@ def get_status():
         if details[3] == 'disabled':
             status['dynamicdns_user'] = ''
         else:
-            status['dynamicdns_user'] = details[3]
+            status['dynamicdns_user'] = details[3].replace("'", "")
     else:
         status['dynamicdns_user'] = ''
 
@@ -271,7 +283,7 @@ def get_status():
         if details[4] == 'disabled':
             status['dynamicdns_secret'] = ''
         else:
-            status['dynamicdns_secret'] = details[4]
+            status['dynamicdns_secret'] = details[4].replace("'", "")
     else:
         status['dynamicdns_secret'] = ''
 
@@ -279,7 +291,7 @@ def get_status():
         if details[5] == 'disabled':
             status['dynamicdns_ipurl'] = ''
         else:
-            status['dynamicdns_ipurl'] = details[5]
+            status['dynamicdns_ipurl'] = details[5].replace("'", "")
     else:
         status['dynamicdns_ipurl'] = ''
 
@@ -287,7 +299,7 @@ def get_status():
         if details[6] == 'disabled':
             status['dynamicdns_update_url'] = ''
         else:
-            status['dynamicdns_update_url'] = details[6]
+            status['dynamicdns_update_url'] = details[6].replace("'", "")
     else:
         status['dynamicdns_update_url'] = ''
 

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -70,17 +70,21 @@ class TrimmedCharField(forms.CharField):
 
 class ConfigureForm(forms.Form):
     """Form to configure the dynamic DNS client"""
+
+    hlp_updt_url = 'The Variables &lt;User&gt;, &lt;Pass&gt;, &lt;Ip&gt;, \
+                    &lt;Domain&gt; may be used.'
+
+    hlp_services = 'Please choose a update protocol according to your \
+                    provider. If your provider does not support the GnudIP \
+                    protocol or your provider is not listed you may use \
+                    the update URL of your provider.'
+
     enabled = forms.BooleanField(label=_('Enable Dynamic DNS'),
                                  required=False, widget=forms.CheckboxInput
                                 (attrs={'onclick': 'mod_form();'}))
 
     service_type = forms.ChoiceField(label=_('Service type'),
-                                     help_text=_('Please choose a update\
-                                     protocol according to your \
-                                     provider. If your provider does not\
-                                     support the GnudIP protocol or your\
-                                     provider is not listed you may use\
-                                     the update URL of your provider.'),
+                                     help_text=_(hlp_services),
                                      choices=(('1', 'GnuDIP'),
                                              ('2', 'noip.com'),
                                              ('3', 'selfhost.bz'),
@@ -98,10 +102,7 @@ class ConfigureForm(forms.Form):
 
     dynamicdns_update_url = TrimmedCharField(label=_('Update URL'),
                                              required=False,
-                                             help_text=_('The Variables <User>\
-                                                         , <Pass>, <Ip>, \
-                                                         <Domain> may be \
-                                                         used'))
+                                             help_text=_(hlp_updt_url))
 
     disable_SSL_cert_check = forms.BooleanField(label=_('accept all SSL \
                                                         certificates'),

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -84,8 +84,10 @@ class ConfigureForm(forms.Form):
     hlp_disable_ssl = 'use this option if your provider uses self signed \
                        certificates'
 
-    hlp_secret = 'You should have been requested to select a password \
-                  when you created the account. Leave this field empty \
+    hlp_http_auth = 'if this option is selected, your username and \
+                     password will be used for HTTP basic authentication'
+
+    hlp_secret = 'Leave this field empty \
                   if you want to keep your previous configured password.'
 
     hlp_ipurl = 'Optional Value. If your FreedomBox is not connected \
@@ -132,6 +134,7 @@ class ConfigureForm(forms.Form):
 
     use_http_basic_auth = forms.BooleanField(label=_('use HTTP basic \
                                                       authentication'),
+                                             help_text=_(hlp_http_auth),
                                              required=False)
 
     dynamicdns_domain = TrimmedCharField(

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -174,16 +174,17 @@ class ConfigureForm(forms.Form):
         else:
             dynamicdns_server = ""
 
-        """check if gnudip server or update URL is filled"""
-        if not dynamicdns_update_url and not dynamicdns_server:
-            raise forms.ValidationError('please give update URL or \
-                                         a GnuDIP Server')
-            LOGGER.info('no server address given')
+        if cleaned_data.get('enabled'):
+            """check if gnudip server or update URL is filled"""
+            if not dynamicdns_update_url and not dynamicdns_server:
+                raise forms.ValidationError('please give update URL or \
+                                             a GnuDIP Server')
+                LOGGER.info('no server address given')
 
-        """check if a password was set before or a password is set now"""
-        if not dynamicdns_secret and not old_dynamicdns_secret:
-            raise forms.ValidationError('please give a password')
-            LOGGER.info('no password given')
+            """check if a password was set before or a password is set now"""
+            if not dynamicdns_secret and not old_dynamicdns_secret:
+                raise forms.ValidationError('please give a password')
+                LOGGER.info('no password given')
 
 
 @login_required

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -72,12 +72,37 @@ class ConfigureForm(forms.Form):
     """Form to configure the dynamic DNS client"""
 
     hlp_updt_url = 'The Variables &lt;User&gt;, &lt;Pass&gt;, &lt;Ip&gt;, \
-                    &lt;Domain&gt; may be used.'
+                    &lt;Domain&gt; may be used within the URL. For details\
+                    see the update URL templates of the example providers.'
 
     hlp_services = 'Please choose a update protocol according to your \
                     provider. If your provider does not support the GnudIP \
                     protocol or your provider is not listed you may use \
                     the update URL of your provider.'
+
+    hlp_disable_ssl = 'use this option if your provider uses self signed \
+                       certificates'
+
+    hlp_secret = 'You should have been requested to select a password \
+                  when you created the account. Leave this field empty \
+                  if you want to keep your previous configured password.'
+
+    hlp_ipurl = 'Optional Value. If your FreedomBox is not connected \
+                 directly to the Internet (i.e. connected to a NAT \
+                 router) this URL is used to figure out the real Internet \
+                 IP. The URL should simply return the IP where the \
+                 client comes from. Example: \
+                 http://myip.datasystems24.de'
+
+    hlp_user = 'You should have been requested to select a username \
+                when you created the account'
+
+    """ToDo: sync this list with the html template file"""
+    provider_choices = (
+                       ('1', 'GnuDIP'),
+                       ('2', 'noip.com'),
+                       ('3', 'selfhost.bz'),
+                       ('4', 'other Update URL'))
 
     enabled = forms.BooleanField(label=_('Enable Dynamic DNS'),
                                  required=False, widget=forms.CheckboxInput
@@ -85,10 +110,7 @@ class ConfigureForm(forms.Form):
 
     service_type = forms.ChoiceField(label=_('Service type'),
                                      help_text=_(hlp_services),
-                                     choices=(('1', 'GnuDIP'),
-                                             ('2', 'noip.com'),
-                                             ('3', 'selfhost.bz'),
-                                             ('4', 'other Update URL')),
+                                     choices=provider_choices,
                                      widget=forms.Select(attrs={'onChange':
                                                                 'dropdown()'}))
 
@@ -106,10 +128,7 @@ class ConfigureForm(forms.Form):
 
     disable_SSL_cert_check = forms.BooleanField(label=_('accept all SSL \
                                                         certificates'),
-                                                help_text=_('use this option \
-                                                             if your provider \
-                                                             uses self signed\
-                                                             certificates'),
+                                                help_text=_(hlp_disable_ssl),
                                                 required=False)
 
     use_http_basic_auth = forms.BooleanField(label=_('use HTTP basic \
@@ -125,15 +144,12 @@ class ConfigureForm(forms.Form):
 
     dynamicdns_user = TrimmedCharField(
         label=_('Username'),
-        help_text=_('You should have been requested to select a username \
-                     when you created the account'))
+        help_text=_(hlp_user))
 
     dynamicdns_secret = TrimmedCharField(
         label=_('Password'), widget=forms.PasswordInput(),
         required=False,
-        help_text=_('You should have been requested to select a password \
-                     when you created the account. Leave this field empty \
-                     if you want to keep your previous configured password.'))
+        help_text=_(hlp_secret))
 
     showpw = forms.BooleanField(label=_('show password'),
                                 required=False,
@@ -143,12 +159,7 @@ class ConfigureForm(forms.Form):
     dynamicdns_ipurl = TrimmedCharField(
         label=_('IP check URL'),
         required=False,
-        help_text=_('Optional Value. If your FreedomBox is not connected \
-                     directly to the Internet (i.e. connected to a NAT \
-                     router) this URL is used to figure out the real Internet \
-                     IP. The URL should simply return the IP where the \
-                     client comes from. Example: \
-                     http://myip.datasystems24.de'),
+        help_text=_(hlp_ipurl),
         validators=[
             validators.URLValidator(schemes=['http', 'https', 'ftp'])])
 

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -165,7 +165,13 @@ class ConfigureForm(forms.Form):
         dynamicdns_secret = cleaned_data.get('dynamicdns_secret')
         dynamicdns_update_url = cleaned_data.get('dynamicdns_update_url')
         dynamicdns_server = cleaned_data.get('dynamicdns_server')
+        service_type = cleaned_data.get('service_type')
         old_dynamicdns_secret = self.initial['dynamicdns_secret']
+
+        if service_type == '1':
+            dynamicdns_update_url = ""
+        else:
+            dynamicdns_server = ""
 
         """Todo: this is not working!! will see tomorrow why"""
         if not dynamicdns_update_url and not dynamicdns_server:
@@ -317,11 +323,6 @@ def _apply_changes(request, old_status, new_status):
         new_status['dynamicdns_update_url'] = EMPTYSTRING
 
     if new_status['dynamicdns_server'] == '':
-        new_status['dynamicdns_server'] = EMPTYSTRING
-
-    if new_status['service_type'] == '1':
-        new_status['dynamicdns_ipurl'] = EMPTYSTRING
-    else:
         new_status['dynamicdns_server'] = EMPTYSTRING
 
     if old_status != new_status:

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -166,7 +166,13 @@ class ConfigureForm(forms.Form):
     def clean(self):
         cleaned_data = super(ConfigureForm, self).clean()
         dynamicdns_secret = cleaned_data.get('dynamicdns_secret')
+        dynamicdns_update_url = cleaned_data.get('dynamicdns_update_url')
+        dynamicdns_server = cleaned_data.get('dynamicdns_server')
         old_dynamicdns_secret = self.initial['dynamicdns_secret']
+
+        if not dynamicdns_update_url and not dynamicdns_server:
+            raise forms.ValidationError('please give update URL or \
+                                         a GnuDIP Server')
 
         if not dynamicdns_secret and not old_dynamicdns_secret:
             raise forms.ValidationError('please give a password')

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -70,15 +70,44 @@ class TrimmedCharField(forms.CharField):
 
 class ConfigureForm(forms.Form):
     """Form to configure the dynamic DNS client"""
-    enabled = forms.BooleanField(label=_('Enable dynamicdns'),
+    enabled = forms.BooleanField(label=_('Enable Dynamic DNS'),
                                  required=False)
 
+    dynamicdns_service = forms.ChoiceField(label=_('Service type'),
+       help_text=_('Please choose a update protocol according to your provider.\
+                   We recommend the GnudIP protocol. If your provider does not \
+                   support the GnudIP protocol or your provider is not listed \
+                   you may use the update URL of your provider.'),
+                   choices=(('1', 'GnudIP'), 
+                            ('2', 'noip.com'),
+                            ('3', 'selfhost.bz'),
+                            ('4', 'other Update URL')))
+
     dynamicdns_server = TrimmedCharField(
-        label=_('Server Address'),
+        label=_('GnudIP Server Address'),
         help_text=_('Example: gnudip.provider.org'),
         validators=[
             validators.RegexValidator(r'^[\w-]{1,63}(\.[\w-]{1,63})*$',
                                       _('Invalid server name'))])
+    
+    dynamicdns_update_url = TrimmedCharField(
+         label=_('Update URL'),
+         required=False,
+         help_text=_('The Variables $User, $Pass, $IP, $Domain may be used \
+                within this URL.</br> Example URL: </br> \
+                https://some.tld/up.php?us=$User&pw=$Pass&ip=$IP&dom=$Domain'),
+    validators=[
+        validators.URLValidator(schemes=['http', 'https'])])
+    
+    disable_SSL_cert_check = forms.BooleanField(
+                            label=_('accept all SSL certificates'),
+                            help_text=_('use this option if your provider uses\
+                            self signed certificates'),
+                            required=False)
+    
+    use_http_basic_auth = forms.BooleanField(
+                            label=_('use HTTP basic authentication'),
+                            required=False)
 
     dynamicdns_domain = TrimmedCharField(
         label=_('Domain Name'),
@@ -96,7 +125,8 @@ class ConfigureForm(forms.Form):
         label=_('Password'), widget=forms.PasswordInput(),
         required=False,
         help_text=_('You should have been requested to select a password \
-                     when you created the account.'))
+                     when you created the account. Leave this field empty \
+                     if you want to keep your previous configured password.'))
 
     showpw = forms.BooleanField(label=_('show password'),
                                 required=False,

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -76,7 +76,7 @@ class ConfigureForm(forms.Form):
                     &lt;Domain&gt; may be used within the URL. For details\
                     see the update URL templates of the example providers.'
 
-    hlp_services = 'Please choose a update protocol according to your \
+    hlp_services = 'Please choose an update protocol according to your \
                     provider. If your provider does not support the GnudIP \
                     protocol or your provider is not listed you may use \
                     the update URL of your provider.'

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -81,11 +81,17 @@ class ConfigureForm(forms.Form):
                     protocol or your provider is not listed you may use \
                     the update URL of your provider.'
 
-    hlp_disable_ssl = 'use this option if your provider uses self signed \
-                       certificates'
+    hlp_server = 'Please do not enter a URL here (like "https://example.com/")\
+                  but only the hostname of the GnuDIP server (like \
+                  "example.com").'
 
-    hlp_http_auth = 'if this option is selected, your username and \
-                     password will be used for HTTP basic authentication'
+    hlp_domain = 'The public domain name you want use to reach your box.'
+
+    hlp_disable_ssl = 'Use this option if your provider uses self signed \
+                       certificates.'
+
+    hlp_http_auth = 'If this option is selected, your username and \
+                     password will be used for HTTP basic authentication.'
 
     hlp_secret = 'Leave this field empty \
                   if you want to keep your previous configured password.'
@@ -98,7 +104,7 @@ class ConfigureForm(forms.Form):
                  http://myip.datasystems24.de'
 
     hlp_user = 'You should have been requested to select a username \
-                when you created the account'
+                when you created the account.'
 
     """ToDo: sync this list with the html template file"""
     provider_choices = (
@@ -118,7 +124,7 @@ class ConfigureForm(forms.Form):
     dynamicdns_server = TrimmedCharField(
         label=_('GnudIP Server Address'),
         required=False,
-        help_text=_('Example: gnudip.provider.org'),
+        help_text=_(hlp_server),
         validators=[
             validators.RegexValidator(r'^[\w-]{1,63}(\.[\w-]{1,63})*$',
                                       _('Invalid server name'))])
@@ -139,7 +145,7 @@ class ConfigureForm(forms.Form):
 
     dynamicdns_domain = TrimmedCharField(
         label=_('Domain Name'),
-        help_text=_('Example: hostname.sds-ip.de'),
+        help_text=_(hlp_domain),
         required=False,
         validators=[
             validators.RegexValidator(r'^[\w-]{1,63}(\.[\w-]{1,63})*$',

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -319,7 +319,7 @@ def _apply_changes(request, old_status, new_status):
     if new_status['dynamicdns_server'] == '':
         new_status['dynamicdns_server'] = EMPTYSTRING
 
-    if new_status['service_type'] == 'GnuDIP':
+    if new_status['service_type'] == '1':
         new_status['dynamicdns_ipurl'] = EMPTYSTRING
     else:
         new_status['dynamicdns_server'] = EMPTYSTRING

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -29,6 +29,7 @@ from plinth import cfg
 from plinth import package
 
 LOGGER = logging.getLogger(__name__)
+EMPTYSTRING = 'none'
 
 subsubmenu = [{'url': reverse_lazy('dynamicdns:index'),
                'text': _('About')},
@@ -170,12 +171,15 @@ class ConfigureForm(forms.Form):
         dynamicdns_server = cleaned_data.get('dynamicdns_server')
         old_dynamicdns_secret = self.initial['dynamicdns_secret']
 
+        """Todo: this is not working!! will see tomorrow why"""
         if not dynamicdns_update_url and not dynamicdns_server:
             raise forms.ValidationError('please give update URL or \
                                          a GnuDIP Server')
+            LOGGER.info('no server address given')
 
         if not dynamicdns_secret and not old_dynamicdns_secret:
             raise forms.ValidationError('please give a password')
+            LOGGER.info('no password given')
 
 
 @login_required
@@ -311,27 +315,15 @@ def _apply_changes(request, old_status, new_status):
         new_status['dynamicdns_secret'] = old_status['dynamicdns_secret']
 
     if new_status['dynamicdns_ipurl'] == '':
-        new_status['dynamicdns_ipurl'] = 'none'
+        new_status['dynamicdns_ipurl'] = EMPTYSTRING
 
-    if old_status['dynamicdns_server'] != \
-       new_status['dynamicdns_server'] or \
-       old_status['dynamicdns_domain'] != \
-       new_status['dynamicdns_domain'] or \
-       old_status['dynamicdns_user'] != \
-       new_status['dynamicdns_user'] or \
-       old_status['dynamicdns_secret'] != \
-       new_status['dynamicdns_secret'] or \
-       old_status['dynamicdns_ipurl'] != \
-       new_status['dynamicdns_ipurl'] or \
-       old_status['dynamicdns_update_url'] != \
-       new_status['dynamicdns_update_url'] or \
-       old_status['disable_SSL_cert_check'] != \
-       new_status['disable_SSL_cert_check'] or \
-       old_status['use_http_basic_auth'] != \
-       new_status['use_http_basic_auth'] or \
-       old_status['enabled'] != \
-       new_status['enabled']:
+    if new_status['dynamicdns_update_url'] == '':
+        new_status['dynamicdns_update_url'] = EMPTYSTRING
 
+    if new_status['dynamicdns_server'] == '':
+        new_status['dynamicdns_server'] = EMPTYSTRING
+
+    if old_status != new_status:
         disable_ssl_check = "disabled"
         use_http_basic_auth = "disabled"
 
@@ -357,6 +349,8 @@ def _apply_changes(request, old_status, new_status):
 
         messages.success(request,
                          _('Dynamic DNS configuration is updated!'))
+    else:
+        LOGGER.info('nothing changed')
 
 
 def _run(arguments, superuser=False):

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -103,7 +103,8 @@ class ConfigureForm(forms.Form):
                        ('1', 'GnuDIP'),
                        ('2', 'noip.com'),
                        ('3', 'selfhost.bz'),
-                       ('4', 'other update URL'))
+                       ('4', 'freedns.afraid.org'),
+                       ('5', 'other update URL'))
 
     enabled = forms.BooleanField(label=_('Enable Dynamic DNS'),
                                  required=False)
@@ -294,7 +295,7 @@ def get_status():
     if not status['dynamicdns_server'] and not status['dynamicdns_update_url']:
             status['service_type'] = '1'
     elif not status['dynamicdns_server'] and status['dynamicdns_update_url']:
-            status['service_type'] = '4'
+            status['service_type'] = '5'
     else:
         status['service_type'] = '1'
 

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -99,7 +99,7 @@ class ConfigureForm(forms.Form):
     dynamicdns_update_url = TrimmedCharField(label=_('Update URL'),
                                              required=False,
                                              help_text=_('The Variables <User>\
-                                                         , <Pass>, <IP>, \
+                                                         , <Pass>, <Ip>, \
                                                          <Domain> may be \
                                                          used'))
 

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -173,7 +173,6 @@ class ConfigureForm(forms.Form):
         else:
             dynamicdns_server = ""
 
-        """Todo: this is not working!! will see tomorrow why"""
         if not dynamicdns_update_url and not dynamicdns_server:
             raise forms.ValidationError('please give update URL or \
                                          a GnuDIP Server')
@@ -323,6 +322,11 @@ def _apply_changes(request, old_status, new_status):
         new_status['dynamicdns_update_url'] = EMPTYSTRING
 
     if new_status['dynamicdns_server'] == '':
+        new_status['dynamicdns_server'] = EMPTYSTRING
+
+    if new_status['service_type'] == '1':
+        new_status['dynamicdns_update_url'] = EMPTYSTRING
+    else:
         new_status['dynamicdns_server'] = EMPTYSTRING
 
     if old_status != new_status:

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -318,6 +318,11 @@ def _apply_changes(request, old_status, new_status):
     if new_status['dynamicdns_server'] == '':
         new_status['dynamicdns_server'] = EMPTYSTRING
 
+    if new_status['service_type'] == 'GnuDIP':
+        new_status['dynamicdns_ipurl'] = EMPTYSTRING
+    else:
+        new_status['dynamicdns_server'] = EMPTYSTRING
+
     if old_status != new_status:
         disable_ssl_check = "disabled"
         use_http_basic_auth = "disabled"

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -103,17 +103,14 @@ class ConfigureForm(forms.Form):
                        ('1', 'GnuDIP'),
                        ('2', 'noip.com'),
                        ('3', 'selfhost.bz'),
-                       ('4', 'other Update URL'))
+                       ('4', 'other update URL'))
 
     enabled = forms.BooleanField(label=_('Enable Dynamic DNS'),
-                                 required=False, widget=forms.CheckboxInput
-                                (attrs={'onclick': 'mod_form();'}))
+                                 required=False)
 
     service_type = forms.ChoiceField(label=_('Service type'),
                                      help_text=_(hlp_services),
-                                     choices=provider_choices,
-                                     widget=forms.Select(attrs={'onChange':
-                                                                'dropdown()'}))
+                                     choices=provider_choices)
 
     dynamicdns_server = TrimmedCharField(
         label=_('GnudIP Server Address'),
@@ -153,9 +150,7 @@ class ConfigureForm(forms.Form):
         help_text=_(hlp_secret))
 
     showpw = forms.BooleanField(label=_('show password'),
-                                required=False,
-                                widget=forms.CheckboxInput
-                                (attrs={'onclick': 'show_pass();'}))
+                                required=False)
 
     dynamicdns_ipurl = TrimmedCharField(
         label=_('IP check URL'),

--- a/plinth/modules/dynamicdns/templates/dynamicdns.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns.html
@@ -32,7 +32,10 @@
     and if someone from the internet asks for your DNS name he will get your
     current IP answered.
    </br> </br>
-   If you are looking for a free dynamic DNS account, you may find one 
-   <a href='http://gnudip.datasystems24.net' target='_blank'> here</a>
-   or <a href='http://freedns.afraid.org/' target='_blank'> here</a></p>
+   If you are looking for a free dynamic DNS account, you may find a free
+   GnuDIP service at <a href='http://gnudip.datasystems24.net'
+   target='_blank'>gnudip.datasystems24.net</a> or you may find free update
+   URL based services on
+   <a href='http://freedns.afraid.org/' target='_blank'> 
+   freedns.afraid.org</a></p>
 {% endblock %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns.html
@@ -33,5 +33,6 @@
     current IP answered.
    </br> </br>
    If you are looking for a free dynamic DNS account, you may find one 
-   <a href='http://gnudip.datasystems24.net' target='_blank'> here</a></>
+   <a href='http://gnudip.datasystems24.net' target='_blank'> here</a>
+   or <a href='http://freedns.afraid.org/' target='_blank'> here</a></p>
 {% endblock %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns.html
@@ -37,5 +37,10 @@
    target='_blank'>gnudip.datasystems24.net</a> or you may find free update
    URL based services on
    <a href='http://freedns.afraid.org/' target='_blank'> 
-   freedns.afraid.org</a></p>
+   freedns.afraid.org</a>
+   </br> </br>
+   If your freedombox is connected behind some NAT router, don't forget
+   to add portforwarding (i.e. forward some standard ports like 80 and 443)
+   to your freedombox device.
+</p>
 {% endblock %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns.html
@@ -27,9 +27,10 @@
    The solution is to assign a DNS name to your IP address and update the DNS 
    name every time your IP is changed by your Internet provider. Dynamic DNS 
    allows you to push your current public IP address to an  
-   <a href='http://gnudip2.sourceforge.net/' target='_blank'> gnudip </a> server. 
-   Afterwards the Server will assign your DNS name with the new IP and if someone
-   from the internet asks for your DNS name he will get your current IP answered.
+   <a href='http://gnudip2.sourceforge.net/' target='_blank'> gnudip </a>
+    server. Afterwards the Server will assign your DNS name with the new IP
+    and if someone from the internet asks for your DNS name he will get your
+    current IP answered.
    </br> </br>
    If you are looking for a free dynamic DNS account, you may find one 
    <a href='http://gnudip.datasystems24.net' target='_blank'> here</a></>

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -35,7 +35,7 @@
         only "GnudIP Server Address" or "Update URL" field.</br><hr>
       </div>
       <div id='div-dynamicdns-dropdown' style="display:none">
-      {% include 'bootstrapform/field.html' with field=form.dynamicdns_service %}
+      {% include 'bootstrapform/field.html' with field=form.service_type %}
       </div>
       <div id='div-dynamicdns-gnudip'>
       {% include 'bootstrapform/field.html' with field=form.dynamicdns_server %}
@@ -78,7 +78,7 @@
 	
 	function dropdown()
 	{
-		var dropdown = document.getElementById('id_dynamicdns-dynamicdns_service');
+		var dropdown = document.getElementById('id_dynamicdns-service_type');
 		var service_type = dropdown.options[dropdown.selectedIndex].value;
 		if (service_type == 1){
 			document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
@@ -112,7 +112,7 @@
 		
 		if ( document.getElementById('id_dynamicdns-enabled').checked ) {
 			document.getElementById('dynamicdns-post-enabled-form').style.display = 'block';
-			var dropdown = document.getElementById('id_dynamicdns-dynamicdns_service');
+			var dropdown = document.getElementById('id_dynamicdns-service_type');
 			var service_type = dropdown.options[dropdown.selectedIndex].value;
 			if (service_type == 1){
 				document.getElementById('div-dynamicdns-updateurl').style.display = 'none';

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -21,25 +21,123 @@
 {% load bootstrap %}
 
 {% block content %}
-  <h3>Configuration</h3>
+
   <form class="form" method="post">
     {% csrf_token %}
 
-    {{ form|bootstrap }}
+    {% include 'bootstrapform/field.html' with field=form.enabled %}
 
-    <input type="submit" class="btn btn-primary btn-md" value="Update setup"/>
+     <div id='dynamicdns-post-enabled-form'
+         style='display: {{ form.enabled.value|yesno:'block,none' }};'>
+      <h3>Dynamic DNS type</h3>
+      {% include 'bootstrapform/field.html' with field=form.dynamicdns_service %}
+      <div id='dynamicdns-gnudip'>
+      {% include 'bootstrapform/field.html' with field=form.dynamicdns_server %}
+      </div>
+      
+      <div id='dynamicdns-updateurl'>
+      {% include 'bootstrapform/field.html' with field=form.dynamicdns_update_url %}
+      {% include 'bootstrapform/field.html' with field=form.disable_SSL_cert_check %}
+      {% include 'bootstrapform/field.html' with field=form.use_http_basic_auth %}
+      </div>
+
+      <h3>Account Information</h3>
+      {% include 'bootstrapform/field.html' with field=form.dynamicdns_domain %}
+      {% include 'bootstrapform/field.html' with field=form.dynamicdns_user %}
+      {% include 'bootstrapform/field.html' with field=form.dynamicdns_secret %}
+      {% include 'bootstrapform/field.html' with field=form.showpw %}
+      
+      <h3>IP check URL</h3>
+      {% include 'bootstrapform/field.html' with field=form.dynamicdns_ipurl %}
+    </div>
+
+    <input type="submit" class="btn btn-primary" value="Update setup"/>
 
   </form>
+
 {% endblock %}
 
 {% block page_js %}
-<script type="text/javascript">
-function show_pass()
-{
-if(document.getElementById('id_dynamicdns-showpw').checked){
-	document.getElementById("id_dynamicdns-dynamicdns_secret").type='text';}
-else
-	document.getElementById("id_dynamicdns-dynamicdns_secret").type='password';
-}
-</script>
+
+
+
+  <script type="text/javascript">
+  
+  window.onload = function() {hide()}
+  
+    (function($) {
+
+    $('#id_dynamicdns-enabled').change(function() {
+      if ($('#id_dynamicdns-enabled').prop('checked')) {
+        $('#dynamicdns-post-enabled-form').show('slow');
+      } else {
+        $('#dynamicdns-post-enabled-form').hide('slow');
+      }
+    });
+
+    $('#id_dynamicdns-dynamicdns_service').change(function() {
+    	//$(this).find('option:selected').text() == GnudIP
+        if ($(this).val() == 1){
+        	$('#dynamicdns-updateurl').hide();
+        	$('#dynamicdns-gnudip').show('slow');
+        	$('#id_dynamicdns-dynamicdns_update_url').val("");
+        }
+        if ($(this).val() == 2){
+        	$('#dynamicdns-updateurl').show('slow');
+        	$('#dynamicdns-gnudip').hide();
+        	$('#id_dynamicdns-dynamicdns_server').val("");
+        	$('#id_dynamicdns-dynamicdns_update_url').val("https://noip.com/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
+        }
+        if ($(this).val() == 3){
+        	$('#dynamicdns-updateurl').show('slow');
+        	$('#dynamicdns-gnudip').hide();
+        	$('#id_dynamicdns-dynamicdns_server').val("");
+        	$('#id_dynamicdns-dynamicdns_update_url').val("https://selfhost.bz/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
+        }
+        if ($(this).val() == 4){
+        	$('#dynamicdns-updateurl').show('slow');
+        	$('#dynamicdns-gnudip').hide();
+        	$('#id_dynamicdns-dynamicdns_server').val("");
+        	$('#id_dynamicdns-dynamicdns_update_url').val("https://example.com/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
+        }  
+    });
+    })(jQuery);
+    
+	function show_pass()
+	{
+		if(document.getElementById('id_dynamicdns-showpw').checked){
+			document.getElementById("id_dynamicdns-dynamicdns_secret").type='text';}
+		else
+			document.getElementById("id_dynamicdns-dynamicdns_secret").type='password';
+	}
+	
+	function hide()
+	{
+	      if ($('#id_dynamicdns-enabled').prop('checked')) {
+		    	//$(this).find('option:selected').text() == GnudIP
+		        if ($(this).val() == 1){
+		        	$('#dynamicdns-updateurl').hide();
+		        	$('#id_dynamicdns-dynamicdns_update_url').val("");
+		        }
+		        if ($(this).val() == 2){
+		        	$('#dynamicdns-gnudip').hide();
+		        	$('#id_dynamicdns-dynamicdns_server').val("");
+		        	$('#id_dynamicdns-dynamicdns_update_url').val("https://noip.com/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
+		        }
+		        if ($(this).val() == 3){
+		        	$('#dynamicdns-gnudip').hide();
+		        	$('#id_dynamicdns-dynamicdns_server').val("");
+		        	$('#id_dynamicdns-dynamicdns_update_url').val("https://selfhost.bz/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
+		        }
+		        if ($(this).val() == 4){
+		        	$('#dynamicdns-gnudip').hide();
+		        	$('#id_dynamicdns-dynamicdns_server').val("");
+		        	$('#id_dynamicdns-dynamicdns_update_url').val("https://example.com/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
+		        }
+	      } else {
+	        $('#dynamicdns-post-enabled-form').hide('slow');
+	      }	    
+	}
+	
+  </script>
 {% endblock %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -49,12 +49,18 @@
                      '<Domain>&myip=<Ip>'
       var FREEDNS  = 'http://freedns.afraid.org/dynamic/update.php?' +
                      '_YOURAPIKEYHERE_'
+
+      //hide javascript warning
       $('#dynamicdns-no-js').hide();
+      //hide ALL form fields
       $('.form-group').hide();
+      //show the enable checkbox
       $('#id_dynamicdns-enabled').closest('.form-group').show();
       if ($('#id_dynamicdns-enabled').prop('checked')) {
+      //show all form fields
         show_all();
-
+        //set the selectbox to the last configured value
+        select_service();
       }
 
       $('#id_dynamicdns-enabled').change(function() {
@@ -83,6 +89,31 @@
                               'type', 'password'));
         }
       });
+
+      function select_service()
+      {
+        if ( $("#id_dynamicdns-dynamicdns_server").val().length == 0 ) {
+          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
+          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
+          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
+          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').hide();
+          if($("#id_dynamicdns-dynamicdns_update_url").val() == NOIP){
+            $("#id_dynamicdns-service_type").val(2);
+          }else if($("#id_dynamicdns-dynamicdns_update_url").val() == SELFHOST){
+            $("#id_dynamicdns-service_type").val(3);
+          }else if ($("#id_dynamicdns-dynamicdns_update_url").val() == FREEDNS){
+            $("#id_dynamicdns-service_type").val(4);
+          }else{
+            $("#id_dynamicdns-service_type option:selected").text("other update URL")
+          }
+        }else{
+          $("#id_dynamicdns-service_type").val(1);
+          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').hide();
+          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').hide();
+          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').hide();
+          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
+        }
+      }
 
       function configure_dropdown()
       {

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -66,6 +66,8 @@
 {% block page_js %}
 
   <script type="text/javascript">
+  var SELFHOST = 'https://carol.selfhost.de/update?username=<Username>&password=<Password>&myip=<Ip>'
+  var NOIP = "http://dynupdate.no-ip.com/nic/update?hostname=<domain>&myip=<Ip>"
   window.onload = function() {mod_form()}
 
 	function show_pass()
@@ -80,6 +82,8 @@
 	{
 		var dropdown = document.getElementById('id_dynamicdns-service_type');
 		var service_type = dropdown.options[dropdown.selectedIndex].value;
+		document.getElementById('id_dynamicdns-use_http_basic_auth').checked = false;
+		document.getElementById('id_dynamicdns-disable_SSL_cert_check').checked = false;
 		if (service_type == 1){
 			document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
 			document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
@@ -88,13 +92,14 @@
 		if (service_type == 2){
 			document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
 			document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-			document.getElementById('id_dynamicdns-dynamicdns_update_url').value='noip';
+			document.getElementById('id_dynamicdns-dynamicdns_update_url').value = NOIP;
+			document.getElementById('id_dynamicdns-use_http_basic_auth').checked = true;
 			document.getElementById('id_dynamicdns-dynamicdns_server').value='';
 		}
 		if (service_type == 3){
 			document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
 			document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-			document.getElementById('id_dynamicdns-dynamicdns_update_url').value='selfhost';
+			document.getElementById('id_dynamicdns-dynamicdns_update_url').value = SELFHOST;
 			document.getElementById('id_dynamicdns-dynamicdns_server').value='';
 		}
 		if (service_type == 4){

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -31,8 +31,9 @@
      
       <h3>Dynamic DNS type</h3>
       <div id='dynamicdns-no-js'>
-       You have disabled Javascript. Dynamic form mode is disabled. Please fill
-        only "GnudIP Server Address" or "Update URL" field.</br><hr>
+       You have disabled Javascript. Dynamic form mode is disabled and 
+       some helper functions may not work </br> (but the main functionality should work)
+       </br><hr>
       </div>
       <div id='div-dynamicdns-dropdown' style="display:none">
       {% include 'bootstrapform/field.html' with field=form.service_type %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -118,16 +118,16 @@
         if ( $("#id_dynamicdns_server").val().length == 0 ) {
           set_update_url_mode()
           if ( update_url == NOIP) {
-            $("#id_service_type").val(2);
+            $("#id_service_type").val("noip");
           } else if ( update_url == SELFHOST) {
-            $("#id_service_type").val(3);
+            $("#id_service_type").val("selfhost");
           } else if ( update_url == FREEDNS) {
-            $("#id_service_type").val(4);
+            $("#id_service_type").val("freedns");
           } else {
-            $("#id_service_type").val(5);
+            $("#id_service_type").val("other");
           }
         } else {
-          $("#id_service_type").val(1);
+          $("#id_service_type").val("GnuDIP");
           set_gnudip_mode();
         }
       }

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -27,15 +27,21 @@
 
     {% include 'bootstrapform/field.html' with field=form.enabled %}
 
-     <div id='dynamicdns-post-enabled-form'
-         style='display: {{ form.enabled.value|yesno:'block,none' }};'>
+     <div id='dynamicdns-post-enabled-form'>
+     
       <h3>Dynamic DNS type</h3>
+      <div id='dynamicdns-no-js'>
+       You have disabled Javascript. Dynamic form mode is disabled. Please fill
+        only "GnudIP Server Address" or "Update URL" field.</br><hr>
+      </div>
+      <div id='div-dynamicdns-dropdown' style="display:none">
       {% include 'bootstrapform/field.html' with field=form.dynamicdns_service %}
-      <div id='dynamicdns-gnudip'>
+      </div>
+      <div id='div-dynamicdns-gnudip'>
       {% include 'bootstrapform/field.html' with field=form.dynamicdns_server %}
       </div>
       
-      <div id='dynamicdns-updateurl'>
+      <div id='div-dynamicdns-updateurl'>
       {% include 'bootstrapform/field.html' with field=form.dynamicdns_update_url %}
       {% include 'bootstrapform/field.html' with field=form.disable_SSL_cert_check %}
       {% include 'bootstrapform/field.html' with field=form.use_http_basic_auth %}
@@ -59,85 +65,52 @@
 
 {% block page_js %}
 
-
-
   <script type="text/javascript">
-  
-  window.onload = function() {hide()}
-  
-    (function($) {
+  window.onload = function() {mod_form()}
 
-    $('#id_dynamicdns-enabled').change(function() {
-      if ($('#id_dynamicdns-enabled').prop('checked')) {
-        $('#dynamicdns-post-enabled-form').show('slow');
-      } else {
-        $('#dynamicdns-post-enabled-form').hide('slow');
-      }
-    });
-
-    $('#id_dynamicdns-dynamicdns_service').change(function() {
-    	//$(this).find('option:selected').text() == GnudIP
-        if ($(this).val() == 1){
-        	$('#dynamicdns-updateurl').hide();
-        	$('#dynamicdns-gnudip').show('slow');
-        	$('#id_dynamicdns-dynamicdns_update_url').val("");
-        }
-        if ($(this).val() == 2){
-        	$('#dynamicdns-updateurl').show('slow');
-        	$('#dynamicdns-gnudip').hide();
-        	$('#id_dynamicdns-dynamicdns_server').val("");
-        	$('#id_dynamicdns-dynamicdns_update_url').val("https://noip.com/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
-        }
-        if ($(this).val() == 3){
-        	$('#dynamicdns-updateurl').show('slow');
-        	$('#dynamicdns-gnudip').hide();
-        	$('#id_dynamicdns-dynamicdns_server').val("");
-        	$('#id_dynamicdns-dynamicdns_update_url').val("https://selfhost.bz/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
-        }
-        if ($(this).val() == 4){
-        	$('#dynamicdns-updateurl').show('slow');
-        	$('#dynamicdns-gnudip').hide();
-        	$('#id_dynamicdns-dynamicdns_server').val("");
-        	$('#id_dynamicdns-dynamicdns_update_url').val("https://example.com/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
-        }  
-    });
-    })(jQuery);
-    
 	function show_pass()
 	{
 		if(document.getElementById('id_dynamicdns-showpw').checked){
-			document.getElementById("id_dynamicdns-dynamicdns_secret").type='text';}
+			document.getElementById('id_dynamicdns-dynamicdns_secret').type='text';}
 		else
-			document.getElementById("id_dynamicdns-dynamicdns_secret").type='password';
+			document.getElementById('id_dynamicdns-dynamicdns_secret').type='password';
 	}
 	
-	function hide()
+	function mod_form()
 	{
-	      if ($('#id_dynamicdns-enabled').prop('checked')) {
-		    	//$(this).find('option:selected').text() == GnudIP
-		        if ($(this).val() == 1){
-		        	$('#dynamicdns-updateurl').hide();
-		        	$('#id_dynamicdns-dynamicdns_update_url').val("");
-		        }
-		        if ($(this).val() == 2){
-		        	$('#dynamicdns-gnudip').hide();
-		        	$('#id_dynamicdns-dynamicdns_server').val("");
-		        	$('#id_dynamicdns-dynamicdns_update_url').val("https://noip.com/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
-		        }
-		        if ($(this).val() == 3){
-		        	$('#dynamicdns-gnudip').hide();
-		        	$('#id_dynamicdns-dynamicdns_server').val("");
-		        	$('#id_dynamicdns-dynamicdns_update_url').val("https://selfhost.bz/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
-		        }
-		        if ($(this).val() == 4){
-		        	$('#dynamicdns-gnudip').hide();
-		        	$('#id_dynamicdns-dynamicdns_server').val("");
-		        	$('#id_dynamicdns-dynamicdns_update_url').val("https://example.com/update.php?user=$user&pass=$pass&domain=$domain&IP=foo$ip");
-		        }
-	      } else {
-	        $('#dynamicdns-post-enabled-form').hide('slow');
-	      }	    
-	}
-	
+		document.getElementById('dynamicdns-no-js').style.display = 'none';
+		document.getElementById('div-dynamicdns-dropdown').style.display = 'block';
+		
+		if ( document.getElementById('id_dynamicdns-enabled').checked ) {
+			document.getElementById('dynamicdns-post-enabled-form').style.display = 'block';
+			var dropdown = document.getElementById('id_dynamicdns-dynamicdns_service');
+			var service_type = dropdown.options[dropdown.selectedIndex].value;
+			if (service_type == 1){
+				document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
+				document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
+				document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
+			}
+			if (service_type == 2){
+				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+				document.getElementById('id_dynamicdns-dynamicdns_update_url').value='noip';
+				document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+			}
+			if (service_type == 3){
+				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+				document.getElementById('id_dynamicdns-dynamicdns_update_url').value='selfhost';
+				document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+			}
+			if (service_type == 4){
+				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+				document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
+				document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+			}
+		}else{
+			document.getElementById('dynamicdns-post-enabled-form').style.display = 'none';
+		}
+	}	
   </script>
 {% endblock %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -26,7 +26,8 @@
     {% csrf_token %}
     <div id='dynamicdns-no-js'>
       You have disabled Javascript. Dynamic form mode is disabled and 
-      some helper functions may not work <br> (but the main functionality should work)
+      some helper functions may not work <br>
+      (but the main functionality should work)
       <br><hr>
     </div>
 
@@ -63,8 +64,8 @@
       });
 
       $('#id_dynamicdns-showpw').change(function() {
-        //changing type attribute from password to text is prevented by most browsers
-        //make a new form field works for me
+        //changing type attribute from password to text is prevented by
+        //most browsers make a new form field works for me
         if ($('#id_dynamicdns-showpw').prop('checked')) {
               $('#id_dynamicdns-dynamicdns_secret').replaceWith(
                       $('#id_dynamicdns-dynamicdns_secret').clone().attr(
@@ -78,8 +79,10 @@
 
       function configure_dropdown()
       {
-        var SELFHOST = 'https://carol.selfhost.de/update?username=<User>&password=<Pass>&myip=<Ip>'
-        var NOIP = 'http://dynupdate.no-ip.com/nic/update?hostname=<Domain>&myip=<Ip>'
+        var SELFHOST = 'https://carol.selfhost.de/update?username=<User>&' +
+                       'password=<Pass>&myip=<Ip>'
+        var NOIP = 'http://dynupdate.no-ip.com/nic/update?hostname=<' +
+                   'Domain>&myip=<Ip>'
 
         if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
           document.getElementById('id_dynamicdns-dynamicdns_update_url').value = '';

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -148,17 +148,17 @@
 
       function show_all()
       {
-          $('#id_dynamicdns-enabled').closest('.form-group').show();
-          $('#id_dynamicdns-service_type').closest('.form-group').show();
-          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
-          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
-          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
-          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
-          $('#id_dynamicdns-dynamicdns_domain').closest('.form-group').show();
-          $('#id_dynamicdns-dynamicdns_user').closest('.form-group').show();
-          $('#id_dynamicdns-dynamicdns_secret').closest('.form-group').show();
-          $('#id_dynamicdns-showpw').closest('.form-group').show();
-          $('#id_dynamicdns-dynamicdns_ipurl').closest('.form-group').show();
+        $('#id_dynamicdns-enabled').closest('.form-group').show();
+        $('#id_dynamicdns-service_type').closest('.form-group').show();
+        $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
+        $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
+        $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
+        $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
+        $('#id_dynamicdns-dynamicdns_domain').closest('.form-group').show();
+        $('#id_dynamicdns-dynamicdns_user').closest('.form-group').show();
+        $('#id_dynamicdns-dynamicdns_secret').closest('.form-group').show();
+        $('#id_dynamicdns-showpw').closest('.form-group').show();
+        $('#id_dynamicdns-dynamicdns_ipurl').closest('.form-group').show();
       }
     })(jQuery);
   </script>

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -67,7 +67,7 @@
 {% block page_js %}
 
   <script type="text/javascript">
-  var SELFHOST = 'https://carol.selfhost.de/update?username=<Usere>&password=<Pass>&myip=<Ip>'
+  var SELFHOST = 'https://carol.selfhost.de/update?username=<User>&password=<Pass>&myip=<Ip>'
   var NOIP = 'http://dynupdate.no-ip.com/nic/update?hostname=<Domain>&myip=<Ip>'
   window.onload = function() {mod_form()}
 

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -39,13 +39,13 @@
       {% include 'bootstrapform/field.html' with field=form.service_type %}
       </div>
       <div id='div-dynamicdns-gnudip'>
-      {% include 'bootstrapform/field.html' with field=form.dynamicdns_server %}
+        {% include 'bootstrapform/field.html' with field=form.dynamicdns_server %}
       </div>
       
       <div id='div-dynamicdns-updateurl'>
-      {% include 'bootstrapform/field.html' with field=form.dynamicdns_update_url %}
-      {% include 'bootstrapform/field.html' with field=form.disable_SSL_cert_check %}
-      {% include 'bootstrapform/field.html' with field=form.use_http_basic_auth %}
+        {% include 'bootstrapform/field.html' with field=form.dynamicdns_update_url %}
+        {% include 'bootstrapform/field.html' with field=form.disable_SSL_cert_check %}
+        {% include 'bootstrapform/field.html' with field=form.use_http_basic_auth %}
       </div>
 
       <h3>Account Information</h3>
@@ -71,74 +71,74 @@
   var NOIP = 'http://dynupdate.no-ip.com/nic/update?hostname=<Domain>&myip=<Ip>'
   window.onload = function() {mod_form()}
 
-	function show_pass()
-	{
-		if(document.getElementById('id_dynamicdns-showpw').checked){
-			document.getElementById('id_dynamicdns-dynamicdns_secret').type='text';}
-		else
-			document.getElementById('id_dynamicdns-dynamicdns_secret').type='password';
-	}
-	
-	function dropdown()
-	{
-		var dropdown = document.getElementById('id_dynamicdns-service_type');
-		var service_type = dropdown.options[dropdown.selectedIndex].value;
-		document.getElementById('id_dynamicdns-use_http_basic_auth').checked = false;
-		document.getElementById('id_dynamicdns-disable_SSL_cert_check').checked = false;
-		if (service_type == 1){
-			document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
-			document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
-			document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
-		}
-		if (service_type == 2){
-			document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-			document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-			document.getElementById('id_dynamicdns-dynamicdns_update_url').value = NOIP;
-			document.getElementById('id_dynamicdns-use_http_basic_auth').checked = true;
-			document.getElementById('id_dynamicdns-dynamicdns_server').value='';
-		}
-		if (service_type == 3){
-			document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-			document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-			document.getElementById('id_dynamicdns-dynamicdns_update_url').value = SELFHOST;
-			document.getElementById('id_dynamicdns-dynamicdns_server').value='';
-		}
-		if (service_type == 4){
-			document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-			document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-			document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
-			document.getElementById('id_dynamicdns-dynamicdns_server').value='';
-		}
-	}
-	
-	function mod_form()
-	{
-		document.getElementById('dynamicdns-no-js').style.display = 'none';
-		document.getElementById('div-dynamicdns-dropdown').style.display = 'block';
-		
-		if ( document.getElementById('id_dynamicdns-enabled').checked ) {
-			document.getElementById('dynamicdns-post-enabled-form').style.display = 'block';
-			var dropdown = document.getElementById('id_dynamicdns-service_type');
-			var service_type = dropdown.options[dropdown.selectedIndex].value;
-			if (service_type == 1){
-				document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
-				document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
-			}
-			if (service_type == 2){
-				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-			}
-			if (service_type == 3){
-				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-			}
-			if (service_type == 4){
-				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-			}
-		}else{
-			document.getElementById('dynamicdns-post-enabled-form').style.display = 'none';
-		}
-	}	
+  function show_pass()
+  {
+    if(document.getElementById('id_dynamicdns-showpw').checked){
+      document.getElementById('id_dynamicdns-dynamicdns_secret').type='text';}
+    else
+      document.getElementById('id_dynamicdns-dynamicdns_secret').type='password';
+  }
+
+  function dropdown()
+  {
+    var dropdown = document.getElementById('id_dynamicdns-service_type');
+    var service_type = dropdown.options[dropdown.selectedIndex].value;
+    document.getElementById('id_dynamicdns-use_http_basic_auth').checked = false;
+    document.getElementById('id_dynamicdns-disable_SSL_cert_check').checked = false;
+    if (service_type == 1){
+      document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
+      document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
+      document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
+    }
+    if (service_type == 2){
+      document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+      document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+      document.getElementById('id_dynamicdns-dynamicdns_update_url').value = NOIP;
+      document.getElementById('id_dynamicdns-use_http_basic_auth').checked = true;
+      document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+    }
+    if (service_type == 3){
+      document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+      document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+      document.getElementById('id_dynamicdns-dynamicdns_update_url').value = SELFHOST;
+      document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+    }
+    if (service_type == 4){
+      document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+      document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+      document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
+      document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+    }
+  }
+
+  function mod_form()
+  {
+    document.getElementById('dynamicdns-no-js').style.display = 'none';
+    document.getElementById('div-dynamicdns-dropdown').style.display = 'block';
+
+    if ( document.getElementById('id_dynamicdns-enabled').checked ) {
+      document.getElementById('dynamicdns-post-enabled-form').style.display = 'block';
+      var dropdown = document.getElementById('id_dynamicdns-service_type');
+      var service_type = dropdown.options[dropdown.selectedIndex].value;
+      if (service_type == 1){
+        document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
+        document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
+      }
+      if (service_type == 2){
+        document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+        document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+      }
+      if (service_type == 3){
+        document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+        document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+      }
+      if (service_type == 4){
+        document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+        document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+      }
+    }else{
+      document.getElementById('dynamicdns-post-enabled-form').style.display = 'none';
+    }
+  }
   </script>
 {% endblock %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -24,39 +24,13 @@
 
   <form class="form" method="post">
     {% csrf_token %}
-
-    {% include 'bootstrapform/field.html' with field=form.enabled %}
-
-     <div id='dynamicdns-post-enabled-form'>
-     
-      <h3>Dynamic DNS type</h3>
-      <div id='dynamicdns-no-js'>
-       You have disabled Javascript. Dynamic form mode is disabled and 
-       some helper functions may not work <br> (but the main functionality should work)
-       <br><hr>
-      </div>
-      <div id='div-dynamicdns-dropdown' style="display:none">
-      {% include 'bootstrapform/field.html' with field=form.service_type %}
-      </div>
-      <div id='div-dynamicdns-gnudip'>
-        {% include 'bootstrapform/field.html' with field=form.dynamicdns_server %}
-      </div>
-      
-      <div id='div-dynamicdns-updateurl'>
-        {% include 'bootstrapform/field.html' with field=form.dynamicdns_update_url %}
-        {% include 'bootstrapform/field.html' with field=form.disable_SSL_cert_check %}
-        {% include 'bootstrapform/field.html' with field=form.use_http_basic_auth %}
-      </div>
-
-      <h3>Account Information</h3>
-      {% include 'bootstrapform/field.html' with field=form.dynamicdns_domain %}
-      {% include 'bootstrapform/field.html' with field=form.dynamicdns_user %}
-      {% include 'bootstrapform/field.html' with field=form.dynamicdns_secret %}
-      {% include 'bootstrapform/field.html' with field=form.showpw %}
-      
-      <h3>IP check URL</h3>
-      {% include 'bootstrapform/field.html' with field=form.dynamicdns_ipurl %}
+    <div id='dynamicdns-no-js'>
+      You have disabled Javascript. Dynamic form mode is disabled and 
+      some helper functions may not work <br> (but the main functionality should work)
+      <br><hr>
     </div>
+
+    {{ form|bootstrap }}
 
     <input type="submit" class="btn btn-primary" value="Update setup"/>
 
@@ -65,80 +39,85 @@
 {% endblock %}
 
 {% block page_js %}
-
   <script type="text/javascript">
-  var SELFHOST = 'https://carol.selfhost.de/update?username=<User>&password=<Pass>&myip=<Ip>'
-  var NOIP = 'http://dynupdate.no-ip.com/nic/update?hostname=<Domain>&myip=<Ip>'
-  window.onload = function() {mod_form()}
-
-  function show_pass()
-  {
-    if(document.getElementById('id_dynamicdns-showpw').checked){
-      document.getElementById('id_dynamicdns-dynamicdns_secret').type='text';}
-    else
-      document.getElementById('id_dynamicdns-dynamicdns_secret').type='password';
-  }
-
-  function dropdown()
-  {
-    var dropdown = document.getElementById('id_dynamicdns-service_type');
-    var service_type = dropdown.options[dropdown.selectedIndex].value;
-    document.getElementById('id_dynamicdns-use_http_basic_auth').checked = false;
-    document.getElementById('id_dynamicdns-disable_SSL_cert_check').checked = false;
-    if (service_type == 1){
-      document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
-      document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
-      document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
-    }
-    if (service_type == 2){
-      document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-      document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-      document.getElementById('id_dynamicdns-dynamicdns_update_url').value = NOIP;
-      document.getElementById('id_dynamicdns-use_http_basic_auth').checked = true;
-      document.getElementById('id_dynamicdns-dynamicdns_server').value='';
-    }
-    if (service_type == 3){
-      document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-      document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-      document.getElementById('id_dynamicdns-dynamicdns_update_url').value = SELFHOST;
-      document.getElementById('id_dynamicdns-dynamicdns_server').value='';
-    }
-    if (service_type == 4){
-      document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-      document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-      document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
-      document.getElementById('id_dynamicdns-dynamicdns_server').value='';
-    }
-  }
-
-  function mod_form()
-  {
-    document.getElementById('dynamicdns-no-js').style.display = 'none';
-    document.getElementById('div-dynamicdns-dropdown').style.display = 'block';
-
-    if ( document.getElementById('id_dynamicdns-enabled').checked ) {
-      document.getElementById('dynamicdns-post-enabled-form').style.display = 'block';
-      var dropdown = document.getElementById('id_dynamicdns-service_type');
-      var service_type = dropdown.options[dropdown.selectedIndex].value;
-      if (service_type == 1){
-        document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
-        document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
+    (function($) {
+      $('#dynamicdns-no-js').hide();
+      $('.form-group').hide();
+      $('#id_dynamicdns-enabled').closest('.form-group').show();
+      if ($('#id_dynamicdns-enabled').prop('checked')) {
+        show_all();
+        configure_dropdown();
       }
-      if (service_type == 2){
-        document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-        document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+
+      $('#id_dynamicdns-enabled').change(function() {
+        if ($('#id_dynamicdns-enabled').prop('checked')) {
+          show_all();
+        } else {
+          $('.form-group').hide();
+          $('#id_dynamicdns-enabled').closest('.form-group').show();
+        }
+      });
+
+      $('#id_dynamicdns-service_type').change(function() {
+        configure_dropdown();
+      });
+
+      $('#id_dynamicdns-showpw').change(function() {
+        //changing type attribute from password to text is prevented by most browsers
+        //make a new form field works for me
+        if ($('#id_dynamicdns-showpw').prop('checked')) {
+              $('#id_dynamicdns-dynamicdns_secret').replaceWith(
+                      $('#id_dynamicdns-dynamicdns_secret').clone().attr(
+                              'type', 'text'));
+        }else{
+              $('#id_dynamicdns-dynamicdns_secret').replaceWith(
+                      $('#id_dynamicdns-dynamicdns_secret').clone().attr(
+                              'type', 'password'));
+        }
+      });
+
+      function configure_dropdown()
+      {
+        var SELFHOST = 'https://carol.selfhost.de/update?username=<User>&password=<Pass>&myip=<Ip>'
+        var NOIP = 'http://dynupdate.no-ip.com/nic/update?hostname=<Domain>&myip=<Ip>'
+
+        if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
+          document.getElementById('id_dynamicdns-dynamicdns_update_url').value = '';
+          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').hide();
+          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').hide();
+          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').hide();
+          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
+        }else{
+          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
+          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
+          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
+          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').hide();
+          if ($("#id_dynamicdns-service_type option:selected").text() == "noip.com") {
+            $('#id_dynamicdns-dynamicdns_update_url').val(NOIP);
+          }
+          if ($("#id_dynamicdns-service_type option:selected").text() == "selfhost.bz") {
+            $('#id_dynamicdns-dynamicdns_update_url').val(SELFHOST);
+          }
+          if ($("#id_dynamicdns-service_type option:selected").text() == "other update URL") {
+            $('#id_dynamicdns-dynamicdns_update_url').val('');
+          }
+        }
       }
-      if (service_type == 3){
-        document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-        document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+
+      function show_all()
+      {
+          $('#id_dynamicdns-enabled').closest('.form-group').show();
+          $('#id_dynamicdns-service_type').closest('.form-group').show();
+          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
+          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
+          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
+          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
+          $('#id_dynamicdns-dynamicdns_domain').closest('.form-group').show();
+          $('#id_dynamicdns-dynamicdns_user').closest('.form-group').show();
+          $('#id_dynamicdns-dynamicdns_secret').closest('.form-group').show();
+          $('#id_dynamicdns-showpw').closest('.form-group').show();
+          $('#id_dynamicdns-dynamicdns_ipurl').closest('.form-group').show();
       }
-      if (service_type == 4){
-        document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
-        document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-      }
-    }else{
-      document.getElementById('dynamicdns-post-enabled-form').style.display = 'none';
-    }
-  }
+    })(jQuery);
   </script>
 {% endblock %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -105,7 +105,7 @@
           }else if ($("#id_dynamicdns-dynamicdns_update_url").val() == FREEDNS){
             $("#id_dynamicdns-service_type").val(4);
           }else{
-            $("#id_dynamicdns-service_type option:selected").text("other update URL")
+            $("#id_dynamicdns-service_type").val(5);
           }
         }else{
           $("#id_dynamicdns-service_type").val(1);

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -24,12 +24,12 @@
 
   <form class="form" method="post">
     {% csrf_token %}
-    <div id='dynamicdns-no-js'>
+    <noscript>
       You have disabled Javascript. Dynamic form mode is disabled and 
       some helper functions may not work <br>
       (but the main functionality should work)
       <br><hr>
-    </div>
+    </noscript>
 
     {{ form|bootstrap }}
 
@@ -50,118 +50,114 @@
       var FREEDNS  = 'https://freedns.afraid.org/dynamic/update.php?' +
                      '_YOURAPIKEYHERE_'
 
-      //hide javascript warning
-      $('#dynamicdns-no-js').hide();
       //hide ALL form fields
       $('.form-group').hide();
       //show the enable checkbox
-      $('#id_dynamicdns-enabled').closest('.form-group').show();
-      if ($('#id_dynamicdns-enabled').prop('checked')) {
-      //show all form fields
+      $('#id_enabled').closest('.form-group').show();
+      if ($('#id_enabled').prop('checked')) {
+        //show all form fields
         show_all();
         //set the selectbox to the last configured value
         select_service();
       }
 
-      $('#id_dynamicdns-enabled').change(function() {
-        if ($('#id_dynamicdns-enabled').prop('checked')) {
+      $('#id_enabled').change(function() {
+        if ($('#id_enabled').prop('checked')) {
           show_all();
-          if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
-              set_gnudip_mode()
-            }else{
-              set_update_url_mode();
-            }
+          if ($("#id_service_type option:selected").text() == "GnuDIP") {
+            set_gnudip_mode()
+          } else {
+            set_update_url_mode();
+          }
         } else {
           $('.form-group').hide();
-          $('#id_dynamicdns-enabled').closest('.form-group').show();
+          $('#id_enabled').closest('.form-group').show();
         }
       });
 
-      $('#id_dynamicdns-service_type').change(function() {
-        if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
-            set_gnudip_mode()
-          }else{
+      $('#id_service_type').change(function() {
+        var service_type = $("#id_service_type option:selected").text();
+        if ( service_type == "GnuDIP" ) {
+          set_gnudip_mode()
+          } else {
             set_update_url_mode();
-            if ($("#id_dynamicdns-service_type option:selected").text() == "noip.com") {
-              $('#id_dynamicdns-dynamicdns_update_url').val(NOIP);
-              $('#id_dynamicdns-use_http_basic_auth').prop('checked', true);
-            }else{
-              $('#id_dynamicdns-use_http_basic_auth').prop('checked', false);
+            if ( service_type == "noip.com" ) {
+              $( '#id_dynamicdns_update_url' ).val( NOIP );
+              $( '#id_use_http_basic_auth' ).prop( 'checked', true);
+            } else {
+              $( '#id_use_http_basic_auth' ).prop( 'checked', false);
             }
-            if ($("#id_dynamicdns-service_type option:selected").text() == "selfhost.bz") {
-              $('#id_dynamicdns-dynamicdns_update_url').val(SELFHOST);
+            if ( service_type == "selfhost.bz" ) {
+              $( '#id_dynamicdns_update_url' ).val(SELFHOST);
             }
-            if ($("#id_dynamicdns-service_type option:selected").text() == "freedns.afraid.org") {
-                $('#id_dynamicdns-dynamicdns_update_url').val(FREEDNS);
-              }
-            if ($("#id_dynamicdns-service_type option:selected").text() == "other update URL") {
-              $('#id_dynamicdns-dynamicdns_update_url').val('');
+            if ( service_type == "freedns.afraid.org" ) {
+              $('#id_dynamicdns_update_url').val(FREEDNS);
+            }
+            if ( service_type == "other update URL" ) {
+              $('#id_dynamicdns_update_url').val('');
             }
           }
       });
 
-      $('#id_dynamicdns-showpw').change(function() {
+      $('#id_showpw').change(function() {
         //changing type attribute from password to text is prevented by
         //most browsers make a new form field works for me
-        if ($('#id_dynamicdns-showpw').prop('checked')) {
-              $('#id_dynamicdns-dynamicdns_secret').replaceWith(
-                      $('#id_dynamicdns-dynamicdns_secret').clone().attr(
-                              'type', 'text'));
-        }else{
-              $('#id_dynamicdns-dynamicdns_secret').replaceWith(
-                      $('#id_dynamicdns-dynamicdns_secret').clone().attr(
-                              'type', 'password'));
+        if ($('#id_showpw').prop('checked')) {
+          $('#id_dynamicdns_secret').replaceWith(
+            $('#id_dynamicdns_secret').clone().attr(
+            'type', 'text'));
+        } else {
+          $('#id_dynamicdns_secret').replaceWith(
+            $('#id_dynamicdns_secret').clone().attr(
+            'type', 'password'));
         }
       });
 
-      function select_service()
-      {
-        if ( $("#id_dynamicdns-dynamicdns_server").val().length == 0 ) {
+      function select_service() {
+        var update_url = $("#id_dynamicdns_update_url").val()
+        if ( $("#id_dynamicdns_server").val().length == 0 ) {
           set_update_url_mode()
-          if($("#id_dynamicdns-dynamicdns_update_url").val() == NOIP){
-            $("#id_dynamicdns-service_type").val(2);
-          }else if($("#id_dynamicdns-dynamicdns_update_url").val() == SELFHOST){
-            $("#id_dynamicdns-service_type").val(3);
-          }else if ($("#id_dynamicdns-dynamicdns_update_url").val() == FREEDNS){
-            $("#id_dynamicdns-service_type").val(4);
-          }else{
-            $("#id_dynamicdns-service_type").val(5);
+          if ( update_url == NOIP) {
+            $("#id_service_type").val(2);
+          } else if ( update_url == SELFHOST) {
+            $("#id_service_type").val(3);
+          } else if ( update_url == FREEDNS) {
+            $("#id_service_type").val(4);
+          } else {
+            $("#id_service_type").val(5);
           }
-        }else{
-          $("#id_dynamicdns-service_type").val(1);
+        } else {
+          $("#id_service_type").val(1);
           set_gnudip_mode();
         }
       }
 
-      function set_gnudip_mode()
-      {
-        $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').hide();
-        $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').hide();
-        $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').hide();
-        $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
+      function set_gnudip_mode() {
+        $('#id_dynamicdns_update_url').closest('.form-group').hide();
+        $('#id_disable_SSL_cert_check').closest('.form-group').hide();
+        $('#id_use_http_basic_auth').closest('.form-group').hide();
+        $('#id_dynamicdns_server').closest('.form-group').show();
       }
 
-      function set_update_url_mode()
-      {
-        $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
-        $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
-        $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
-        $('#id_dynamicdns-dynamicdns_server').closest('.form-group').hide();
+      function set_update_url_mode() {
+        $('#id_dynamicdns_update_url').closest('.form-group').show();
+        $('#id_disable_SSL_cert_check').closest('.form-group').show();
+        $('#id_use_http_basic_auth').closest('.form-group').show();
+        $('#id_dynamicdns_server').closest('.form-group').hide();
       }
 
-      function show_all()
-      {
-        $('#id_dynamicdns-enabled').closest('.form-group').show();
-        $('#id_dynamicdns-service_type').closest('.form-group').show();
-        $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
-        $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
-        $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
-        $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
-        $('#id_dynamicdns-dynamicdns_domain').closest('.form-group').show();
-        $('#id_dynamicdns-dynamicdns_user').closest('.form-group').show();
-        $('#id_dynamicdns-dynamicdns_secret').closest('.form-group').show();
-        $('#id_dynamicdns-showpw').closest('.form-group').show();
-        $('#id_dynamicdns-dynamicdns_ipurl').closest('.form-group').show();
+      function show_all() {
+        $('#id_enabled').closest('.form-group').show();
+        $('#id_service_type').closest('.form-group').show();
+        $('#id_dynamicdns_server').closest('.form-group').show();
+        $('#id_dynamicdns_update_url').closest('.form-group').show();
+        $('#id_disable_SSL_cert_check').closest('.form-group').show();
+        $('#id_use_http_basic_auth').closest('.form-group').show();
+        $('#id_dynamicdns_domain').closest('.form-group').show();
+        $('#id_dynamicdns_user').closest('.form-group').show();
+        $('#id_dynamicdns_secret').closest('.form-group').show();
+        $('#id_showpw').closest('.form-group').show();
+        $('#id_dynamicdns_ipurl').closest('.form-group').show();
       }
     })(jQuery);
   </script>

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -78,7 +78,26 @@
       });
 
       $('#id_dynamicdns-service_type').change(function() {
-        configure_dropdown();
+        if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
+            set_gnudip_mode()
+          }else{
+            set_update_url_mode();
+            if ($("#id_dynamicdns-service_type option:selected").text() == "noip.com") {
+              $('#id_dynamicdns-dynamicdns_update_url').val(NOIP);
+              $('#id_dynamicdns-use_http_basic_auth').prop('checked', true);
+            }else{
+              $('#id_dynamicdns-use_http_basic_auth').prop('checked', false);
+            }
+            if ($("#id_dynamicdns-service_type option:selected").text() == "selfhost.bz") {
+              $('#id_dynamicdns-dynamicdns_update_url').val(SELFHOST);
+            }
+            if ($("#id_dynamicdns-service_type option:selected").text() == "freedns.afraid.org") {
+                $('#id_dynamicdns-dynamicdns_update_url').val(FREEDNS);
+              }
+            if ($("#id_dynamicdns-service_type option:selected").text() == "other update URL") {
+              $('#id_dynamicdns-dynamicdns_update_url').val('');
+            }
+          }
       });
 
       $('#id_dynamicdns-showpw').change(function() {
@@ -111,30 +130,6 @@
         }else{
           $("#id_dynamicdns-service_type").val(1);
           set_gnudip_mode();
-        }
-      }
-
-      function configure_dropdown()
-      {
-        if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
-          set_gnudip_mode()
-        }else{
-          set_update_url_mode();
-          if ($("#id_dynamicdns-service_type option:selected").text() == "noip.com") {
-            $('#id_dynamicdns-dynamicdns_update_url').val(NOIP);
-            $('#id_dynamicdns-use_http_basic_auth').prop('checked', true);
-          }else{
-            $('#id_dynamicdns-use_http_basic_auth').prop('checked', false);
-          }
-          if ($("#id_dynamicdns-service_type option:selected").text() == "selfhost.bz") {
-            $('#id_dynamicdns-dynamicdns_update_url').val(SELFHOST);
-          }
-          if ($("#id_dynamicdns-service_type option:selected").text() == "freedns.afraid.org") {
-              $('#id_dynamicdns-dynamicdns_update_url').val(FREEDNS);
-            }
-          if ($("#id_dynamicdns-service_type option:selected").text() == "other update URL") {
-            $('#id_dynamicdns-dynamicdns_update_url').val('');
-          }
         }
       }
 

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -66,7 +66,11 @@
       $('#id_dynamicdns-enabled').change(function() {
         if ($('#id_dynamicdns-enabled').prop('checked')) {
           show_all();
-          configure_dropdown();
+          if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
+              set_gnudip_mode()
+            }else{
+              set_update_url_mode();
+            }
         } else {
           $('.form-group').hide();
           $('#id_dynamicdns-enabled').closest('.form-group').show();
@@ -94,10 +98,7 @@
       function select_service()
       {
         if ( $("#id_dynamicdns-dynamicdns_server").val().length == 0 ) {
-          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
-          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
-          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
-          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').hide();
+          set_update_url_mode()
           if($("#id_dynamicdns-dynamicdns_update_url").val() == NOIP){
             $("#id_dynamicdns-service_type").val(2);
           }else if($("#id_dynamicdns-dynamicdns_update_url").val() == SELFHOST){
@@ -109,25 +110,16 @@
           }
         }else{
           $("#id_dynamicdns-service_type").val(1);
-          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').hide();
-          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').hide();
-          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').hide();
-          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
+          set_gnudip_mode();
         }
       }
 
       function configure_dropdown()
       {
         if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
-          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').hide();
-          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').hide();
-          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').hide();
-          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
+          set_gnudip_mode()
         }else{
-          $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
-          $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
-          $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
-          $('#id_dynamicdns-dynamicdns_server').closest('.form-group').hide();
+          set_update_url_mode();
           if ($("#id_dynamicdns-service_type option:selected").text() == "noip.com") {
             $('#id_dynamicdns-dynamicdns_update_url').val(NOIP);
             $('#id_dynamicdns-use_http_basic_auth').prop('checked', true);
@@ -144,6 +136,22 @@
             $('#id_dynamicdns-dynamicdns_update_url').val('');
           }
         }
+      }
+
+      function set_gnudip_mode()
+      {
+        $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').hide();
+        $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').hide();
+        $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').hide();
+        $('#id_dynamicdns-dynamicdns_server').closest('.form-group').show();
+      }
+
+      function set_update_url_mode()
+      {
+        $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').show();
+        $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').show();
+        $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').show();
+        $('#id_dynamicdns-dynamicdns_server').closest('.form-group').hide();
       }
 
       function show_all()

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -66,6 +66,7 @@
       $('#id_dynamicdns-enabled').change(function() {
         if ($('#id_dynamicdns-enabled').prop('checked')) {
           show_all();
+          configure_dropdown();
         } else {
           $('.form-group').hide();
           $('#id_dynamicdns-enabled').closest('.form-group').show();

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -76,6 +76,35 @@
 			document.getElementById('id_dynamicdns-dynamicdns_secret').type='password';
 	}
 	
+	function dropdown()
+	{
+		var dropdown = document.getElementById('id_dynamicdns-dynamicdns_service');
+		var service_type = dropdown.options[dropdown.selectedIndex].value;
+		if (service_type == 1){
+			document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
+			document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
+			document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
+		}
+		if (service_type == 2){
+			document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+			document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+			document.getElementById('id_dynamicdns-dynamicdns_update_url').value='noip';
+			document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+		}
+		if (service_type == 3){
+			document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+			document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+			document.getElementById('id_dynamicdns-dynamicdns_update_url').value='selfhost';
+			document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+		}
+		if (service_type == 4){
+			document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
+			document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
+			document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
+			document.getElementById('id_dynamicdns-dynamicdns_server').value='';
+		}
+	}
+	
 	function mod_form()
 	{
 		document.getElementById('dynamicdns-no-js').style.display = 'none';
@@ -88,25 +117,18 @@
 			if (service_type == 1){
 				document.getElementById('div-dynamicdns-updateurl').style.display = 'none';
 				document.getElementById('div-dynamicdns-gnudip').style.display = 'block';
-				document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
 			}
 			if (service_type == 2){
 				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
 				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-				document.getElementById('id_dynamicdns-dynamicdns_update_url').value='noip';
-				document.getElementById('id_dynamicdns-dynamicdns_server').value='';
 			}
 			if (service_type == 3){
 				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
 				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-				document.getElementById('id_dynamicdns-dynamicdns_update_url').value='selfhost';
-				document.getElementById('id_dynamicdns-dynamicdns_server').value='';
 			}
 			if (service_type == 4){
 				document.getElementById('div-dynamicdns-gnudip').style.display = 'none';
 				document.getElementById('div-dynamicdns-updateurl').style.display = 'block';
-				document.getElementById('id_dynamicdns-dynamicdns_update_url').value='';
-				document.getElementById('id_dynamicdns-dynamicdns_server').value='';
 			}
 		}else{
 			document.getElementById('dynamicdns-post-enabled-form').style.display = 'none';

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -41,13 +41,20 @@
 
 {% block page_js %}
   <script type="text/javascript">
+
     (function($) {
+      var SELFHOST = 'https://carol.selfhost.de/update?username=<User>&' +
+                     'password=<Pass>&myip=<Ip>'
+      var NOIP     = 'http://dynupdate.no-ip.com/nic/update?hostname=' +
+                     '<Domain>&myip=<Ip>'
+      var FREEDNS  = 'http://freedns.afraid.org/dynamic/update.php?' +
+                     '_YOURAPIKEYHERE_'
       $('#dynamicdns-no-js').hide();
       $('.form-group').hide();
       $('#id_dynamicdns-enabled').closest('.form-group').show();
       if ($('#id_dynamicdns-enabled').prop('checked')) {
         show_all();
-        configure_dropdown();
+
       }
 
       $('#id_dynamicdns-enabled').change(function() {
@@ -79,11 +86,6 @@
 
       function configure_dropdown()
       {
-        var SELFHOST = 'https://carol.selfhost.de/update?username=<User>&' +
-                       'password=<Pass>&myip=<Ip>'
-        var NOIP = 'http://dynupdate.no-ip.com/nic/update?hostname=<' +
-                   'Domain>&myip=<Ip>'
-
         if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
           $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').hide();
           $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').hide();
@@ -103,6 +105,9 @@
           if ($("#id_dynamicdns-service_type option:selected").text() == "selfhost.bz") {
             $('#id_dynamicdns-dynamicdns_update_url').val(SELFHOST);
           }
+          if ($("#id_dynamicdns-service_type option:selected").text() == "freedns.afraid.org") {
+              $('#id_dynamicdns-dynamicdns_update_url').val(FREEDNS);
+            }
           if ($("#id_dynamicdns-service_type option:selected").text() == "other update URL") {
             $('#id_dynamicdns-dynamicdns_update_url').val('');
           }

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -85,7 +85,6 @@
                    'Domain>&myip=<Ip>'
 
         if ($("#id_dynamicdns-service_type option:selected").text() == "GnuDIP") {
-          document.getElementById('id_dynamicdns-dynamicdns_update_url').value = '';
           $('#id_dynamicdns-dynamicdns_update_url').closest('.form-group').hide();
           $('#id_dynamicdns-disable_SSL_cert_check').closest('.form-group').hide();
           $('#id_dynamicdns-use_http_basic_auth').closest('.form-group').hide();
@@ -97,6 +96,9 @@
           $('#id_dynamicdns-dynamicdns_server').closest('.form-group').hide();
           if ($("#id_dynamicdns-service_type option:selected").text() == "noip.com") {
             $('#id_dynamicdns-dynamicdns_update_url').val(NOIP);
+            $('#id_dynamicdns-use_http_basic_auth').prop('checked', true);
+          }else{
+            $('#id_dynamicdns-use_http_basic_auth').prop('checked', false);
           }
           if ($("#id_dynamicdns-service_type option:selected").text() == "selfhost.bz") {
             $('#id_dynamicdns-dynamicdns_update_url').val(SELFHOST);

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -47,7 +47,7 @@
                      'password=<Pass>&myip=<Ip>'
       var NOIP     = 'http://dynupdate.no-ip.com/nic/update?hostname=' +
                      '<Domain>&myip=<Ip>'
-      var FREEDNS  = 'http://freedns.afraid.org/dynamic/update.php?' +
+      var FREEDNS  = 'https://freedns.afraid.org/dynamic/update.php?' +
                      '_YOURAPIKEYHERE_'
 
       //hide javascript warning

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -14,7 +14,7 @@
 # GNU Affero General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 {% endcomment %}
 
@@ -32,8 +32,8 @@
       <h3>Dynamic DNS type</h3>
       <div id='dynamicdns-no-js'>
        You have disabled Javascript. Dynamic form mode is disabled and 
-       some helper functions may not work </br> (but the main functionality should work)
-       </br><hr>
+       some helper functions may not work <br> (but the main functionality should work)
+       <br><hr>
       </div>
       <div id='div-dynamicdns-dropdown' style="display:none">
       {% include 'bootstrapform/field.html' with field=form.service_type %}

--- a/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
+++ b/plinth/modules/dynamicdns/templates/dynamicdns_configure.html
@@ -66,8 +66,8 @@
 {% block page_js %}
 
   <script type="text/javascript">
-  var SELFHOST = 'https://carol.selfhost.de/update?username=<Username>&password=<Password>&myip=<Ip>'
-  var NOIP = "http://dynupdate.no-ip.com/nic/update?hostname=<domain>&myip=<Ip>"
+  var SELFHOST = 'https://carol.selfhost.de/update?username=<Usere>&password=<Pass>&myip=<Ip>'
+  var NOIP = 'http://dynupdate.no-ip.com/nic/update?hostname=<Domain>&myip=<Ip>'
   window.onload = function() {mod_form()}
 
 	function show_pass()


### PR DESCRIPTION
Would be nice if freedombox could be reached via DNS resolved hostname (even if freedombox is connected via dynamic IP).

For this reason I'm implementing a ez-ipupdate module.

The module should detect the current WAN IP (even if freedombox is connected behind NAT router) and push the IP to a open source GnudIP server if a change is detected.

IPv6 and other Server types than gnudip should also be included later.

GnudIP vs. update URL:

* Gnudip is more safe (md5 hashed and salted password transmission prevent replay attacks)
* update URL is more generic (the most common dynamic DNS Service provides a URL to update the IP)

