### PR TITLE
Upgrades module

### DIFF
--- a/actions/upgrades
+++ b/actions/upgrades
@@ -23,6 +23,7 @@ Configures or runs unattended-upgrades
 
 import argparse
 import os
+import re
 import subprocess
 
 CONF_FILE = '/etc/apt/apt.conf.d/50unattended-upgrades'
@@ -100,13 +101,13 @@ def setup():
         lines = conffile.readlines()
 
     for line in lines:
-        if '"origin=Debian";' in line:
+        if re.match(r'\s*"o(rigin)?=Debian";', line):
             return  # already configured
 
     with open(CONF_FILE, 'w') as conffile:
         for line in lines:
             conffile.write(line)
-            if 'Unattended-Upgrade::Origins-Pattern {' in line:
+            if re.match(r'\s*Unattended-Upgrade::Origins-Pattern', line):
                 conffile.write('        "origin=Debian";\n')
 
 

--- a/actions/upgrades
+++ b/actions/upgrades
@@ -107,7 +107,7 @@ def setup():
     with open(CONF_FILE, 'w') as conffile:
         for line in lines:
             conffile.write(line)
-            if re.match(r'\s*Unattended-Upgrade::Origins-Pattern', line):
+            if re.match(r'\s*Unattended-Upgrade::Origins-Pattern\s+{', line):
                 conffile.write('        "origin=Debian";\n')
 
 

--- a/actions/upgrades
+++ b/actions/upgrades
@@ -1,0 +1,111 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configures or runs unattended-upgrades
+"""
+
+import argparse
+import os
+import subprocess
+
+CONF_FILE = '/etc/apt/apt.conf.d/50unattended-upgrades'
+AUTO_CONF_FILE = '/etc/apt/apt.conf.d/20auto-upgrades'
+
+
+def parse_arguments():
+    """REturn parsed command line arguments as dictionary"""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    # Run unattended-upgrades
+    subparsers.add_parser('run', help='Upgrade packages on the system')
+
+    # Enable automatic upgrades
+    subparsers.add_parser('enable-auto', help='Enable automatic upgrades')
+
+    # Disable automatic upgrades
+    subparsers.add_parser('disable-auto', help='Disable automatic upgrades.')
+
+    return parser.parse_args()
+
+
+def subcommand_run(_):
+    """Run unattended-upgrades"""
+    try:
+        setup()
+    except FileNotFoundError:
+        print('Error: Could not configure unattended-upgrades.')
+        return
+
+    try:
+        output = subprocess.check_output(['unattended-upgrades', '-v'])
+    except subprocess.CalledProcessError as error:
+        print('Error: %s', error)
+    except FileNotFoundError:
+        print('Error: unattended-upgrades is not available.')
+    else:
+        print('%s', output.decode())
+
+
+def subcommand_enable_auto(_):
+    """Enable automatic upgrades"""
+    try:
+        setup()
+    except FileNotFoundError:
+        print('Error: Could not configure unattended-upgrades.')
+        return
+
+    with open(AUTO_CONF_FILE, 'w') as conffile:
+        conffile.write('APT::Periodic::Update-Package-Lists "1";\n')
+        conffile.write('APT::Periodic::Unattended-Upgrade "1";\n')
+
+
+def subcommand_disable_auto(_):
+    """Disable automatic upgrades"""
+    os.remove(AUTO_CONF_FILE)
+
+
+def setup():
+    """Sets unattended-upgrades config to upgrade any package from Debian."""
+    with open(CONF_FILE, 'r') as conffile:
+        lines = conffile.readlines()
+
+    for line in lines:
+        if '"origin=Debian";' in line:
+            return  # already configured
+
+    with open(CONF_FILE, 'w') as conffile:
+        for line in lines:
+            conffile.write(line)
+            if 'Unattended-Upgrade::Origins-Pattern {' in line:
+                conffile.write('        "origin=Debian";\n')
+
+
+def main():
+    """Parse arguments and perform all duties"""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/actions/upgrades
+++ b/actions/upgrades
@@ -30,12 +30,16 @@ AUTO_CONF_FILE = '/etc/apt/apt.conf.d/20auto-upgrades'
 
 
 def parse_arguments():
-    """REturn parsed command line arguments as dictionary"""
+    """Return parsed command line arguments as dictionary"""
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
     # Run unattended-upgrades
     subparsers.add_parser('run', help='Upgrade packages on the system')
+
+    # Check if automatic upgrades are enabled
+    subparsers.add_parser('check-auto',
+                          help='Check if automatic upgrades are enabled')
 
     # Enable automatic upgrades
     subparsers.add_parser('enable-auto', help='Enable automatic upgrades')
@@ -64,6 +68,11 @@ def subcommand_run(_):
         print('%s', output.decode())
 
 
+def subcommand_check_auto(_):
+    """Check if automatic upgrades are enabled"""
+    print(os.path.isfile(AUTO_CONF_FILE))
+
+
 def subcommand_enable_auto(_):
     """Enable automatic upgrades"""
     try:
@@ -79,7 +88,10 @@ def subcommand_enable_auto(_):
 
 def subcommand_disable_auto(_):
     """Disable automatic upgrades"""
-    os.remove(AUTO_CONF_FILE)
+    try:
+        os.rename(AUTO_CONF_FILE, AUTO_CONF_FILE + '.disabled')
+    except FileNotFoundError:
+        print('Already disabled.')
 
 
 def setup():

--- a/data/etc/plinth/modules-enabled/upgrades
+++ b/data/etc/plinth/modules-enabled/upgrades
@@ -1,0 +1,1 @@
+plinth.modules.upgrades

--- a/plinth/modules/upgrades/__init__.py
+++ b/plinth/modules/upgrades/__init__.py
@@ -1,0 +1,27 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module for upgrades
+"""
+
+from . import upgrades
+from .upgrades import init
+
+__all__ = ['upgrades', 'init']
+
+depends = ['plinth.modules.system']

