### PR TITLE
ikiwiki: Require some Recommends needed to compile wikis.

### DIFF
--- a/plinth/modules/ikiwiki/forms.py
+++ b/plinth/modules/ikiwiki/forms.py
@@ -32,7 +32,7 @@ class IkiwikiForm(forms.Form):
 
 class IkiwikiCreateForm(forms.Form):
     """Form to create a wiki or blog."""
-    type = forms.ChoiceField(
+    site_type = forms.ChoiceField(
         label=_('Type'),
         choices=[('wiki', 'Wiki'), ('blog', 'Blog')])
 

--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -46,6 +46,9 @@ def on_install():
 
 @login_required
 @package.required(['ikiwiki',
+                   'gcc',
+                   'libc6-dev',
+                   'libtimedate-perl',
                    'libcgi-formbuilder-perl',
                    'libcgi-session-perl'],
                   on_install=on_install)

--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -116,11 +116,11 @@ def create(request):
     if request.method == 'POST':
         form = IkiwikiCreateForm(request.POST, prefix='ikiwiki')
         if form.is_valid():
-            if form.cleaned_data['type'] == 'wiki':
+            if form.cleaned_data['site_type'] == 'wiki':
                 _create_wiki(request, form.cleaned_data['name'],
                              form.cleaned_data['admin_name'],
                              form.cleaned_data['admin_password'])
-            elif form.cleaned_data['type'] == 'blog':
+            elif form.cleaned_data['site_type'] == 'blog':
                 _create_blog(request, form.cleaned_data['name'],
                              form.cleaned_data['admin_name'],
                              form.cleaned_data['admin_password'])


### PR DESCRIPTION
I built and tested a plinth v0.4.5 package in a VM, and found that ikiwiki's wiki setup was failing due to some missing packages. These are listed as Recommends instead of Depends for ikiwiki. I'm not sure why that is, but this change adds them to the required packages list for ikiwiki.