### PR TITLE
Implement Mumble!

### DIFF
--- a/actions/mumble
+++ b/actions/mumble
@@ -1,0 +1,125 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for Mumble server
+"""
+
+import argparse
+import subprocess
+
+
+SERVICE_CONFIG = '/etc/default/mumble-server'
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    # Get whether service is enabled
+    subparsers.add_parser('get-enabled',
+                          help='Get whether Mumble service is enabled')
+
+    # Enable service
+    subparsers.add_parser('enable', help='Enable Mumble service')
+
+    # Disable service
+    subparsers.add_parser('disable', help='Disable Mumble service')
+
+    # Get whether daemon is running
+    subparsers.add_parser('is-running',
+                          help='Get whether Mumble daemon is running')
+
+    return parser.parse_args()
+
+
+def subcommand_get_enabled(_):
+    """Get whether service is enabled."""
+    try:
+        with open(SERVICE_CONFIG, 'r') as file:
+            for line in file:
+                if line.startswith('MURMUR_DAEMON_START'):
+                    value = line.split('=')[1].strip()
+                    print('yes' if int(value) else 'no')
+                    return
+    except FileNotFoundError:
+        pass
+
+    print('no')
+
+
+def subcommand_enable(_):
+    """Start service."""
+    set_service_enable(enable=True)
+    subprocess.call(['service', 'mumble-server', 'start'])
+
+
+def subcommand_disable(_):
+    """Stop service."""
+    subprocess.call(['service', 'mumble-server', 'stop'])
+    set_service_enable(enable=False)
+
+
+def set_service_enable(enable):
+    """Enable/disable daemon; enable: boolean."""
+    newline = 'MURMUR_DAEMON_START=1\n' if enable \
+        else 'MURMUR_DAEMON_START=0\n'
+
+    with open(SERVICE_CONFIG, 'r') as file:
+        lines = file.readlines()
+        for index, line in enumerate(lines):
+            if line.startswith('MURMUR_DAEMON_START'):
+                lines[index] = newline
+                break
+
+    with open(SERVICE_CONFIG, 'w') as file:
+        file.writelines(lines)
+
+
+def subcommand_is_running(_):
+    """Get whether server is running."""
+    try:
+        output = subprocess.check_output(['service', 'mumble-server',
+                                          'status'])
+    except subprocess.CalledProcessError:
+        # If daemon is not running we get a status code != 0 and a
+        # CalledProcessError
+        print('no')
+    else:
+        running = False
+        for line in output.decode().split('\n'):
+            if 'Active' in line and 'running' in line:
+                running = True
+                break
+
+        print('yes' if running else 'no')
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/data/etc/plinth/modules-enabled/mumble
+++ b/data/etc/plinth/modules-enabled/mumble
@@ -1,0 +1,1 @@
+plinth.modules.mumble

--- a/data/usr/lib/firewalld/services/mumble-plinth.xml
+++ b/data/usr/lib/firewalld/services/mumble-plinth.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Mumble Voice Chat Server</short>
+  <description>Mumble is an open source, low-latency, encrypted, high quality voice chat software primarily intended for use while gaming.  Mumble uses a client-server architecture which allows users to talk to each other via the same server.  Enable this if you are running a Mumble server and if you wish to connect external clients such as Mumble desktop client and Plumble Android app to your Mumble server.</description>
+  <port protocol="tcp" port="64738"/>
+  <port protocol="udp" port="64738"/>
+</service>

--- a/plinth/modules/firewall/firewall.py
+++ b/plinth/modules/firewall/firewall.py
@@ -43,7 +43,7 @@ def init():
 
 
 @login_required
-@package.required('firewalld')
+@package.required(['firewalld'])
 def index(request):
     """Serve introcution page"""
     if not get_enabled_status():

--- a/plinth/modules/firewall/templates/firewall.html
+++ b/plinth/modules/firewall/templates/firewall.html
@@ -55,7 +55,7 @@ firewalld'</p>
               {% if service.is_enabled %}
                 <span class='label label-success'>Enabled</span>
               {% else %}
-                <span class='label label-important'>Disabled</span>
+                <span class='label label-warning'>Disabled</span>
               {% endif %}
             </td>
           </tr>

--- a/plinth/modules/mumble/__init__.py
+++ b/plinth/modules/mumble/__init__.py
@@ -1,0 +1,46 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure Mumble server
+"""
+
+from gettext import gettext as _
+
+from plinth import actions
+from plinth import cfg
+from plinth import service as service_module
+
+
+depends = ['plinth.modules.apps']
+
+service = None
+
+
+def init():
+    """Intialize the Mumble module."""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(_('Voice Chat (Mumble)'), 'glyphicon-headphones',
+                     'mumble:index', 50)
+
+    output = actions.run('mumble', ['get-enabled'])
+    enabled = (output.strip() == 'yes')
+
+    global service
+    service = service_module.Service(
+        'mumble-plinth', _('Mumble Voice Chat Server'),
+        is_external=True, enabled=enabled)

