### PR TITLE
xmpp: Add setup for ejabberd and jwchat

### DIFF
--- a/actions/xmpp
+++ b/actions/xmpp
@@ -47,6 +47,9 @@ def parse_arguments():
         '--domainname',
         help='The domain name that will be used by the XMPP service.')
 
+    # Setup jwchat apache conf
+    subparsers.add_parser('setup', help='Setup jwchat apache conf')
+
     # Prepare ejabberd for hostname change
     pre_hostname_change = subparsers.add_parser(
         'pre-change-hostname',
@@ -101,6 +104,13 @@ def subcommand_pre_install(arguments):
     subprocess.check_output(
         ['debconf-set-selections'],
         input=b'jwchat jwchat/ApacheServerName string ' + domainname.encode())
+
+
+def subcommand_setup(_):
+    """Setup jwchat apache conf"""
+    subprocess.call(['a2dissite', 'jwchat'])
+    subprocess.call(['a2enconf', 'jwchat-plinth'])
+    subprocess.call(['service', 'apache2', 'reload'])
 
 
 def subcommand_pre_change_hostname(arguments):

--- a/actions/xmpp
+++ b/actions/xmpp
@@ -39,6 +39,14 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
+    # Preseed debconf values before packages are installed.
+    pre_install = subparsers.add_parser(
+        'pre-install',
+        help='Preseed debconf values before packages are installed.')
+    pre_install.add_argument(
+        '--domainname',
+        help='The domain name that will be used by the XMPP service.')
+
     # Prepare ejabberd for hostname change
     pre_hostname_change = subparsers.add_parser(
         'pre-change-hostname',
@@ -78,6 +86,21 @@ def parse_arguments():
                           help='Password for the new user account')
 
     return parser.parse_args()
+
+
+def subcommand_pre_install(arguments):
+    """Preseed debconf values before packages are installed."""
+    domainname = arguments.domainname.strip("'")
+    if not domainname:
+        # If new domainname is blank, use hostname instead.
+        domainname = socket.gethostname()
+
+    subprocess.check_output(
+        ['debconf-set-selections'],
+        input=b'ejabberd ejabberd/hostname string ' + domainname.encode())
+    subprocess.check_output(
+        ['debconf-set-selections'],
+        input=b'jwchat jwchat/ApacheServerName string ' + domainname.encode())
 
 
 def subcommand_pre_change_hostname(arguments):

--- a/data/etc/apache2/conf-available/jwchat-plinth.conf
+++ b/data/etc/apache2/conf-available/jwchat-plinth.conf
@@ -1,0 +1,12 @@
+Alias /jwchat /usr/share/jwchat/www
+
+<Directory /usr/share/jwchat/www>
+    Options +Indexes +Multiviews +FollowSymLinks
+</Directory>
+
+# proxy for BOSH server
+ProxyPass /http-bind/ http://localhost:5280/http-bind/
+ProxyPassReverse /http-bind/ http://localhost:5280/http-bind/
+<Proxy http://localhost:5280/http-bind/*>
+    Allow from all
+</Proxy>

--- a/plinth/modules/xmpp/xmpp.py
+++ b/plinth/modules/xmpp/xmpp.py
@@ -61,8 +61,17 @@ def init():
     domainname_change.connect(on_domainname_change)
 
 
+def before_install():
+    """Preseed debconf values before the packages are installed."""
+    fqdn = socket.getfqdn()
+    domainname = '.'.join(fqdn.split('.')[1:])
+    LOGGER.info('XMPP service domainname will be ', domainname)
+    actions.superuser_run('xmpp', ['pre-install', '--domainname', domainname])
+
+
 @login_required
-@package.required(['jwchat', 'ejabberd'])
+@package.required(['jwchat', 'ejabberd'],
+                  before_install=before_install)
 def index(request):
     """Serve XMPP page"""
     return TemplateResponse(request, 'xmpp.html',

--- a/plinth/modules/xmpp/xmpp.py
+++ b/plinth/modules/xmpp/xmpp.py
@@ -22,6 +22,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.template.response import TemplateResponse
 from gettext import gettext as _
 import logging
+import socket
 
 from plinth import actions
 from plinth import cfg
@@ -65,7 +66,7 @@ def before_install():
     """Preseed debconf values before the packages are installed."""
     fqdn = socket.getfqdn()
     domainname = '.'.join(fqdn.split('.')[1:])
-    LOGGER.info('XMPP service domainname will be ', domainname)
+    LOGGER.info('XMPP service domainname will be ' + domainname)
     actions.superuser_run('xmpp', ['pre-install', '--domainname', domainname])
 
 

--- a/plinth/modules/xmpp/xmpp.py
+++ b/plinth/modules/xmpp/xmpp.py
@@ -70,9 +70,15 @@ def before_install():
     actions.superuser_run('xmpp', ['pre-install', '--domainname', domainname])
 
 
+def on_install():
+    """Setup jwchat apache conf"""
+    actions.superuser_run('xmpp', ['setup'])
+
+
 @login_required
 @package.required(['jwchat', 'ejabberd'],
-                  before_install=before_install)
+                  before_install=before_install,
+                  on_install=on_install)
 def index(request):
     """Serve XMPP page"""
     return TemplateResponse(request, 'xmpp.html',

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -56,6 +56,8 @@ class PackageInstallView(TemplateView):
         Start the package installation, and refresh the page every x seconds to
         keep displaying PackageInstallView.get() with the installation status.
         """
-        package_module.start_install(self.kwargs['package_names'],
-                                     on_install=self.kwargs.get('on_install'))
+        package_module.start_install(
+            self.kwargs['package_names'],
+            before_install=self.kwargs.get('before_install'),
+            on_install=self.kwargs.get('on_install'))
         return self.render_to_response(self.get_context_data())


### PR DESCRIPTION
This change adds setup for ejabberd and jwchat. It should remove the need to install / setup these packages in freedombox-setup.

I added a before_install handler to the @package.required decorator as suggested in #130. It's used to set debconf values before ejabberd and jwchat are installed.

I also added an apache conf file for jwchat (copied from freedombox-setup) that is installed with plinth, and then enabled after jwchat is installed.