### PR TITLE
ikiwiki and deluge cleanups

### DIFF
--- a/actions/deluge
+++ b/actions/deluge
@@ -78,9 +78,7 @@ def parse_arguments():
 def subcommand_setup(_):
     """Perform first time setup operations."""
     setup()
-    start()
-    subprocess.check_call(['a2enconf', 'deluge-plinth'])
-    subprocess.check_call(['service', 'apache2', 'reload'])
+    enable()
 
 
 def subcommand_get_enabled(_):
@@ -94,16 +92,12 @@ def subcommand_get_enabled(_):
 
 def subcommand_enable(_):
     """Enable deluge-web site and start deluge-web."""
-    start()
-    subprocess.check_call(['a2enconf', 'deluge-plinth'])
-    subprocess.check_call(['service', 'apache2', 'reload'])
+    enable()
 
 
 def subcommand_disable(_):
     """Disable deluge-web site and stop deluge-web."""
-    subprocess.check_call(['a2disconf', 'deluge-plinth'])
-    subprocess.check_call(['service', 'apache2', 'reload'])
-    stop()
+    disable()
 
 
 def subcommand_is_running(_):
@@ -122,14 +116,20 @@ def subcommand_is_running(_):
         print('yes' if running else 'no')
 
 
-def start():
+def enable():
     """Start and enable deluge-web service."""
     subprocess.check_call(['systemctl', 'enable', 'deluge-web'])
     subprocess.check_call(['systemctl', 'start', 'deluge-web'])
 
+    subprocess.check_call(['a2enconf', 'deluge-plinth'])
+    subprocess.check_call(['service', 'apache2', 'reload'])
 
-def stop():
+
+def disable():
     """Stop and disable deluge-web service."""
+    subprocess.check_call(['a2disconf', 'deluge-plinth'])
+    subprocess.check_call(['service', 'apache2', 'reload'])
+
     try:
         subprocess.check_output(['systemctl', 'stop', 'deluge-web'])
         subprocess.check_output(['systemctl', 'disable', 'deluge-web'])

--- a/actions/deluge
+++ b/actions/deluge
@@ -55,6 +55,9 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
+    # Setup deluge-web
+    subparsers.add_parser('setup', help='Perform first time setup operations.')
+
     # Get whether deluge-web site is enabled
     subparsers.add_parser('get-enabled',
                           help='Get whether deluge-web site is enabled')
@@ -72,6 +75,14 @@ def parse_arguments():
     return parser.parse_args()
 
 
+def subcommand_setup(_):
+    """Perform first time setup operations."""
+    setup()
+    start()
+    subprocess.check_call(['a2enconf', 'deluge-plinth'])
+    subprocess.check_call(['service', 'apache2', 'reload'])
+
+
 def subcommand_get_enabled(_):
     """Get whether deluge-web site is enabled."""
     if os.path.isfile(APACHE_CONF_ENABLED_PATH) and \
@@ -83,8 +94,6 @@ def subcommand_get_enabled(_):
 
 def subcommand_enable(_):
     """Enable deluge-web site and start deluge-web."""
-    setup()
-
     start()
     subprocess.check_call(['a2enconf', 'deluge-plinth'])
     subprocess.check_call(['service', 'apache2', 'reload'])

--- a/actions/deluge
+++ b/actions/deluge
@@ -26,19 +26,7 @@ import os
 import subprocess
 
 
