### PR TITLE
Fixes for user dropdown menu when javascript is disabled

### DIFF
--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -122,6 +122,13 @@
                 Log in</a>
             {% endif %}
           </li>
+	  {% if user.is_authenticated %}
+          <li id="logout_nojs">
+            <a href="{% url 'users:logout' %}" title="Log out">
+              <i class="glyphicon glyphicon-remove-circle nav-icon"></i>
+              Log out</a>
+          </li>
+          {% endif %}
         </ul>
 
       {% endblock %}
@@ -176,6 +183,12 @@
   <script type="text/javascript" src="{% static '/javascript/jquery/jquery.min.js' %}"></script>
   <!-- Local link to system Bootstrap JS -->
   <script type="text/javascript" src="{% static '/javascript/bootstrap/js/bootstrap.min.js' %}"></script>
+  <!-- Hide log out button if user dropdown is available -->
+  <script type="text/javascript">
+    (function($) {
+      $("#logout_nojs").hide();
+    })(jQuery);
+  </script>
 
   {% block app_js %}<!-- placeholder for app-specific js files -->{% endblock %}
   {% block page_js %}<!-- placeholder for page-specific js files -->{% endblock %}

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -102,7 +102,8 @@
           </li>
           <li class="dropdown">
             {% if user.is_authenticated %}
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown"
+              <a href="{% url 'users:edit' user.username %}"
+                 class="dropdown-toggle" data-toggle="dropdown"
                  role="button" aria-expanded="false">
                 <i class="glyphicon glyphicon-user nav-icon"></i>
                 {{ user.username }}
@@ -122,12 +123,12 @@
                 Log in</a>
             {% endif %}
           </li>
-	  {% if user.is_authenticated %}
-          <li id="logout_nojs">
-            <a href="{% url 'users:logout' %}" title="Log out">
-              <i class="glyphicon glyphicon-remove-circle nav-icon"></i>
-              Log out</a>
-          </li>
+          {% if user.is_authenticated %}
+            <li id="logout_nojs">
+              <a href="{% url 'users:logout' %}" title="Log out">
+                <i class="glyphicon glyphicon-remove-circle nav-icon"></i>
+                Log out</a>
+            </li>
           {% endif %}
         </ul>
 


### PR DESCRIPTION
I suggest the following changes to fix #134:
1. Add a Log out button to the right of the user dropdown menu. Hide the button using javascript (if enabled). So the button will only be shown when javascript is disabled.
2. Add a link from the user dropdown button to the user's edit page. If javascript is enabled, the button will function as a dropdown menu, otherwise it is just a link.