### PR TITLE
Tor setup in Plinth instead of freedombox-setup

### DIFF
--- a/actions/tor
+++ b/actions/tor
@@ -39,6 +39,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
+    subparsers.add_parser('setup', help='Setup Tor configuration')
     subparsers.add_parser('enable', help='Enable and start Tor service')
     subparsers.add_parser('disable', help='Disable and stop Tor service')
     subparsers.add_parser('get-hs', help='Get hidden service')
@@ -47,6 +48,37 @@ def parse_arguments():
     subparsers.add_parser('get-ports', help='Get list of Tor ports')
 
     return parser.parse_args()
+
+
+def subcommand_setup(_):
+    """Setup Tor configuration after installing it."""
+    # XXX: Performing this as a post-install step instead of
+    # pre-install setup for now.  Creating a configuration before hand
+    # leads dpkg to ask question about configuration overwrite which
+    # makes aptcc backend of packagekit to wait forever even with
+    # interactive=False.
+    lines = """
+# Run as non-exit bridge relay
+SocksPort 0.0.0.0:9050
+ORPort auto
+ControlPort 9051
+BridgeRelay 1
+Exitpolicy reject *:*
+
+# Enable obfsproxy
+ServerTransportPlugin obfs3,scramblesuit exec /usr/bin/obfsproxy managed
+ExtORPort auto
+
+# Enable transparent proxy
+VirtualAddrNetworkIPv4 10.192.0.0/10
+AutomapHostsOnResolve 1
+TransPort 127.0.0.1:9040
+DNSPort 127.0.0.1:9053
+"""
+    with open(TOR_CONFIG, 'w') as conffile:
+        conffile.writelines(lines)
+
+    action_utils.service_restart('tor')
 
 
 def subcommand_enable(_):

--- a/actions/tor
+++ b/actions/tor
@@ -59,11 +59,13 @@ def subcommand_setup(_):
     # interactive=False.
     lines = """
 # Run as non-exit bridge relay
+SocksPort [::]:9050
 SocksPort 0.0.0.0:9050
 ORPort auto
 ControlPort 9051
 BridgeRelay 1
 Exitpolicy reject *:*
+Exitpolicy reject6 *:*
 
 # Enable obfsproxy
 ServerTransportPlugin obfs3,scramblesuit exec /usr/bin/obfsproxy managed
@@ -73,7 +75,9 @@ ExtORPort auto
 VirtualAddrNetworkIPv4 10.192.0.0/10
 AutomapHostsOnResolve 1
 TransPort 127.0.0.1:9040
+TransPort [::1]:9040
 DNSPort 127.0.0.1:9053
+DNSPort [::1]:9053
 """
     with open(TOR_CONFIG, 'w') as conffile:
         conffile.writelines(lines)

--- a/plinth/modules/tor/tor.py
+++ b/plinth/modules/tor/tor.py
@@ -50,7 +50,12 @@ def init():
                      'tor:index', 100)
 
 
-@package.required(['tor'])
+def on_install():
+    """Setup Tor configuration as soon as it is installed."""
+    actions.superuser_run('tor', ['setup'])
+
+
+@package.required(['tor', 'obfsproxy'], on_install=on_install)
 def index(request):
     """Service the index page"""
     status = get_status()

--- a/plinth/package.py
+++ b/plinth/package.py
@@ -263,7 +263,8 @@ def _should_show_install_view(request, package_names):
         return False
     else:
         messages.error(request, _('Error installing packages: {details}')
-                       .format(details=exception.error_string))
+                       .format(details=getattr(exception, 'error_string',
+                                               str(exception))))
         return True
 
 


### PR DESCRIPTION
This pull request sets up Tor after installation instead of in freedombox-setup.  We can now remove Tor code from freedomxbox-setup.

Also enabled IPv6 for Tor.

Minor fix during packages installation.