### PR TITLE
Simpler look

### DIFF
--- a/plinth/modules/first_boot/templates/firstboot_sidebar.html
+++ b/plinth/modules/first_boot/templates/firstboot_sidebar.html
@@ -17,7 +17,7 @@
 #
 {% endcomment %}
 
-<div class="well sidebar">
+<div class="sidebar">
 
   <h3>Getting Help</h3>
 

--- a/plinth/modules/help/templates/help_about.html
+++ b/plinth/modules/help/templates/help_about.html
@@ -50,7 +50,7 @@ href="http://wiki.debian.org/FreedomBox" target="_blank">Learn more
 
 {% block sidebar %}
 
-<div class="well sidebar">
+<div class="sidebar">
 
   <h3>Our Goal</h3>
 

--- a/plinth/modules/owncloud/templates/owncloud.html
+++ b/plinth/modules/owncloud/templates/owncloud.html
@@ -41,7 +41,7 @@
 
 {% block sidebar %}
 
-  <div class="well sidebar">
+  <div class="sidebar">
 
     <h3>ownCloud</h3>
 

--- a/plinth/modules/packages/templates/packages.html
+++ b/plinth/modules/packages/templates/packages.html
@@ -48,7 +48,7 @@
 
 {% block sidebar %}
 
-  <div class="well sidebar">
+  <div class="sidebar">
 
     <h3>Help</h3>
 

--- a/plinth/modules/tor/templates/tor.html
+++ b/plinth/modules/tor/templates/tor.html
@@ -82,7 +82,7 @@ port-forwarded, if necessary:</p>
 
 {% block sidebar %}
 
-  <div class="well sidebar">
+  <div class="sidebar">
 
     <h3>Tor</h3>
 

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -89,39 +89,42 @@
       </div>
       <div class="collapse navbar-collapse">
       {% block add_nav_and_login %}
-        <ul class="nav navbar-nav">
-          {% for item in cfg.main_menu.items %}
-            {% if item.url in active_menu_urls %}
-              <li class="active">
-                <a href="{{ item.url }}" class="active">
+        <ul class="nav navbar-nav navbar-right">
+          <li>
+            <a href="{% url 'help:index' %}">
+              <span class="glyphicon-question-sign glyphicon nav-icon"></span>
+            </a>
+          </li>
+          <li>
+            <a href="{% url 'system:index' %}">
+              <span class="glyphicon-cog glyphicon nav-icon"></span>
+            </a>
+          </li>
+          <li class="dropdown">
+            {% if user.is_authenticated %}
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown"
+                 role="button" aria-expanded="false">
+                <i class="glyphicon glyphicon-user nav-icon"></i>
+                {{ user.username }}
+                <span class="caret"></span></a>
+              <ul class="dropdown-menu" role="menu">
+                <li><a href="{% url 'users:edit' user.username %}"
+                       title="Edit">Edit</a></li>
+                <li><a href="{% url 'users:change_password' user.username %}"
+                       title="Change password">Change password</a></li>
+                <li class="divider"></li>
+                <li><a href="{% url 'users:logout' %}" title="Log out">
+                    Log out</a></li>
+              </ul>
             {% else %}
-              <li>
-                <a href="{{ item.url }}">
+              <a href="{% url 'users:login' %}" title="Log in">
+                <i class="glyphicon glyphicon-user nav-icon"></i>
+                Log in</a>
             {% endif %}
-
-                <span class="{{ item.icon }} glyphicon nav-icon"></span>
-                {{ item.label }}
-              </a>
-            </li>
-          {% endfor %}
+          </li>
         </ul>
 
-        {% if user.is_authenticated %}
-          <p class="navbar-text pull-right">
-            <i class="glyphicon glyphicon-user nav-icon"></i>
-            Logged in as <a href="#">{{ user.username }}</a>.
-            <a href="{% url 'users:logout' %}" title="Log out">
-              Log out</a>.
-          </p>
-        {% else %}
-          <p class="navbar-text pull-right">
-            Not logged in.
-            <i class="glyphicon glyphicon-user nav-icon"></i>
-            <a href="{% url 'users:login' %}" title="Log in">
-              Log in</a>.
-          </p>
-        {% endif %}
-        {% endblock %}
+      {% endblock %}
       </div>
     </div>
   </div>

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -131,9 +131,9 @@
       <div class="col-md-3">
         {% block submenu %}
           {% if submenu %}
-            <div class="well sidebar">
+            <div class="sidebar">
               {% include "submenu.html" with menu=submenu %}
-            </div><!--/.well -->
+            </div><!--/.sidebar -->
           {% endif %}
         {% endblock %}
 
@@ -143,20 +143,17 @@
       </div>
 
       <div class="col-md-9">
-        <div class="well">
+        {% block subsubmenu %}
+          {% if subsubmenu %}
+            {% show_subsubmenu subsubmenu %}
+          {% endif %}
+        {% endblock %}
 
-          {% block subsubmenu %}
-            {% if subsubmenu %}
-              {% show_subsubmenu subsubmenu %}
-            {% endif %}
-          {% endblock %}
+        {% include 'messages.html' %}
 
-          {% include 'messages.html' %}
-
-          {% block content %}
-            {# main content goes here #}
-          {% endblock %}
-        </div>
+        {% block content %}
+          {# main content goes here #}
+        {% endblock %}
       </div><!--/col-->
     </div><!--/row-->
 

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -71,7 +71,7 @@
 
 <body>
 <!--[if lt IE 7]><p class=chromeframe>Your browser is <em>ancient!</em> <a href="http://mozilla.org/firefox">Upgrade to a modern version of Firefox</a> to experience this site.</p><![endif]-->
-  <div class="navbar navbar-fixed-top navbar-inverse" role="navigation">
+  <div class="navbar navbar-fixed-top navbar-default" role="navigation">
     <div class="container-fluid">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle" data-toggle="collapse"

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -28,10 +28,7 @@ from plinth import package as package_module
 
 def index(request):
     """Serve the main index page."""
-    if request.user.is_authenticated():
-        return HttpResponseRedirect(reverse('apps:index'))
-
-    return HttpResponseRedirect(reverse('help:about'))
+    return HttpResponseRedirect(reverse('apps:index'))
 
 
 class PackageInstallView(TemplateView):


### PR DESCRIPTION
As discussed in issue #72 and during one of the progress calls, this merge request simplifies the look of Plinth to that it can become the front page for FreedomBox.  It also makes the look much more flatter to make it resemble a modern web page rather than a GUI application.