### PR TITLE
ikiwiki module

### DIFF
--- a/actions/ikiwiki
+++ b/actions/ikiwiki
@@ -30,7 +30,8 @@ CONFIG_ENABLE = '/etc/apache2/conf-enabled/ikiwiki.conf'
 CONFIG_FILE = '/etc/apache2/conf-available/ikiwiki.conf'
 SETUP_WIKI = '/etc/ikiwiki/plinth-wiki.setup'
 SETUP_BLOG = '/etc/ikiwiki/plinth-blog.setup'
-WIKI_PATH = '/var/www/ikiwiki'
+SITE_PATH = '/var/www/ikiwiki'
+WIKI_PATH = '/var/ikiwiki'
 
 
 def parse_arguments():
@@ -53,11 +54,17 @@ def parse_arguments():
 
     # Create a wiki
     create_wiki = subparsers.add_parser('create-wiki', help='Create a wiki')
-    create_wiki.add_argument('--name', help='Name of new wiki')
+    create_wiki.add_argument('--wiki_name', help='Name of new wiki')
+    create_wiki.add_argument('--admin_name', help='Administrator account name')
+    create_wiki.add_argument('--admin_password',
+                             help='Administrator account password')
 
     # Create a blog
     create_blog = subparsers.add_parser('create-blog', help='Create a blog')
-    create_blog.add_argument('--name', help='Name of new blog')
+    create_blog.add_argument('--blog_name', help='Name of new blog')
+    create_blog.add_argument('--admin_name', help='Administrator account name')
+    create_blog.add_argument('--admin_password',
+                             help='Administrator account password')
 
     # Delete a wiki or blog
     delete = subparsers.add_parser('delete', help='Delete a wiki or blog.')
@@ -78,40 +85,59 @@ def subcommand_enable(_):
     """Enable ikiwiki site."""
     if not os.path.isfile(CONFIG_FILE):
         setup()
-        subprocess.check_output(['a2enconf', 'ikiwiki'])
-        subprocess.check_output(['service', 'apache2', 'restart'])
+        subprocess.check_call(['a2enconf', 'ikiwiki'])
+        subprocess.check_call(['service', 'apache2', 'restart'])
     else:
-        subprocess.check_output(['a2enconf', 'ikiwiki'])
-        subprocess.check_output(['service', 'apache2', 'reload'])
+        subprocess.check_call(['a2enconf', 'ikiwiki'])
+        subprocess.check_call(['service', 'apache2', 'reload'])
 
 
 def subcommand_disable(_):
     """Disable ikiwiki site."""
-    subprocess.check_output(['a2disconf', 'ikiwiki'])
-    subprocess.check_output(['service', 'apache2', 'reload'])
+    subprocess.check_call(['a2disconf', 'ikiwiki'])
+    subprocess.check_call(['service', 'apache2', 'reload'])
 
 
 def subcommand_get_sites(_):
     """Get wikis and blogs."""
-    sites = os.listdir(WIKI_PATH)
+    sites = os.listdir(SITE_PATH)
     print('\n'.join(sites))
 
 
 def subcommand_create_wiki(arguments):
     """Create a wiki."""
