### PR TITLE
Add BitTorrent module (deluge-web).

### DIFF
--- a/actions/bittorrent
+++ b/actions/bittorrent
@@ -1,0 +1,129 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for BitTorrent web client
+"""
+
+import argparse
+import os
+import subprocess
+
+
+SITE_CONF = '/etc/apache2/conf-available/deluge-web.conf'
+SITE_ENABLED = '/etc/apache2/conf-enabled/deluge-web.conf'
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    # Get whether deluge-web site is enabled
+    subparsers.add_parser('get-enabled',
+                          help='Get whether deluge-web site is enabled')
+
+    # Enable deluge-web site and start deluge-web
+    subparsers.add_parser('enable', help='Enable deluge-web site')
+
+    # Disable deluge-web site and stop deluge-web
+    subparsers.add_parser('disable', help='Disable deluge-web site')
+
+    # Get whether deluge-web is running
+    subparsers.add_parser('is-running',
+                          help='Get whether deluge-web is running')
+
+    # Start deluge-web
+    subparsers.add_parser('start', help='Start deluge-web')
+
+    # Stop deluge-web
+    subparsers.add_parser('stop', help='Stop deluge-web')
+
+    return parser.parse_args()
+
+
+def subcommand_get_enabled(_):
+    """Get whether deluge-web site is enabled."""
+    if os.path.isfile(SITE_ENABLED):
+        print('yes')
+    else:
+        print('no')
+
+
+def subcommand_enable(_):
+    """Enable deluge-web site and start deluge-web."""
+    if not os.path.isfile(SITE_CONF):
+        setup()
+    subprocess.check_call(['a2enconf', 'deluge-web'])
+    subprocess.check_call(['service', 'apache2', 'reload'])
+
+    subcommand_start(_)
+
+
+def subcommand_disable(_):
+    """Disable deluge-web site and stop deluge-web."""
+    subprocess.check_call(['a2disconf', 'deluge-web'])
+    subprocess.check_call(['service', 'apache2', 'reload'])
+
+    subcommand_stop(_)
+
+
+def subcommand_is_running(_):
+    """Get whether deluge-web is running."""
+    if subprocess.call(['pgrep', 'deluge-web']) == 0:
+        print('yes')
+    else:
+        print('no')
+
+
+def subcommand_start(_):
+    """Start deluge-web."""
+    subprocess.check_call(['start-stop-daemon', '--start', '--background',
+                           '--name', 'deluge-web',
+                           '--exec', '/usr/bin/deluge-web',
+                           '--chuid', 'debian-deluged',
+                           '--', '--base=bittorrent'])
+
+
+def subcommand_stop(_):
+    """Stop deluge-web."""
+    subprocess.call(['killall', 'deluge-web'])
+
+
+def setup():
+    """Perform initial setup for deluge-web site."""
+    with open(SITE_CONF, 'w') as conffile:
+        conffile.writelines([
+            '<Location /bittorrent>\n',
+            '    ProxyPass http://localhost:8112\n',
+            '</Location>\n',
+        ])
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/data/etc/plinth/modules-enabled/bittorrent
+++ b/data/etc/plinth/modules-enabled/bittorrent
@@ -1,0 +1,1 @@
+plinth.modules.bittorrent

--- a/plinth/modules/bittorrent/__init__.py
+++ b/plinth/modules/bittorrent/__init__.py
@@ -1,0 +1,34 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure a BitTorrent web client (deluge-web)
+"""
+
+from gettext import gettext as _
+
+from plinth import cfg
+
+
+depends = ['plinth.modules.apps']
+
+
+def init():
+    """Initialize the BitTorrent module."""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(_('BitTorrent (Deluge)'), 'glyphicon-magnet',
+                     'bittorrent:index', 60)