-APACHE_CONF_PATH = '/etc/apache2/conf-available/deluge-web.conf'
-APACHE_CONF_ENABLED_PATH = '/etc/apache2/conf-enabled/deluge-web.conf'
-APACHE_CONF = '''
-##
-## On all sites, provide Deluge on a default path: /deluge
-##
-## This file is managed and overwritten by Plinth.  If you wish to edit
-## it, disable Deluge in Plinth, remove this file and manage it manually.
-##
-<Location /deluge>
-        ProxyPass http://localhost:8112
-</Location>
-'''
+APACHE_CONF_ENABLED_PATH = '/etc/apache2/conf-enabled/deluge-plinth.conf'
 
 SYSTEMD_SERVICE_PATH = '/etc/systemd/system/deluge-web.service'
 SYSTEMD_SERVICE = '''
@@ -98,13 +86,13 @@ def subcommand_enable(_):
     setup()
 
     start()
-    subprocess.check_call(['a2enconf', 'deluge-web'])
+    subprocess.check_call(['a2enconf', 'deluge-plinth'])
     subprocess.check_call(['service', 'apache2', 'reload'])
 
 
 def subcommand_disable(_):
     """Disable deluge-web site and stop deluge-web."""
-    subprocess.check_call(['a2disconf', 'deluge-web'])
+    subprocess.check_call(['a2disconf', 'deluge-plinth'])
     subprocess.check_call(['service', 'apache2', 'reload'])
     stop()
 
@@ -140,11 +128,7 @@ def stop():
 
 
 def setup():
-    """Perform initial setup for deluge-web site."""
-    if not os.path.isfile(APACHE_CONF_PATH):
-        with open(APACHE_CONF_PATH, 'w') as conffile:
-            conffile.write(APACHE_CONF)
-
+    """Perform initial setup for deluge-web."""
     if not os.path.isfile(SYSTEMD_SERVICE_PATH):
         with open(SYSTEMD_SERVICE_PATH, 'w') as file_handle:
             file_handle.write(SYSTEMD_SERVICE)

--- a/actions/deluge
+++ b/actions/deluge
@@ -123,15 +123,16 @@ def subcommand_is_running(_):
 
 
 def start():
-    """Start deluge-web."""
+    """Start and enable deluge-web service."""
     subprocess.check_call(['systemctl', 'enable', 'deluge-web'])
     subprocess.check_call(['systemctl', 'start', 'deluge-web'])
 
 
 def stop():
-    """Stop deluge-web."""
+    """Stop and disable deluge-web service."""
     try:
         subprocess.check_output(['systemctl', 'stop', 'deluge-web'])
+        subprocess.check_output(['systemctl', 'disable', 'deluge-web'])
     except subprocess.CalledProcessError:
         pass
 

--- a/actions/ikiwiki
+++ b/actions/ikiwiki
@@ -82,9 +82,10 @@ def subcommand_setup(_):
 
 def subcommand_get_enabled(_):
     """Get whether ikiwiki site is enabled."""
-    if os.path.isfile(CONFIG_ENABLE):
+    try:
+        subprocess.check_output(['a2query', '-c', 'ikiwiki-plinth'])
         print('yes')
-    else:
+    except subprocess.CalledProcessError:
         print('no')
 
 

--- a/actions/ikiwiki
+++ b/actions/ikiwiki
@@ -246,6 +246,7 @@ def setup():
     with open(SETUP_BLOG, 'w') as setupfile:
         setupfile.writelines(ikiwiki_setup_automator_blog)
 
+    subprocess.check_call(['a2enconf', 'ikiwiki'])
     subprocess.check_call(['service', 'apache2', 'restart'])
 
 

--- a/actions/ikiwiki
+++ b/actions/ikiwiki
@@ -26,93 +26,12 @@ import shutil
 import subprocess
 
 
-CONFIG_ENABLE = '/etc/apache2/conf-enabled/ikiwiki.conf'
-CONFIG_FILE = '/etc/apache2/conf-available/ikiwiki.conf'
+CONFIG_ENABLE = '/etc/apache2/conf-enabled/ikiwiki-plinth.conf'
 SETUP_WIKI = '/etc/ikiwiki/plinth-wiki.setup'
 SETUP_BLOG = '/etc/ikiwiki/plinth-blog.setup'
 SITE_PATH = '/var/www/ikiwiki'
 WIKI_PATH = '/var/lib/ikiwiki'
 
-apache_cgi_configuration = '''
-Alias /ikiwiki /var/www/ikiwiki
-AddHandler cgi-script .cgi
-
-<Directory /var/www/ikiwiki>
-    Options +ExecCGI
-</Directory>
-'''
-
-ikiwiki_setup_automator = '''
-#!/usr/bin/perl
-# Ikiwiki setup automator for Plinth.
-
-require IkiWiki::Setup::Automator;
-
-our $wikiname=$ARGV[0];
-our $admin=$ARGV[1];
-if (($wikiname eq "") || ($admin eq "")) {
-	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-wiki.setup wiki_name admin_name";
-	exit;
-}
-
-our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname($wikiname);
-
-IkiWiki::Setup::Automator->import(
-	wikiname => $wikiname,
-	adminuser => [$admin],
-	rcs => "git",
-	srcdir => "/var/lib/ikiwiki/$wikiname_short",
-	destdir => "/var/www/ikiwiki/$wikiname_short",
-	repository => "/var/lib/ikiwiki/$wikiname_short.git",
-	dumpsetup => "/var/lib/ikiwiki/$wikiname_short.setup",
-	url => "/ikiwiki/$wikiname_short",
-	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",
-	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",
-	add_plugins => [qw{goodstuff websetup httpauth}],
-	rss => 1,
-	atom => 1,
-	syslog => 1,
-)
-'''
-
-ikiwiki_setup_automator_blog = '''
-#!/usr/bin/perl
-# Ikiwiki setup automator for Plinth (blog version).
-
-require IkiWiki::Setup::Automator;
-
-our $wikiname=$ARGV[0];
-our $admin=$ARGV[1];
-if (($wikiname eq "") || ($admin eq "")) {
-	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-blog.setup blog_name admin_name";
-	exit;
-}
-
-our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname($wikiname);
-
-IkiWiki::Setup::Automator->import(
-	wikiname => $wikiname,
-	adminuser => [$admin],
-	rcs => "git",
-	srcdir => "/var/lib/ikiwiki/$wikiname_short",
-	destdir => "/var/www/ikiwiki/$wikiname_short",
-	repository => "/var/lib/ikiwiki/$wikiname_short.git",
-	dumpsetup => "/var/lib/ikiwiki/$wikiname_short.setup",
-	url => "/ikiwiki/$wikiname_short",
-	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",
-	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",
-	add_plugins => [qw{goodstuff websetup comments calendar sidebar trail httpauth}],
-	rss => 1,
-	atom => 1,
-	syslog => 1,
-	example => "blog",
-	comments_pagespec => "posts/* and !*/Discussion",
-	archive_pagespec => "page(posts/*) and !*/Discussion",
-	global_sidebars => 0,
-	discussion => 0,
-	tagbase => "tags",
-)
-'''
 
 def parse_arguments():
     """Return parsed command line arguments as dictionary."""
@@ -171,13 +90,13 @@ def subcommand_get_enabled(_):
 
 def subcommand_enable(_):
     """Enable ikiwiki site."""
-    subprocess.check_call(['a2enconf', 'ikiwiki'])
+    subprocess.check_call(['a2enconf', 'ikiwiki-plinth'])
     subprocess.check_call(['service', 'apache2', 'reload'])
 
 
 def subcommand_disable(_):
     """Disable ikiwiki site."""
-    subprocess.check_call(['a2disconf', 'ikiwiki'])
+    subprocess.check_call(['a2disconf', 'ikiwiki-plinth'])
     subprocess.check_call(['service', 'apache2', 'reload'])
 
 
@@ -236,17 +155,7 @@ def setup():
         os.makedirs(SITE_PATH)
 
     subprocess.check_call(['a2enmod', 'cgi'])
-
-    with open(CONFIG_FILE, 'w') as conffile:
-        conffile.write(apache_cgi_configuration)
-
-    with open(SETUP_WIKI, 'w') as setupfile:
-        setupfile.writelines(ikiwiki_setup_automator)
-
-    with open(SETUP_BLOG, 'w') as setupfile:
-        setupfile.writelines(ikiwiki_setup_automator_blog)
-
-    subprocess.check_call(['a2enconf', 'ikiwiki'])
+    subprocess.check_call(['a2enconf', 'ikiwiki-plinth'])
     subprocess.check_call(['service', 'apache2', 'restart'])
 
 

--- a/data/etc/apache2/conf-available/deluge-plinth.conf
+++ b/data/etc/apache2/conf-available/deluge-plinth.conf
@@ -1,0 +1,6 @@
+##
+## On all sites, provide Deluge on a default path: /deluge
+##
+<Location /deluge>
+        ProxyPass http://localhost:8112
+</Location>

--- a/data/etc/apache2/conf-available/ikiwiki-plinth.conf
+++ b/data/etc/apache2/conf-available/ikiwiki-plinth.conf
@@ -1,0 +1,6 @@
+Alias /ikiwiki /var/www/ikiwiki
+AddHandler cgi-script .cgi
+
+<Directory /var/www/ikiwiki>
+    Options +ExecCGI
+</Directory>

--- a/data/etc/ikiwiki/plinth-blog.setup
+++ b/data/etc/ikiwiki/plinth-blog.setup
@@ -1,0 +1,36 @@
+#!/usr/bin/perl
+# Ikiwiki setup automator for Plinth (blog version).
+
+require IkiWiki::Setup::Automator;
+
+our $wikiname=$ARGV[0];
+our $admin=$ARGV[1];
+if (($wikiname eq "") || ($admin eq "")) {
+	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-blog.setup blog_name admin_name";
+	exit;
+}
+
+our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname($wikiname);
+
+IkiWiki::Setup::Automator->import(
+	wikiname => $wikiname,
+	adminuser => [$admin],
+	rcs => "git",
+	srcdir => "/var/lib/ikiwiki/$wikiname_short",
+	destdir => "/var/www/ikiwiki/$wikiname_short",
+	repository => "/var/lib/ikiwiki/$wikiname_short.git",
+	dumpsetup => "/var/lib/ikiwiki/$wikiname_short.setup",
+	url => "/ikiwiki/$wikiname_short",
+	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",
+	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",
+	add_plugins => [qw{goodstuff websetup comments calendar sidebar trail httpauth}],
+	rss => 1,
+	atom => 1,
+	syslog => 1,
+	example => "blog",
+	comments_pagespec => "posts/* and !*/Discussion",
+	archive_pagespec => "page(posts/*) and !*/Discussion",
+	global_sidebars => 0,
+	discussion => 0,
+	tagbase => "tags",
+)

--- a/data/etc/ikiwiki/plinth-wiki.setup
+++ b/data/etc/ikiwiki/plinth-wiki.setup
@@ -1,0 +1,30 @@
+#!/usr/bin/perl
+# Ikiwiki setup automator for Plinth.
+
+require IkiWiki::Setup::Automator;
+
+our $wikiname=$ARGV[0];
+our $admin=$ARGV[1];
+if (($wikiname eq "") || ($admin eq "")) {
+	print "Usage: ikiwiki -setup /etc/ikiwiki/plinth-wiki.setup wiki_name admin_name";
+	exit;
+}
+
+our $wikiname_short=IkiWiki::Setup::Automator::sanitize_wikiname($wikiname);
+
+IkiWiki::Setup::Automator->import(
+	wikiname => $wikiname,
+	adminuser => [$admin],
+	rcs => "git",
+	srcdir => "/var/lib/ikiwiki/$wikiname_short",
+	destdir => "/var/www/ikiwiki/$wikiname_short",
+	repository => "/var/lib/ikiwiki/$wikiname_short.git",
+	dumpsetup => "/var/lib/ikiwiki/$wikiname_short.setup",
+	url => "/ikiwiki/$wikiname_short",
+	cgiurl => "/ikiwiki/$wikiname_short/ikiwiki.cgi",
+	cgi_wrapper => "/var/www/ikiwiki/$wikiname_short/ikiwiki.cgi",
+	add_plugins => [qw{goodstuff websetup httpauth}],
+	rss => 1,
+	atom => 1,
+	syslog => 1,
+)

--- a/plinth/modules/deluge/__init__.py
+++ b/plinth/modules/deluge/__init__.py
@@ -21,10 +21,14 @@ Plinth module to configure a Deluge web client.
 
 from gettext import gettext as _
 
+from plinth import actions
 from plinth import cfg
+from plinth import service as service_module
 
 
 depends = ['plinth.modules.apps']
+
+service = None
 
 
 def init():
@@ -32,3 +36,11 @@ def init():
     menu = cfg.main_menu.get('apps:index')
     menu.add_urlname(_('BitTorrent (Deluge)'), 'glyphicon-magnet',
                      'deluge:index', 60)
+
+    output = actions.run('deluge', ['get-enabled'])
+    enabled = (output.strip() == 'yes')
+
+    global service
+    service = service_module.Service(
+        'deluge', _('Deluge BitTorrent'), ['http', 'https'],
+        is_external=True, enabled=enabled)

--- a/plinth/modules/deluge/views.py
+++ b/plinth/modules/deluge/views.py
@@ -27,6 +27,7 @@ from gettext import gettext as _
 from .forms import DelugeForm
 from plinth import actions
 from plinth import package
+from plinth.modules import deluge
 
 
 def on_install():
@@ -79,6 +80,7 @@ def _apply_changes(request, old_status, new_status):
     if old_status['enabled'] != new_status['enabled']:
         sub_command = 'enable' if new_status['enabled'] else 'disable'
         actions.superuser_run('deluge', [sub_command])
+        deluge.service.notify_enabled(None, new_status['enabled'])
         modified = True
 
     if modified:

--- a/plinth/modules/deluge/views.py
+++ b/plinth/modules/deluge/views.py
@@ -29,8 +29,13 @@ from plinth import actions
 from plinth import package
 
 
+def on_install():
+    """Setup deluge-web on install."""
+    actions.superuser_run('deluge', ['setup'])
+
+
 @login_required
-@package.required(['deluged', 'deluge-web'])
+@package.required(['deluged', 'deluge-web'], on_install=on_install)
 def index(request):
     """Serve configuration page."""
     status = get_status()

--- a/plinth/modules/ikiwiki/__init__.py
+++ b/plinth/modules/ikiwiki/__init__.py
@@ -21,10 +21,14 @@ Plinth module to configure ikiwiki
 
 from gettext import gettext as _
 
+from plinth import actions
 from plinth import cfg
+from plinth import service as service_module
 
 
 depends = ['plinth.modules.apps']
+
+service = None
 
 
 def init():
@@ -32,3 +36,11 @@ def init():
     menu = cfg.main_menu.get('apps:index')
     menu.add_urlname(_('Wiki & Blog (Ikiwiki)'), 'glyphicon-edit',
                      'ikiwiki:index', 38)
+
+    output = actions.run('ikiwiki', ['get-enabled'])
+    enabled = (output.strip() == 'yes')
+
+    global service
+    service = service_module.Service(
+        'ikiwiki', _('ikiwiki wikis and blogs'), ['http', 'https'],
+        is_external=True, enabled=enabled)

--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -29,6 +29,7 @@ from gettext import gettext as _
 from .forms import IkiwikiForm, IkiwikiCreateForm
 from plinth import actions
 from plinth import package
+from plinth.modules import ikiwiki
 
 
 subsubmenu = [{'url': reverse_lazy('ikiwiki:index'),
@@ -88,6 +89,7 @@ def _apply_changes(request, old_status, new_status):
     if old_status['enabled'] != new_status['enabled']:
         sub_command = 'enable' if new_status['enabled'] else 'disable'
         actions.superuser_run('ikiwiki', [sub_command])
+        ikiwiki.service.notify_enabled(None, new_status['enabled'])
         modified = True
 
     if modified:

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,8 @@ setuptools.setup(
                  glob.glob('data/etc/apache2/conf-available/*.conf')),
                 ('/etc/apache2/sites-available',
                  glob.glob('data/etc/apache2/sites-available/*.conf')),
+                ('/etc/ikiwiki',
+                 glob.glob('data/etc/ikiwiki/*.setup')),
                 ('/etc/sudoers.d', ['data/etc/sudoers.d/plinth']),
                 ('/lib/systemd/system',
                  ['data/lib/systemd/system/plinth.service']),


### PR DESCRIPTION
Here are some cleanups for the ikiwiki and deluge modules:
- Enable these services during their initial setup (which is run after packages are installed).
- Move conf files under data/, and install them during Plinth install.
- Notify when services are enabled/disabled to update firewall page.
- Minor refactoring