### PR TITLE
Add systemd service file

### DIFF
--- a/data/etc/plinth/plinth.config
+++ b/data/etc/plinth/plinth.config
@@ -9,7 +9,7 @@ config_dir = /etc/plinth
 data_dir = /var/lib/plinth
 log_dir = /var/log/plinth
 pid_dir = /var/run
-server_dir = plinth/
+server_dir = /plinth
 actions_dir = /usr/share/plinth/actions
 doc_dir = /usr/share/doc/plinth
 

--- a/data/lib/systemd/system/plinth.service
+++ b/data/lib/systemd/system/plinth.service
@@ -1,0 +1,29 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+[Unit]
+Description=Plinth Web Interface
+Documentation=man:plinth(1)
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/plinth --no-daemon
+Restart=on-failure
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -40,19 +40,20 @@ LOGGER = logging.getLogger(__name__)
 def parse_arguments():
     """Parse command line arguments"""
     parser = argparse.ArgumentParser(
-        description='Plinth web interface for FreedomBox')
+        description='Plinth web interface for FreedomBox',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '--pidfile', default='plinth.pid',
+        '--pidfile', default=cfg.pidfile,
         help='specify a file in which the server may write its pid')
     # TODO: server_dir is actually a url prefix; use a better variable name
     parser.add_argument(
-        '--server_dir', default='/',
+        '--server_dir', default=cfg.server_dir,
         help='web server path under which to serve')
     parser.add_argument(
-        '--debug', action='store_true', default=False,
+        '--debug', action='store_true', default=cfg.debug,
         help='enable debugging and run server *insecurely*')
     parser.add_argument(
-        '--no-daemon', action='store_true', default=False,
+        '--no-daemon', action='store_true', default=cfg.no_daemon,
         help='do not start as a daemon')
 
     args = parser.parse_args()
@@ -239,9 +240,9 @@ def configure_django():
 
 def main():
     """Intialize and start the application"""
-    parse_arguments()
-
     cfg.read()
+
+    parse_arguments()
 
     setup_logging()
 
@@ -250,6 +251,7 @@ def main():
     configure_django()
 
     LOGGER.info('Configuration loaded from file - %s', cfg.CONFIG_FILE)
+    LOGGER.info('Script prefix - %s', cfg.server_dir)
 
     module_loader.load_modules()
 

--- a/plinth/cfg.py
+++ b/plinth/cfg.py
@@ -78,6 +78,7 @@ def read():
                     ('Path', 'status_log_file'),
                     ('Path', 'access_log_file'),
                     ('Path', 'pidfile'),
+                    ('Path', 'server_dir'),
                     ('Network', 'host'),
                     ('Network', 'port'),
                     ('Network', 'secure_proxy_ssl_header'),

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,8 @@ setuptools.setup(
                  ['data/etc/apache2/sites-available/plinth.conf',
                   'data/etc/apache2/sites-available/plinth-ssl.conf']),
                 ('/etc/sudoers.d', ['data/etc/sudoers.d/plinth']),
+                ('/lib/systemd/system',
+                 ['data/lib/systemd/system/plinth.service']),
                 ('/usr/share/plinth/actions',
                  glob.glob(os.path.join('actions', '*'))),
                 ('/usr/share/man/man1', ['doc/plinth.1']),


### PR DESCRIPTION
- When running in an environment without systemd, the changes are completely
  ignored.

- When running under systemd, the patch introduces a systemd native service
  file to take advantages of nice feature provided by systemd.

- One of the feature currently taken advantage of is the ability to restart the
  service automatically if it ever crashes or exits with error.

- Another feature is that when we wish to kill Plinth all the processes under
  the cgroup are killed as well.