--- a/plinth/modules/upgrades/templates/upgrades.html
+++ b/plinth/modules/upgrades/templates/upgrades.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% block content %}
+
+<h2>{{ title }}</h2>
+
+<p>This will run unattended-upgrades, which will attempt to upgrade your system
+with the latest Debian packages. It may take a minute to complete.</p>
+
+<p><a class="btn btn-primary btn-lg" href="{% url 'upgrades:run' %}">
+  Upgrade now &raquo;
+</a></p>
+
+{% endblock %}

--- a/plinth/modules/upgrades/templates/upgrades_configure.html
+++ b/plinth/modules/upgrades/templates/upgrades_configure.html
@@ -1,3 +1,5 @@
+{% extends "base.html" %}
+{% comment %}
 #
 # This file is part of Plinth.
 #
@@ -8,23 +10,25 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Affero General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+{% endcomment %}
 
-"""
-URLs for the upgrades module
-"""
+{% load bootstrap %}
 
-from django.conf.urls import patterns, url
+{% block content %}
 
+  <form class="form" method="post">
+    {% csrf_token %}
 
-urlpatterns = patterns(
-    'plinth.modules.upgrades.upgrades',
-    url(r'^sys/upgrades/$', 'index', name='index'),
-    url(r'^sys/upgrades/run/$', 'run', name='run'),
-    url(r'^sys/upgrades/configure/$', 'configure', name='configure'),
-    )
+    {{ form|bootstrap }}
+
+    <input type="submit" class="btn btn-primary btn-md" value="Update setup"/>
+
+  </form>
+
+{% endblock %}

--- a/plinth/modules/upgrades/templates/upgrades_run.html
+++ b/plinth/modules/upgrades/templates/upgrades_run.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% block content %}
+
+<h2>{{title}}</h2>
+
+{% if upgrades_error %}
+  <p>There was an error while upgrading:<p>
+  <pre>{{ upgrades_error }}</pre>
+{% endif %}
+
+{% if upgrades_output %}
+  <p>Output from unattended-upgrades:</p>
+  <pre>{{ upgrades_output }}</pre>
+{% endif %}
+
+{% endblock %}

--- a/plinth/modules/upgrades/upgrades.py
+++ b/plinth/modules/upgrades/upgrades.py
@@ -1,0 +1,63 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module for upgrades
+"""
+
+from django.contrib.auth.decorators import login_required
+from django.template.response import TemplateResponse
+from gettext import gettext as _
+
+from plinth import actions
+from plinth import cfg
+from plinth import package
+from plinth.errors import ActionError
+
+
+def init():
+    """Initialize the module"""
+    menu = cfg.main_menu.get('system:index')
+    menu.add_urlname("Upgrades", "glyphicon-refresh",
+                     "upgrades:index", 21)
+
+
+@login_required
+@package.required('unattended-upgrades')
+def index(request):
+    """Serve the index page"""
+    return TemplateResponse(request, 'upgrades.html',
+                            {'title': _('Package Upgrades')})
+
+
+@login_required
+@package.required('unattended-upgrades')
+def run(request):
+    """Run upgrades and show the output page"""
+    output = ''
+    error = ''
+    try:
+        output = actions.superuser_run('upgrades', ['run'])
+    except ActionError as exception:
+        output, error = exception.args[1:]
+    except Exception as exception:
+        error = str(exception)
+
+    return TemplateResponse(request, 'upgrades_run.html',
+                            {'title': _('Package Upgrades'),
+                             'upgrades_output': output,
+                             'upgrades__error': error})

--- a/plinth/modules/upgrades/upgrades.py
+++ b/plinth/modules/upgrades/upgrades.py
@@ -70,7 +70,7 @@ def run(request):
                             {'title': _('Package Upgrades'),
                              'subsubmenu': subsubmenu,
                              'upgrades_output': output,
-                             'upgrades__error': error})
+                             'upgrades_error': error})
 
 
 class ConfigureForm(forms.Form):

--- a/plinth/modules/upgrades/urls.py
+++ b/plinth/modules/upgrades/urls.py
@@ -1,0 +1,29 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the upgrades module
+"""
+
+from django.conf.urls import patterns, url
+
+
+urlpatterns = patterns(
+    'plinth.modules.upgrades.upgrades',
+    url(r'^sys/upgrades/$', 'index', name='index'),
+    url(r'^sys/upgrades/run/$', 'run', name='run'),
+    )


### PR DESCRIPTION
This adds an Upgrades module which is a simple interface to the unattended-upgrades package. The user can run upgrades immediately and view the results, or enable automatic upgrades that will run daily.

Note that unattended-upgrades will skip any upgrade that would require the user to answer a conffile prompt.

Closes #77.