### PR TITLE
owncloud: Do Apache reload instead of restart

### DIFF
--- a/actions/owncloud-setup
+++ b/actions/owncloud-setup
@@ -91,7 +91,7 @@ EOF
 #  'adminpass'     => '$adminpwd',
 
 	    a2enconf owncloud 2>&1 | logger -t owncloud-setup
-	    service apache2 restart 2>&1 | logger -t owncloud-setup
+	    service apache2 reload 2>&1 | logger -t owncloud-setup
 
 	    # Initialize application and database tables by visiting
 	    # the front page.  This only work if admin user and
@@ -99,10 +99,10 @@ EOF
 	    #wget --quiet http://$(uname -n)/owncloud/index.php
 	else
 	    a2enconf owncloud 2>&1 | logger -t owncloud-setup
-	    service apache2 restart 2>&1 | logger -t owncloud-setup
+	    service apache2 reload 2>&1 | logger -t owncloud-setup
 	fi
     else
 	a2disconf owncloud 2>&1 | logger -t owncloud-setup
-	service apache2 restart 2>&1 | logger -t owncloud-setup
+	service apache2 reload 2>&1 | logger -t owncloud-setup
     fi
 fi


### PR DESCRIPTION
Restarting Apache breaks existing connections.  This includes the connection
on which the Plinth's user has made the ownCloud enable/disable request.  This
leads to an almost certain 'Connection Interupted' message to the client when
changes to ownCloud are submitted.

On the other hand, 'reload' is sufficient and 'restart' is not required.  It is
also faster and recommended by 'a2enconf' and 'a2disconf' commands.