### PR TITLE
Test coverage console report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+# .coveragerc -- specifies execution options for coverage.py
+
+[run]
+branch = True
+
+[report]
+precision = 2

--- a/plinth/tests/coverage/test_coverage.py
+++ b/plinth/tests/coverage/test_coverage.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Plinth.
 #
-# Dervied from code sample at:
+# Derived from code sample at:
 # http://jeetworks.org/adding-test-code-coverage-analysis-to-a-python-projects-setup-command/
 #
 # Copyright 2009 Jeet Sukumaran and Mark T. Holder.
@@ -69,7 +69,8 @@ class TestCoverageCommand(setuptools.Command):
                 self.distribution.install_requires)
 
         if self.distribution.tests_require:
-            self.distribution.fetch_build_eggs(self.distribution.tests_require)
+            self.distribution.fetch_build_eggs(
+                self.distribution.tests_require)
 
         # Erase any existing HTML report files
         try:
@@ -88,17 +89,23 @@ class TestCoverageCommand(setuptools.Command):
         # Run the coverage analysis
         runner = unittest.TextTestRunner()
         import coverage
-        cov = coverage.coverage(auto_data=True, branch=True,
+        cov = coverage.coverage(auto_data=True, config_file=True,
                                 source=SOURCE_DIRS, omit=FILES_TO_OMIT)
         cov.erase()     # Erase existing coverage data file
         cov.start()
         runner.run(test_suite)
         cov.stop()
 
-        # Generate an HTML report and print overall coverage
+        # Generate an HTML report
         html_report_title = 'FreedomBox:Plinth -- Test Coverage as of ' + \
                             time.strftime('%x %X %Z')
-        _coverage = cov.html_report(directory=COVERAGE_REPORT_DIR,
-                                    omit=FILES_TO_OMIT,
-                                    title=html_report_title)
-        print('\nOverall test coverage: {0:.2f} %\n'.format(_coverage))
+        cov.html_report(directory=COVERAGE_REPORT_DIR, omit=FILES_TO_OMIT,
+                        title=html_report_title)
+
+        # Print a detailed console report with the overall coverage percentage
+        print()
+        cov.report(omit=FILES_TO_OMIT)
+
+        # Print the location of the HTML report
+        print('\nThe HTML coverage report is located at {}.'.format(
+            COVERAGE_REPORT_DIR))


### PR DESCRIPTION
This pull request addresses suggestions for enhancements made to Pull Request #26 ("Test coverage measurement and reporting").  Specifically:
1. The 'test_coverage' custom setuptools command has been enhanced to add a detailed console report of coverage by module, and which includes the total coverage percentage.
2. The precision of all coverage percentages, including the total percentage, has been expanded to two decimal places.
3. An informational message specifying the location of the HTML coverage report is now printed following the console report.
