### PR TITLE
Use the cherrypy autoreload feature only in debug mode

### DIFF
--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -96,7 +96,10 @@ def setup_server():
     cherrypy.config.update(
         {'server.socket_host': cfg.host,
          'server.socket_port': cfg.port,
-         'server.thread_pool': 10})
+         'server.thread_pool': 10,
+         # Avoid stating files once per second in production
+         'engine.autoreload.on': cfg.debug,
+        })
 
     application = django.core.wsgi.get_wsgi_application()
     cherrypy.tree.graft(application, cfg.server_dir)


### PR DESCRIPTION
Small devices like the raspberry pi end up eating a number of resources (~20%
of the CPU according to top, even more if something else is increasing the
load, together with tor they eat ~70% of the cpu "on idle" ~50% for plinth
and ~20% for tor) stat the files once per second.