### PR TITLE
bugfix: changing user password didn't work

### DIFF
--- a/plinth/modules/users/templates/users_change_password.html
+++ b/plinth/modules/users/templates/users_change_password.html
@@ -41,6 +41,6 @@
 
 {% block page_js %}
   <script>
-    $('#id_password1').focus();
+    $('#id_new_password1').focus();
   </script>
 {% endblock %}

--- a/plinth/modules/users/views.py
+++ b/plinth/modules/users/views.py
@@ -18,7 +18,7 @@
 from django import forms
 from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
-from django.contrib.auth.forms import UserCreationForm, AdminPasswordChangeForm
+from django.contrib.auth.forms import UserCreationForm, SetPasswordForm
 from django.contrib.auth.models import User
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.urlresolvers import reverse, reverse_lazy
@@ -110,10 +110,8 @@ class UserDelete(ContextMixin, DeleteView):
 class UserChangePassword(ContextMixin, SuccessMessageMixin, FormView):
     """View to change user password."""
     template_name = 'users_change_password.html'
-    form_class = AdminPasswordChangeForm
-    slug_field = 'username'
-    model = User
-    title = _('Create User')
+    form_class = SetPasswordForm
+    title = _('Change Password')
     success_message = _('Password changed successfully.')
 
     def get_form_kwargs(self):
@@ -126,7 +124,6 @@ class UserChangePassword(ContextMixin, SuccessMessageMixin, FormView):
         return reverse('users:edit', kwargs={'slug': self.kwargs['slug']})
 
     def form_valid(self, form):
-        if form.user == self.request.user:
-            update_session_auth_hash(self.request, form.user)
-
+        form.save()
+        update_session_auth_hash(self.request, form.user)
         return super(UserChangePassword, self).form_valid(form)


### PR DESCRIPTION
Calling `form.save()` inside of `form_valid()` was missing;
Plus tiny cleanups like using SetPasswordForm instead of AdminPasswordChangeForm.

Note: 
This change allows any logged-in user to change all other user passwords.
I did this because 
- we don't have any other way to recover passwords via the GUI
- logged-in users can create other (potentially privileged) user accounts also.