### PR TITLE
Add Bookmarks (Shaarli) module.

### DIFF
--- a/actions/shaarli
+++ b/actions/shaarli
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for Shaarli.
+"""
+
+import argparse
+
+from plinth import action_utils
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    subparsers.add_parser('enable', help='Enable shaarli site')
+    subparsers.add_parser('disable', help='Disable shaarli site')
+
+    return parser.parse_args()
+
+
+def subcommand_enable(_):
+    """Enable shaarli site."""
+    action_utils.webserver_enable('shaarli')
+
+
+def subcommand_disable(_):
+    """Disable shaarli site."""
+    action_utils.webserver_disable('shaarli')
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/data/etc/plinth/modules-enabled/shaarli
+++ b/data/etc/plinth/modules-enabled/shaarli
@@ -1,0 +1,1 @@
+plinth.modules.shaarli

--- a/plinth/modules/shaarli/__init__.py
+++ b/plinth/modules/shaarli/__init__.py
@@ -1,0 +1,48 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure Shaarli.
+"""
+
+from gettext import gettext as _
+
+from plinth import action_utils
+from plinth import cfg
+from plinth import service as service_module
+
+
+depends = ['plinth.modules.apps']
+
+service = None
+
+
+def init():
+    """Initialize the Shaarli module."""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(_('Bookmarks (Shaarli)'), 'glyphicon-bookmark',
+                     'shaarli:index', 350)
+
+    global service
+    service = service_module.Service(
+        'shaarli', _('Shaarli'), ['http', 'https'],
+        is_external=True, enabled=is_enabled())
+
+
+def is_enabled():
+    """Return whether the module is enabled."""
+    return action_utils.webserver_is_enabled('shaarli')

--- a/plinth/modules/shaarli/forms.py
+++ b/plinth/modules/shaarli/forms.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for configuring Shaarli.
+"""
+
+from django import forms
+from gettext import gettext as _
+
+
+class ShaarliForm(forms.Form):
+    """Shaarli configuration form."""
+    enabled = forms.BooleanField(
+        label=_('Enable Shaarli'),
+        required=False)

--- a/plinth/modules/shaarli/templates/shaarli.html
+++ b/plinth/modules/shaarli/templates/shaarli.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+
+{% block content %}
+
+<h2>Bookmarks (Shaarli)</h2>
+
+<p>Shaarli allows you to save and share bookmarks.</p>
+
+<p>When enabled, Shaarli will be available from <a href="/shaarli">/shaarli</a>
+  path on the web server. Note that Shaarli only supports a single user
+  account, which you will need to setup on the initial visit.<p>
+
+<h3>Configuration</h3>
+
+<form class="form" method="post">
+  {% csrf_token %}
+
+  {{ form|bootstrap }}
+
+  <input type="submit" class="btn btn-primary" value="Update setup"/>
+</form>
+
+{% endblock %}

--- a/plinth/modules/shaarli/urls.py
+++ b/plinth/modules/shaarli/urls.py
@@ -1,0 +1,28 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the Shaarli module.
+"""
+
+from django.conf.urls import patterns, url
+
+
+urlpatterns = patterns(
+    'plinth.modules.shaarli.views',
+    url(r'^apps/shaarli/$', 'index', name='index'),
+)

--- a/plinth/modules/shaarli/views.py
+++ b/plinth/modules/shaarli/views.py
@@ -1,0 +1,73 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure Shaarli.
+"""
+
+from django.contrib import messages
+from django.template.response import TemplateResponse
+from gettext import gettext as _
+
+from .forms import ShaarliForm
+from plinth import actions
+from plinth import package
+from plinth.modules import shaarli
+
+
+@package.required(['shaarli'])
+def index(request):
+    """Serve configuration page."""
+    status = get_status()
+
+    form = None
+
+    if request.method == 'POST':
+        form = ShaarliForm(request.POST, prefix='shaarli')
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = ShaarliForm(initial=status, prefix='shaarli')
+    else:
+        form = ShaarliForm(initial=status, prefix='shaarli')
+
+    return TemplateResponse(request, 'shaarli.html',
+                            {'title': _('Bookmarks (Shaarli)'),
+                             'status': status,
+                             'form': form})
+
+
+def get_status():
+    """Get the current settings."""
+    status = {'enabled': shaarli.is_enabled()}
+    return status
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        sub_command = 'enable' if new_status['enabled'] else 'disable'
+        actions.superuser_run('shaarli', [sub_command])
+        shaarli.service.notify_enabled(None, new_status['enabled'])
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))


### PR DESCRIPTION
This adds a module to install and configure Shaarli, a web app for creating and sharing bookmarks.

One major limitation is that it only supports a single user account, which is created during the first visit to the app.