--- a/plinth/modules/mumble/forms.py
+++ b/plinth/modules/mumble/forms.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for configuring Mumble
+"""
+
+from django import forms
+from gettext import gettext as _
+
+
+class MumbleForm(forms.Form):
+    """Mumble configuration form."""
+    enabled = forms.BooleanField(
+        label=_('Enable Mumble daemon'),
+        required=False)

--- a/plinth/modules/mumble/templates/mumble.html
+++ b/plinth/modules/mumble/templates/mumble.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+
+{% block content %}
+
+<h2>Voice Chat (Mumble)</h2>
+
+<p>Mumble is an open source, low-latency, encrypted, high quality voice chat
+  software.</p>
+
+<p>You can connect to your Mumble server on the regular Mumble port 64738.
+  <a href="http://mumble.info">Clients</a> to connect to Mumble from your
+  desktop and Android devices are available.</p>
+
+
+<h3>Status</h3>
+
+<p>
+  {% if status.is_running %}
+  <span class='running-status active'></span> Mumble server is running
+  {% else %}
+  <span class='running-status inactive'></span> Mumble server is not running
+  {% endif %}
+</p>
+
+<h3>Configuration</h3>
+
+<form class="form" method="post">
+  {% csrf_token %}
+
+  {{ form|bootstrap }}
+
+  <input type="submit" class="btn btn-primary" value="Update setup"/>
+</form>
+
+{% endblock %}

--- a/plinth/modules/mumble/urls.py
+++ b/plinth/modules/mumble/urls.py
@@ -1,0 +1,28 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the Mumble module
+"""
+
+from django.conf.urls import patterns, url
+
+
+urlpatterns = patterns(
+    'plinth.modules.mumble.views',
+    url(r'^apps/mumble/$', 'index', name='index'),
+    )