--- a/plinth/modules/bittorrent/forms.py
+++ b/plinth/modules/bittorrent/forms.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for configuring BitTorrent web client
+"""
+
+from django import forms
+from gettext import gettext as _
+
+
+class BitTorrentForm(forms.Form):
+    """BitTorrent configuration form."""
+    enabled = forms.BooleanField(
+        label=_('Enable BitTorrent web client'),
+        required=False)

--- a/plinth/modules/bittorrent/templates/bittorrent.html
+++ b/plinth/modules/bittorrent/templates/bittorrent.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+
+{% block content %}
+
+<h2>BitTorrent Web Client (Deluge)</h2>
+
+<p>Deluge is a BitTorrent client that features a Web UI.</p>
+
+<p>When enabled, the Deluge web client will be available from
+  <a href="/bittorrent">/bittorrent</a> path on the web server. The default
+  password is 'deluge', but you should log in and change it immediately after
+  enabling this service.</p>
+
+<h3>Configuration</h3>
+
+<form class="form" method="post">
+  {% csrf_token %}
+
+  {{ form|bootstrap }}
+
+  <input type="submit" class="btn btn-primary" value="Update setup"/>
+</form>
+
+{% if status.enabled %}
+<h3>Status</h3>
+
+<p>If your {{ cfg.box_name }} is restarted, you will need to start deluge-web
+  manually. In the future, this will be handled automatically.</p>
+
+<p>
+  {% if status.is_running %}
+  <span class="running-status active"></span> deluge-web is running
+  <form class="form" method="post" action="{% url 'bittorrent:stop' %}">
+    {% csrf_token %}
+    <input type="submit" class="btn btn-primary"
+           value="Stop deluge-web &raquo;"/>
+  </form>
+
+  {% else %}
+  <span class="running-status inactive"></span> deluge-web is not running
+  <form class="form" method="post" action="{% url 'bittorrent:start' %}">
+    {% csrf_token %}
+    <input type="submit" class="btn btn-primary"
+           value="Start deluge-web &raquo;"/>
+  </form>
+
+  {% endif %}
+</p>
+{% endif %}
+
+{% endblock %}

--- a/plinth/modules/bittorrent/urls.py
+++ b/plinth/modules/bittorrent/urls.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the BitTorrent module
+"""
+
+from django.conf.urls import patterns, url
+
+
+urlpatterns = patterns(
+    'plinth.modules.bittorrent.views',
+    url(r'^apps/bittorrent/$', 'index', name='index'),
+    url(r'^apps/bittorrent/start/$', 'start', name='start'),
+    url(r'^apps/bittorrent/stop/$', 'stop', name='stop'),
+    )

--- a/plinth/modules/bittorrent/views.py
+++ b/plinth/modules/bittorrent/views.py
@@ -1,0 +1,101 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure a BitTorrent web client (deluge-web)
+"""
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse_lazy
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
+from django.views.decorators.http import require_POST
+from gettext import gettext as _
+
+from .forms import BitTorrentForm
+from plinth import actions
+from plinth import package
+
+
+@login_required
+@package.required(['deluged', 'deluge-web'])
+def index(request):
+    """Serve configuration page."""
+    status = get_status()
+
+    form = None
+
+    if request.method == 'POST':
+        form = BitTorrentForm(request.POST, prefix='bittorrent')
+        # pylint: disable=E1101
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = BitTorrentForm(initial=status, prefix='bittorrent')
+    else:
+        form = BitTorrentForm(initial=status, prefix='bittorrent')
+
+    return TemplateResponse(request, 'bittorrent.html',
+                            {'title': _('BitTorrent (Deluge)'),
+                             'status': status,
+                             'form': form})
+
+
+@login_required
+@require_POST
+def start(request):
+    """Start deluge-web."""
+    actions.run('bittorrent', ['start'])
+    return redirect(reverse_lazy('bittorrent:index'))
+
+
+@login_required
+@require_POST
+def stop(request):
+    """Stop deluge-web."""
+    actions.run('bittorrent', ['stop'])
+    return redirect(reverse_lazy('bittorrent:index'))
+
+
+def get_status():
+    """Get the current settings."""
+    output = actions.run('bittorrent', ['get-enabled'])
+    enabled = (output.strip() == 'yes')
+
+    output = actions.run('bittorrent', ['is-running'])
+    is_running = ('yes' in output.strip())
+
+    status = {'enabled': enabled,
+              'is_running': is_running}
+
+    return status
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        sub_command = 'enable' if new_status['enabled'] else 'disable'
+        actions.superuser_run('bittorrent', [sub_command])
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))


### PR DESCRIPTION
This module can install and enable the Deluge web UI. It's available at /bittorrent. The application has a default password (deluge) but it asks the user to change it after first login.

deluge-web doesn't ship with an initscript yet (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=722719). So I included a button to start it manually if it's not already running.