### PR TITLE
Issue 88: First timezone shown when no timezone set

### DIFF
--- a/plinth/modules/config/config.py
+++ b/plinth/modules/config/config.py
@@ -153,7 +153,11 @@ def get_status():
 def get_current_timezone():
     """Get current timezone"""
     timezone = open('/etc/timezone').read().rstrip()
-    return timezone or 'none'
+
+    if timezone in ConfigurationForm.get_time_zones():
+        return timezone
+
+    return 'none'
 
 
 def _apply_changes(request, old_status, new_status):


### PR DESCRIPTION
#161 #177 When no timezone is set, by default,  first one is shown. Coded solution is to check if the /etc/timezone is not in list of timezones, show the default message ("----No timezone set-----").