--- a/plinth/modules/mumble/views.py
+++ b/plinth/modules/mumble/views.py
@@ -1,0 +1,87 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module for configuring Mumble Server
+"""
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.template.response import TemplateResponse
+from gettext import gettext as _
+import logging
+
+from .forms import MumbleForm
+from plinth import actions
+from plinth import package
+from plinth.modules import mumble
+
+logger = logging.getLogger(__name__)
+
+
+@login_required
+@package.required('mumble-server')
+def index(request):
+    """Serve configuration page."""
+    status = get_status()
+
+    form = None
+
+    if request.method == 'POST':
+        form = MumbleForm(request.POST, prefix='mumble')
+        # pylint: disable=E1101
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = MumbleForm(initial=status, prefix='mumble')
+    else:
+        form = MumbleForm(initial=status, prefix='mumble')
+
+    return TemplateResponse(request, 'mumble.html',
+                            {'title': _('Voice Chat (Mumble)'),
+                             'status': status,
+                             'form': form})
+
+
+def get_status():
+    """Get the current settings from server."""
+    output = actions.run('mumble', ['get-enabled'])
+    enabled = (output.strip() == 'yes')
+
+    output = actions.superuser_run('mumble', ['is-running'])
+    is_running = (output.strip() == 'yes')
+
+    status = {'enabled': enabled,
+              'is_running': is_running}
+
+    return status
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        sub_command = 'enable' if new_status['enabled'] else 'disable'
+        actions.superuser_run('mumble', [sub_command])
+        mumble.service.notify_enabled(None, new_status['enabled'])
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))

--- a/plinth/modules/mumble/views.py
+++ b/plinth/modules/mumble/views.py
@@ -33,8 +33,13 @@ from plinth.modules import mumble
 logger = logging.getLogger(__name__)
 
 
+def on_install():
+    """Notify that the service is now enabled."""
+    mumble.service.notify_enabled(None, True)
+
+
 @login_required
-@package.required('mumble-server')
+@package.required(['mumble-server'], on_install=on_install)
 def index(request):
     """Serve configuration page."""
     status = get_status()

--- a/plinth/modules/owncloud/owncloud.py
+++ b/plinth/modules/owncloud/owncloud.py
@@ -48,7 +48,7 @@ def init():
 
 
 @login_required
-@package.required('postgresql', 'php5-pgsql', 'owncloud')
+@package.required(['postgresql', 'php5-pgsql', 'owncloud'])
 def index(request):
     """Serve the ownCloud configuration page"""
     status = get_status()

--- a/plinth/modules/pagekite/pagekite.py
+++ b/plinth/modules/pagekite/pagekite.py
@@ -102,7 +102,7 @@ https://pagekite.net/wiki/Howto/SshOverPageKite/">instructions</a>'))
 
 
 @login_required
-@package.required('pagekite')
+@package.required(['pagekite'])
 def configure(request):
     """Serve the configuration form"""
     status = get_status()

--- a/plinth/modules/tor/tor.py
+++ b/plinth/modules/tor/tor.py
@@ -44,7 +44,7 @@ def init():
 
 
 @login_required
-@package.required('tor')
+@package.required(['tor'])
 def index(request):
     """Service the index page"""
     status = get_status()

--- a/plinth/modules/upgrades/upgrades.py
+++ b/plinth/modules/upgrades/upgrades.py
@@ -46,7 +46,7 @@ def init():
 
 
 @login_required
-@package.required('unattended-upgrades')
+@package.required(['unattended-upgrades'])
 def index(request):
     """Serve the index page."""
     return TemplateResponse(request, 'upgrades.html',
@@ -56,7 +56,7 @@ def index(request):
 
 @login_required
 @require_POST
-@package.required('unattended-upgrades')
+@package.required(['unattended-upgrades'])
 def run(request):
     """Run upgrades and show the output page."""
     output = ''
@@ -85,7 +85,7 @@ available.'))
 
 
 @login_required
-@package.required('unattended-upgrades')
+@package.required(['unattended-upgrades'])
 def configure(request):
     """Serve the configuration form."""
     status = get_status()

--- a/plinth/modules/xmpp/xmpp.py
+++ b/plinth/modules/xmpp/xmpp.py
@@ -62,7 +62,7 @@ def init():
 
 
 @login_required
-@package.required('jwchat', 'ejabberd')
+@package.required(['jwchat', 'ejabberd'])
 def index(request):
     """Serve XMPP page"""
     return TemplateResponse(request, 'xmpp.html',

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -58,5 +58,6 @@ class PackageInstallView(TemplateView):
         Start the package installation, and refresh the page every x seconds to
         keep displaying PackageInstallView.get() with the installation status.
         """
-        package_module.start_install(self.kwargs['package_names'])
+        package_module.start_install(self.kwargs['package_names'],
+                                     on_install=self.kwargs.get('on_install'))
         return self.render_to_response(self.get_context_data())

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,8 @@ setuptools.setup(
     package_data={'plinth': ['templates/*',
                              'modules/*/templates/*']},
     data_files=[('/etc/init.d', ['data/etc/init.d/plinth']),
+                ('/usr/lib/firewalld/services/',
+                 glob.glob('data/usr/lib/firewalld/services/*.xml')),
                 ('/usr/lib/freedombox/setup.d/',
                  ['data/usr/lib/freedombox/setup.d/86_plinth']),
                 ('/usr/lib/freedombox/first-run.d',


### PR DESCRIPTION
Contributors to the patch: Me and Bhuvan Krishna <bhuvan@swecha.net>

Thanks to the mumble package available in Debian, this simple set of changes implement installing and configuring Mumble.  A change to packaging framework was necessary to fix issue with opening up firewall after a fresh install.

Following works:
- Server gets installed using package framework (sans the bug that it only works after apt-get update).
- Server automatically runs and no special configuration is required
- Firewall automatically opens ports.
- Enable/disable service (starts/stops daemon and disables it so the daemon would not run).
- Connecting from clients (desktop, Android clients tested) into the default channel without authentication works.
- Voice and text chat works.
- Clients automatically discover the servers that are in LAN.

Possible future work:
- Setting administrator password
- Possibly install and expose Mumble Django based web interfaces which is already available in Debian.
- Making Mumble use an LDAP server to avoid managing authenticated users.