-    subprocess.check_output(['ikiwiki', '-setup', SETUP_WIKI, arguments.name])
+    pw_bytes = arguments.admin_password.encode()
+    proc = subprocess.Popen(
+        ['ikiwiki', '-setup', SETUP_WIKI,
+         arguments.wiki_name, arguments.admin_name],
+        stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    outs, errs = proc.communicate(input=pw_bytes + b'\n' + pw_bytes)
+    print(outs)
+    print(errs)
 
 
 def subcommand_create_blog(arguments):
     """Create a blog."""
-    subprocess.check_output(['ikiwiki', '-setup', SETUP_BLOG, arguments.name])
+    pw_bytes = arguments.admin_password.encode()
+    proc = subprocess.Popen(
+        ['ikiwiki', '-setup', SETUP_BLOG,
+         arguments.blog_name, arguments.admin_name],
+        stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+    outs, errs = proc.communicate(input=pw_bytes + b'\n' + pw_bytes)
+    print(outs)
+    print(errs)
 
 
 def subcommand_delete(arguments):
     """Delete a wiki or blog."""
+    html_folder = os.path.join(SITE_PATH, arguments.name)
     wiki_folder = os.path.join(WIKI_PATH, arguments.name)
+
     try:
+        shutil.rmtree(html_folder)
         shutil.rmtree(wiki_folder)
+        shutil.rmtree(wiki_folder + '.git')
+        os.remove(wiki_folder + '.setup')
         print('Deleted %s' % arguments.name)
     except FileNotFoundError:
         print('Error: %s not found.' % arguments.name)
@@ -120,10 +146,10 @@ def subcommand_delete(arguments):
 
 def setup():
     """Initial setup"""
-    if not os.path.exists(WIKI_PATH):
-        os.makedirs(WIKI_PATH)
+    if not os.path.exists(SITE_PATH):
+        os.makedirs(SITE_PATH)
 
-    subprocess.check_output(['a2enmod', 'cgi'])
+    subprocess.check_call(['a2enmod', 'cgi'])
 
     with open(CONFIG_FILE, 'w') as conffile:
         conffile.writelines([
@@ -143,15 +169,19 @@ def setup():
             'require IkiWiki::Setup::Automator;\n',
             '\n',
             'our $wikiname=$ARGV[0];\n',
-            'if ($wikiname eq "") {\n',
-            '	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-wiki.setup wiki_name";\n',
+            'our $admin=$ARGV[1];\n',
+            'if (($wikiname eq "") || ($admin eq "")) {\n',
+            '	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-wiki.setup ',
+            'wiki_name admin_name";\n',
             '	exit;\n',
             '}\n',
             '\n',
-            'our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname($wikiname);\n',
+            'our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname',
+            '($wikiname);\n',
             '\n',
             'IkiWiki::Setup::Automator->import(\n',
             '	wikiname => $wikiname,\n',
+            '	adminuser => [$admin],\n',
             '	rcs => "git",\n',
             '	srcdir => "/var/ikiwiki/$wikiname_short",\n',
             '	destdir => "/var/www/ikiwiki/$wikiname_short",\n',
@@ -159,7 +189,8 @@ def setup():
             '	dumpsetup => "/var/ikiwiki/$wikiname_short.setup",\n',
             '	url => "/ikiwiki/$wikiname_short",\n',
             '	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
-            '	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
+            '	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",'
+            '\n',
             '	add_plugins => [qw{goodstuff websetup httpauth}],\n',
             '	rss => 1,\n',
             '	atom => 1,\n',
@@ -175,15 +206,19 @@ def setup():
             'require IkiWiki::Setup::Automator;\n',
             '\n',
             'our $wikiname=$ARGV[0];\n',
-            'if ($wikiname eq "") {\n',
-            '	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-blog.setup blog_name";\n',
+            'our $admin=$ARGV[1];\n',
+            'if (($wikiname eq "") || ($admin eq "")) {\n',
+            '	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-blog.setup ',
+            'blog_name admin_name";\n',
             '	exit;\n',
             '}\n',
             '\n',
-            'our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname($wikiname);\n',
+            'our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname',
+            '($wikiname);\n',
             '\n',
             'IkiWiki::Setup::Automator->import(\n',
             '	wikiname => $wikiname,\n',
+            '	adminuser => [$admin],\n',
             '	rcs => "git",\n',
             '	srcdir => "/var/ikiwiki/$wikiname_short",\n',
             '	destdir => "/var/www/ikiwiki/$wikiname_short",\n',
@@ -191,8 +226,10 @@ def setup():
             '	dumpsetup => "/var/ikiwiki/$wikiname_short.setup",\n',
             '	url => "/ikiwiki/$wikiname_short",\n',
             '	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
-            '	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
-            '	add_plugins => [qw{goodstuff websetup comments calendar sidebar trail httpauth}],\n',
+            '	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",'
+            '\n',
+            '	add_plugins => [qw{goodstuff websetup comments calendar '
+            'sidebar trail httpauth}],\n',
             '	rss => 1,\n',
             '	atom => 1,\n',
             '	syslog => 1,\n',

--- a/actions/ikiwiki
+++ b/actions/ikiwiki
@@ -22,6 +22,7 @@ Configuration helper for ikiwiki
 
 import argparse
 import os
+import shutil
 import subprocess
 
 
@@ -58,6 +59,10 @@ def parse_arguments():
     create_blog = subparsers.add_parser('create-blog', help='Create a blog')
     create_blog.add_argument('--name', help='Name of new blog')
 
+    # Delete a wiki or blog
+    delete = subparsers.add_parser('delete', help='Delete a wiki or blog.')
+    delete.add_argument('--name', help='Name of wiki or blog to delete.')
+
     return parser.parse_args()
 
 
@@ -73,10 +78,11 @@ def subcommand_enable(_):
     """Enable ikiwiki site."""
     if not os.path.isfile(CONFIG_FILE):
         setup()
-
-    subprocess.check_output(['a2enmod', 'cgi'])
-    subprocess.check_output(['a2enconf', 'ikiwiki'])
-    subprocess.check_output(['service', 'apache2', 'restart'])
+        subprocess.check_output(['a2enconf', 'ikiwiki'])
+        subprocess.check_output(['service', 'apache2', 'restart'])
+    else:
+        subprocess.check_output(['a2enconf', 'ikiwiki'])
+        subprocess.check_output(['service', 'apache2', 'reload'])
 
 
 def subcommand_disable(_):
@@ -86,25 +92,38 @@ def subcommand_disable(_):
 
 
 def subcommand_get_sites(_):
-    """Get wikis and blogs"""
+    """Get wikis and blogs."""
     sites = os.listdir(WIKI_PATH)
     print('\n'.join(sites))
 
 
 def subcommand_create_wiki(arguments):
-    """Create a wiki"""
+    """Create a wiki."""
     subprocess.check_output(['ikiwiki', '-setup', SETUP_WIKI, arguments.name])
 
 
 def subcommand_create_blog(arguments):
-    """Create a blog"""
+    """Create a blog."""
     subprocess.check_output(['ikiwiki', '-setup', SETUP_BLOG, arguments.name])
+
+
+def subcommand_delete(arguments):
+    """Delete a wiki or blog."""
+    wiki_folder = os.path.join(WIKI_PATH, arguments.name)
+    try:
+        shutil.rmtree(wiki_folder)
+        print('Deleted %s' % arguments.name)
+    except FileNotFoundError:
+        print('Error: %s not found.' % arguments.name)
+        exit(1)
 
 
 def setup():
     """Initial setup"""
     if not os.path.exists(WIKI_PATH):
         os.makedirs(WIKI_PATH)
+
+    subprocess.check_output(['a2enmod', 'cgi'])
 
     with open(CONFIG_FILE, 'w') as conffile:
         conffile.writelines([

--- a/actions/ikiwiki
+++ b/actions/ikiwiki
@@ -47,6 +47,9 @@ def parse_arguments():
     # Disable ikiwiki site
     subparsers.add_parser('disable', help='Disable ikiwiki site')
 
+    # Get wikis and blogs
+    subparsers.add_parser('get-sites', help='Get wikis and blogs')
+
     # Create a wiki
     create_wiki = subparsers.add_parser('create-wiki', help='Create a wiki')
     create_wiki.add_argument('--name', help='Name of new wiki')
@@ -71,14 +74,21 @@ def subcommand_enable(_):
     if not os.path.isfile(CONFIG_FILE):
         setup()
 
+    subprocess.check_output(['a2enmod', 'cgi'])
     subprocess.check_output(['a2enconf', 'ikiwiki'])
-    subprocess.check_output(['service', 'apache2', 'reload'])
+    subprocess.check_output(['service', 'apache2', 'restart'])
 
 
 def subcommand_disable(_):
     """Disable ikiwiki site."""
     subprocess.check_output(['a2disconf', 'ikiwiki'])
     subprocess.check_output(['service', 'apache2', 'reload'])
+
+
+def subcommand_get_sites(_):
+    """Get wikis and blogs"""
+    sites = os.listdir(WIKI_PATH)
+    print('\n'.join(sites))
 
 
 def subcommand_create_wiki(arguments):
@@ -163,18 +173,16 @@ def setup():
             '	url => "/ikiwiki/$wikiname_short",\n',
             '	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
             '	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
-            '	add_plugins => [qw{goodstuff websetup comments blogspam calendar sidebar trail httpauth}],\n',
+            '	add_plugins => [qw{goodstuff websetup comments calendar sidebar trail httpauth}],\n',
             '	rss => 1,\n',
             '	atom => 1,\n',
             '	syslog => 1,\n',
             '\n',
             '	example => "blog",\n',
             '	comments_pagespec => "posts/* and !*/Discussion",\n',
-            '	blogspam_pagespec => "postcomment(*)",\n',
             '	archive_pagespec => "page(posts/*) and !*/Discussion",\n',
             '	global_sidebars => 0,\n',
             '	discussion => 0,\n',
-            '	locked_pages => "* and !postcomment(*)",\n',
             '	tagbase => "tags",\n',
             ')\n',
         ])

--- a/actions/ikiwiki
+++ b/actions/ikiwiki
@@ -1,0 +1,193 @@
+#!/usr/bin/python3
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for ikiwiki
+"""
+
+import argparse
+import os
+import subprocess
+
+
+CONFIG_ENABLE = '/etc/apache2/conf-enabled/ikiwiki.conf'
+CONFIG_FILE = '/etc/apache2/conf-available/ikiwiki.conf'
+SETUP_WIKI = '/etc/ikiwiki/plinth-wiki.setup'
+SETUP_BLOG = '/etc/ikiwiki/plinth-blog.setup'
+WIKI_PATH = '/var/www/ikiwiki'
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    # Get whether ikiwiki site is enabled
+    subparsers.add_parser('get-enabled',
+                          help='Get whether ikiwiki site is enabled')
+
+    # Enable ikiwiki site
+    subparsers.add_parser('enable', help='Enable ikiwiki site')
+
+    # Disable ikiwiki site
+    subparsers.add_parser('disable', help='Disable ikiwiki site')
+
+    # Create a wiki
+    create_wiki = subparsers.add_parser('create-wiki', help='Create a wiki')
+    create_wiki.add_argument('--name', help='Name of new wiki')
+
+    # Create a blog
+    create_blog = subparsers.add_parser('create-blog', help='Create a blog')
+    create_blog.add_argument('--name', help='Name of new blog')
+
+    return parser.parse_args()
+
+
+def subcommand_get_enabled(_):
+    """Get whether ikiwiki site is enabled."""
+    if os.path.isfile(CONFIG_ENABLE):
+        print('yes')
+    else:
+        print('no')
+
+
+def subcommand_enable(_):
+    """Enable ikiwiki site."""
+    if not os.path.isfile(CONFIG_FILE):
+        setup()
+
+    subprocess.check_output(['a2enconf', 'ikiwiki'])
+    subprocess.check_output(['service', 'apache2', 'reload'])
+
+
+def subcommand_disable(_):
+    """Disable ikiwiki site."""
+    subprocess.check_output(['a2disconf', 'ikiwiki'])
+    subprocess.check_output(['service', 'apache2', 'reload'])
+
+
+def subcommand_create_wiki(arguments):
+    """Create a wiki"""
+    subprocess.check_output(['ikiwiki', '-setup', SETUP_WIKI, arguments.name])
+
+
+def subcommand_create_blog(arguments):
+    """Create a blog"""
+    subprocess.check_output(['ikiwiki', '-setup', SETUP_BLOG, arguments.name])
+
+
+def setup():
+    """Initial setup"""
+    if not os.path.exists(WIKI_PATH):
+        os.makedirs(WIKI_PATH)
+
+    with open(CONFIG_FILE, 'w') as conffile:
+        conffile.writelines([
+            'Alias /ikiwiki /var/www/ikiwiki\n',
+            'AddHandler cgi-script .cgi\n',
+            '\n',
+            '<Directory /var/www/ikiwiki>\n',
+            '    Options +ExecCGI\n',
+            '</Directory>\n'
+        ])
+
+    with open(SETUP_WIKI, 'w') as setupfile:
+        setupfile.writelines([
+            '#!/usr/bin/perl\n',
+            '# Ikiwiki setup automator for Plinth.\n',
+            '\n',
+            'require IkiWiki::Setup::Automator;\n',
+            '\n',
+            'our $wikiname=$ARGV[0];\n',
+            'if ($wikiname eq "") {\n',
+            '	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-wiki.setup wiki_name";\n',
+            '	exit;\n',
+            '}\n',
+            '\n',
+            'our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname($wikiname);\n',
+            '\n',
+            'IkiWiki::Setup::Automator->import(\n',
+            '	wikiname => $wikiname,\n',
+            '	rcs => "git",\n',
+            '	srcdir => "/var/ikiwiki/$wikiname_short",\n',
+            '	destdir => "/var/www/ikiwiki/$wikiname_short",\n',
+            '	repository => "/var/ikiwiki/$wikiname_short.git",\n',
+            '	dumpsetup => "/var/ikiwiki/$wikiname_short.setup",\n',
+            '	url => "/ikiwiki/$wikiname_short",\n',
+            '	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
+            '	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
+            '	add_plugins => [qw{goodstuff websetup httpauth}],\n',
+            '	rss => 1,\n',
+            '	atom => 1,\n',
+            '	syslog => 1,\n',
+            ')\n',
+        ])
+
+    with open(SETUP_BLOG, 'w') as setupfile:
+        setupfile.writelines([
+            '#!/usr/bin/perl\n',
+            '# Ikiwiki setup automator for Plinth (blog version).\n',
+            '\n',
+            'require IkiWiki::Setup::Automator;\n',
+            '\n',
+            'our $wikiname=$ARGV[0];\n',
+            'if ($wikiname eq "") {\n',
+            '	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-blog.setup blog_name";\n',
+            '	exit;\n',
+            '}\n',
+            '\n',
+            'our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname($wikiname);\n',
+            '\n',
+            'IkiWiki::Setup::Automator->import(\n',
+            '	wikiname => $wikiname,\n',
+            '	rcs => "git",\n',
+            '	srcdir => "/var/ikiwiki/$wikiname_short",\n',
+            '	destdir => "/var/www/ikiwiki/$wikiname_short",\n',
+            '	repository => "/var/ikiwiki/$wikiname_short.git",\n',
+            '	dumpsetup => "/var/ikiwiki/$wikiname_short.setup",\n',
+            '	url => "/ikiwiki/$wikiname_short",\n',
+            '	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
+            '	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",\n',
+            '	add_plugins => [qw{goodstuff websetup comments blogspam calendar sidebar trail httpauth}],\n',
+            '	rss => 1,\n',
+            '	atom => 1,\n',
+            '	syslog => 1,\n',
+            '\n',
+            '	example => "blog",\n',
+            '	comments_pagespec => "posts/* and !*/Discussion",\n',
+            '	blogspam_pagespec => "postcomment(*)",\n',
+            '	archive_pagespec => "page(posts/*) and !*/Discussion",\n',
+            '	global_sidebars => 0,\n',
+            '	discussion => 0,\n',
+            '	locked_pages => "* and !postcomment(*)",\n',
+            '	tagbase => "tags",\n',
+            ')\n',
+        ])
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/data/etc/plinth/modules-enabled/ikiwiki
+++ b/data/etc/plinth/modules-enabled/ikiwiki
@@ -1,0 +1,1 @@
+plinth.modules.ikiwiki

--- a/plinth/modules/ikiwiki/__init__.py
+++ b/plinth/modules/ikiwiki/__init__.py
@@ -1,0 +1,33 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure ikiwiki
+"""
+
+from gettext import gettext as _
+
+from plinth import cfg
+
+
+depends = ['plinth.modules.apps']
+
+
+def init():
+    """Initialize the ikiwiki module."""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(_('Wiki & Blog'), 'glyphicon-edit', 'ikiwiki:index', 38)

--- a/plinth/modules/ikiwiki/forms.py
+++ b/plinth/modules/ikiwiki/forms.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for configuring ikiwiki
+"""
+
+from django import forms
+from gettext import gettext as _
+
+
+class IkiwikiForm(forms.Form):
+    """ikiwiki configuration form."""
+    enabled = forms.BooleanField(
+        label=_('Enable ikiwiki site'),
+        required=False)

--- a/plinth/modules/ikiwiki/forms.py
+++ b/plinth/modules/ikiwiki/forms.py
@@ -36,3 +36,7 @@ class IkiwikiCreateForm(forms.Form):
         label=_('Type'),
         choices=[('wiki', 'Wiki'), ('blog', 'Blog')])
     name = forms.CharField(label=_('Name'))
+    admin_name = forms.CharField(label=_('Admin Account Name'))
+    admin_password = forms.CharField(
+        label=_('Admin Account Password'),
+        widget=forms.PasswordInput())

--- a/plinth/modules/ikiwiki/forms.py
+++ b/plinth/modules/ikiwiki/forms.py
@@ -28,3 +28,11 @@ class IkiwikiForm(forms.Form):
     enabled = forms.BooleanField(
         label=_('Enable ikiwiki site'),
         required=False)
+
+
+class IkiwikiCreateForm(forms.Form):
+    """Form to create a wiki or blog."""
+    type = forms.ChoiceField(
+        label=_('Type'),
+        choices=[('wiki', 'Wiki'), ('blog', 'Blog')])
+    name = forms.CharField(label=_('Name'))

--- a/plinth/modules/ikiwiki/templates/ikiwiki.html
+++ b/plinth/modules/ikiwiki/templates/ikiwiki.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+
+{% block content %}
+
+<h2>Wiki & Blog</h2>
+
+<p>When enabled, the ikiwiki site will be available from <a href="/ikiwiki">
+    /ikiwiki</a> path on the web server.</p>
+
+<form class="form" method="post">
+  {% csrf_token %}
+
+  {{ form|bootstrap }}
+
+  <input type="submit" class="btn btn-primary" value="Update setup"/>
+</form>
+
+{% endblock %}

--- a/plinth/modules/ikiwiki/templates/ikiwiki.html
+++ b/plinth/modules/ikiwiki/templates/ikiwiki.html
@@ -22,8 +22,6 @@
 
 {% block content %}
 
-<h2>Wiki & Blog</h2>
-
 <p>When enabled, the ikiwiki site will be available from <a href="/ikiwiki">
     /ikiwiki</a> path on the web server.</p>
 

--- a/plinth/modules/ikiwiki/templates/ikiwiki_create.html
+++ b/plinth/modules/ikiwiki/templates/ikiwiki_create.html
@@ -1,3 +1,5 @@
+{% extends "base.html" %}
+{% comment %}
 #
 # This file is part of Plinth.
 #
@@ -14,17 +16,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+{% endcomment %}
 
-"""
-URLs for the ikiwiki module
-"""
+{% load bootstrap %}
 
-from django.conf.urls import patterns, url
+{% block content %}
 
+<form class="form" method="post">
+  {% csrf_token %}
 
-urlpatterns = patterns(
-    'plinth.modules.ikiwiki.views',
-    url(r'^apps/ikiwiki/$', 'index', name='index'),
-    url(r'^apps/ikiwiki/manage/$', 'manage', name='manage'),
-    url(r'^apps/ikiwiki/create/$', 'create', name='create'),
-    )
+  {{ form|bootstrap }}
+
+  <input type="submit" class="btn btn-primary" value="Update setup"/>
+</form>
+
+{% endblock %}

--- a/plinth/modules/ikiwiki/templates/ikiwiki_delete.html
+++ b/plinth/modules/ikiwiki/templates/ikiwiki_delete.html
@@ -1,3 +1,5 @@
+{% extends "base.html" %}
+{% comment %}
 #
 # This file is part of Plinth.
 #
@@ -14,18 +16,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+{% endcomment %}
 
-"""
-URLs for the ikiwiki module
-"""
+{% load bootstrap %}
 
-from django.conf.urls import patterns, url
+{% block content %}
 
+  <h3>Delete Wiki/Blog <em>{{ name }}</em></h3>
 
-urlpatterns = patterns(
-    'plinth.modules.ikiwiki.views',
-    url(r'^apps/ikiwiki/$', 'index', name='index'),
-    url(r'^apps/ikiwiki/manage/$', 'manage', name='manage'),
-    url(r'^apps/ikiwiki/(?P<name>[\w.@+-]+)/delete/$', 'delete', name='delete'),
-    url(r'^apps/ikiwiki/create/$', 'create', name='create'),
-    )
+  <p>Delete this wiki/blog permanently?</p>
+
+  <form class="form" method="post">
+    {% csrf_token %}
+
+    <input type="submit" class="btn btn-md btn-primary"
+           value="Delete {{ name }}"/>
+
+    <a href="{% url 'ikiwiki:manage' %}" role="button"
+       class="btn btn-md btn-primary">Cancel</a>
+  </form>
+
+{% endblock %}

--- a/plinth/modules/ikiwiki/templates/ikiwiki_manage.html
+++ b/plinth/modules/ikiwiki/templates/ikiwiki_manage.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+
+{% block page_head %}
+  <style type="text/css">
+    .wiki-label {
+      display: inline-block;
+      width: 40%;
+    }
+    .list-group-item .btn {
+      margin: -5px 0;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+
+  <div class="row">
+    <div class="col-sm-6">
+      <div class="list-group">
+        {% for site in sites %}
+          <div class="list-group-item clearfix">
+	    <a href="{% url 'ikiwiki:index' %}"
+               class="btn btn-default btn-sm pull-right"
+               role="button" title="Delete site {{ site }}">
+              <span class="glyphicon glyphicon-trash"
+                    aria-hidden="true"></span>
+            </a>
+
+            <a class="wiki-label"
+	       href="/ikiwiki/{{ site }}"
+               title="Go to site {{ site }}">
+              {{ site }}
+            </a>
+
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/plinth/modules/ikiwiki/templates/ikiwiki_manage.html
+++ b/plinth/modules/ikiwiki/templates/ikiwiki_manage.html
@@ -39,7 +39,7 @@
       <div class="list-group">
         {% for site in sites %}
           <div class="list-group-item clearfix">
-	    <a href="{% url 'ikiwiki:index' %}"
+	    <a href="{% url 'ikiwiki:delete' site %}"
                class="btn btn-default btn-sm pull-right"
                role="button" title="Delete site {{ site }}">
               <span class="glyphicon glyphicon-trash"

--- a/plinth/modules/ikiwiki/urls.py
+++ b/plinth/modules/ikiwiki/urls.py
@@ -26,6 +26,7 @@ urlpatterns = patterns(
     'plinth.modules.ikiwiki.views',
     url(r'^apps/ikiwiki/$', 'index', name='index'),
     url(r'^apps/ikiwiki/manage/$', 'manage', name='manage'),
-    url(r'^apps/ikiwiki/(?P<name>[\w.@+-]+)/delete/$', 'delete', name='delete'),
+    url(r'^apps/ikiwiki/(?P<name>[\w.@+-]+)/delete/$',
+        'delete', name='delete'),
     url(r'^apps/ikiwiki/create/$', 'create', name='create'),
     )

--- a/plinth/modules/ikiwiki/urls.py
+++ b/plinth/modules/ikiwiki/urls.py
@@ -1,0 +1,28 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the ikiwiki module
+"""
+
+from django.conf.urls import patterns, url
+
+
+urlpatterns = patterns(
+    'plinth.modules.ikiwiki.views',
+    url(r'^apps/ikiwiki/$', 'index', name='index'),
+    )

--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -25,12 +25,15 @@ from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from gettext import gettext as _
+import logging
 
 from .forms import IkiwikiForm, IkiwikiCreateForm
 from plinth import actions
 from plinth import package
 from plinth.modules import ikiwiki
 
+
+LOGGER = logging.getLogger(__name__)
 
 subsubmenu = [{'url': reverse_lazy('ikiwiki:index'),
                'text': _('Configure')},
@@ -107,9 +110,13 @@ def create(request):
         form = IkiwikiCreateForm(request.POST, prefix='ikiwiki')
         if form.is_valid():
             if form.cleaned_data['type'] == 'wiki':
-                _create_wiki(request, form.cleaned_data['name'])
+                _create_wiki(request, form.cleaned_data['name'],
+                             form.cleaned_data['admin_name'],
+                             form.cleaned_data['admin_password'])
             elif form.cleaned_data['type'] == 'blog':
-                _create_blog(request, form.cleaned_data['name'])
+                _create_blog(request, form.cleaned_data['name'],
+                             form.cleaned_data['admin_name'],
+                             form.cleaned_data['admin_password'])
 
             return redirect(reverse_lazy('ikiwiki:manage'))
     else:
@@ -121,19 +128,27 @@ def create(request):
                              'subsubmenu': subsubmenu})
 
 
-def _create_wiki(request, name):
+def _create_wiki(request, name, admin_name, admin_password):
     """Create wiki."""
     try:
-        actions.superuser_run('ikiwiki', ['create-wiki', '--name', name])
+        output = actions.superuser_run(
+            'ikiwiki',
+            ['create-wiki', '--wiki_name', name,
+             '--admin_name', admin_name, '--admin_password', admin_password])
+        #LOGGER.info('create wiki: %s' % output)
         messages.success(request, _('Created wiki %s.') % name)
     except actions.ActionError as err:
         messages.error(request, _('Could not create wiki: %s') % err)
 
 
-def _create_blog(request, name):
+def _create_blog(request, name, admin_name, admin_password):
     """Create blog."""
     try:
-        actions.superuser_run('ikiwiki', ['create-blog', '--name', name])
+        output = actions.superuser_run(
+            'ikiwiki',
+            ['create-blog', '--blog_name', name,
+             '--admin_name', admin_name, '--admin_password', admin_password])
+        #LOGGER.info('create blog: %s' % output)
         messages.success(request, _('Created blog %s.') % name)
     except actions.ActionError as err:
         messages.error(request, _('Could not create blog: %s') % err)

--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -1,0 +1,75 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module for configuring ikiwiki
+"""
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.template.response import TemplateResponse
+from gettext import gettext as _
+
+from .forms import IkiwikiForm
+from plinth import actions
+from plinth import package
+from plinth.modules import ikiwiki
+
+
+@login_required
+@package.required(['ikiwiki'])
+def index(request):
+    """Serve configuration page."""
+    status = get_status()
+
+    form = None
+
+    if request.method == 'POST':
+        form = IkiwikiForm(request.POST, prefix='ikiwiki')
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = IkiwikiForm(initial=status, prefix='ikiwiki')
+    else:
+        form = IkiwikiForm(initial=status, prefix='ikiwiki')
+
+    return TemplateResponse(request, 'ikiwiki.html',
+                            {'title': _('Wiki'),
+                             'status': status,
+                             'form': form})
+
+
+def get_status():
+    """Get the current setting."""
+    output = actions.run('ikiwiki', ['get-enabled'])
+    enabled = (output.strip() == 'yes')
+    return {'enabled': enabled}
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        sub_command = 'enable' if new_status['enabled'] else 'disable'
+        actions.superuser_run('ikiwiki', [sub_command])
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))

--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -25,15 +25,11 @@ from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from gettext import gettext as _
-import logging
 
 from .forms import IkiwikiForm, IkiwikiCreateForm
 from plinth import actions
 from plinth import package
-from plinth.modules import ikiwiki
 
-
-LOGGER = logging.getLogger(__name__)
 
 subsubmenu = [{'url': reverse_lazy('ikiwiki:index'),
                'text': _('Configure')},
@@ -44,7 +40,9 @@ subsubmenu = [{'url': reverse_lazy('ikiwiki:index'),
 
 
 @login_required
-@package.required(['ikiwiki', 'libcgi-formbuilder-perl', 'libcgi-session-perl'])
+@package.required(['ikiwiki',
+                   'libcgi-formbuilder-perl',
+                   'libcgi-session-perl'])
 def index(request):
     """Serve configuration page."""
     status = get_status()
@@ -131,11 +129,10 @@ def create(request):
 def _create_wiki(request, name, admin_name, admin_password):
     """Create wiki."""
     try:
-        output = actions.superuser_run(
+        actions.superuser_run(
             'ikiwiki',
             ['create-wiki', '--wiki_name', name,
              '--admin_name', admin_name, '--admin_password', admin_password])
-        #LOGGER.info('create wiki: %s' % output)
         messages.success(request, _('Created wiki %s.') % name)
     except actions.ActionError as err:
         messages.error(request, _('Could not create wiki: %s') % err)
@@ -144,11 +141,10 @@ def _create_wiki(request, name, admin_name, admin_password):
 def _create_blog(request, name, admin_name, admin_password):
     """Create blog."""
     try:
-        output = actions.superuser_run(
+        actions.superuser_run(
             'ikiwiki',
             ['create-blog', '--blog_name', name,
              '--admin_name', admin_name, '--admin_password', admin_password])
-        #LOGGER.info('create blog: %s' % output)
         messages.success(request, _('Created blog %s.') % name)
     except actions.ActionError as err:
         messages.error(request, _('Could not create blog: %s') % err)


### PR DESCRIPTION
This is a module to setup wikis and blogs using ikiwiki.
- Can enable or disable entire /ikiwiki site.
- Can create a wiki or blog, which will be hosted at /ikiwiki/wikiname or /ikiwiki/blogname on the web server.
- No SSO support (yet). An admin account username and password is specified when the wiki or blog is created.
- Shows a list of links to existing wikis and blogs.
- Can delete a wiki or blog.
