### PR TITLE
Network manager glib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 # Debian packages required
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install network-manager python3-dbus python3-gi
+  - sudo apt-get install python3-dbus python3-gi
 
 virtualenv:
   system_site_packages: true

--- a/INSTALL
+++ b/INSTALL
@@ -7,7 +7,8 @@
     $ sudo apt-get install libjs-jquery libjs-modernizr libjs-bootstrap \
     make pandoc python3 python3-cherrypy3 python3-coverage \
     python3-django python3-bootstrapform python3-gi \
-    python3-setuptools python3-yaml gir1.2-packagekitglib-1.0
+    python3-setuptools python3-yaml gir1.2-glib-2.0 gir1.2-networkmanager-1.0 \
+    gir1.2-packagekitglib-1.0
 
 2. Install Plinth:
 

--- a/data/etc/plinth/modules-enabled/networks
+++ b/data/etc/plinth/modules-enabled/networks
@@ -1,0 +1,1 @@
+plinth.modules.networks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cherrypy >= 3.0
 coverage >= 3.7
 django >= 1.7.0
-python-networkmanager
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,6 @@ setuptools.setup(
         'cherrypy >= 3.0',
         'django >= 1.7.0',
         'django-bootstrap-form',
-        'python-networkmanager',
         'pyyaml',
     ],
     tests_require=['coverage >= 3.7'],


### PR DESCRIPTION
This fixes #124.  This pull request makes Plinth use libnm (introduced with network-manager 1.0) with gobject-introspection instead of python-networkmanager.  The reasons have been highlighted in original issue.  Since all the required dependencies are now avialable, this pull request also enables networks modules.

There is one known issue: trying to retrieve ip_address during edit connection results in a segfault.  This is most likely an issue with python3-gi or libnm.  So, for now, showing earlier set IP address has been disabled.  Setting a new one works.  I believe we can still merge this with this small issue present.