### PR TITLE
Fix issue with Apache configuration

### DIFF
--- a/data/etc/apache2/sites-available/plinth.conf
+++ b/data/etc/apache2/sites-available/plinth.conf
@@ -7,7 +7,7 @@
 ##   mod_proxy_http
 ##
 <Location /plinth>
-    ProxyPass        http://localhost:8000/plinth
+    ProxyPass        http://127.0.0.1:8000/plinth
     ## Send the scheme from user's request to enable Plinth to redirect
     ## URLs, set cookies, set absolute URLs (if any) properly.
     RequestHeader    set X-Forwarded-Proto 'https' env=HTTPS


### PR DESCRIPTION
I faced a situation that my localhost address resolved to an IPv6 address and
Apache was unable to connect to Plinth as Plinth does not yet listen on
IPv6 address.  It is best to change this to an explict local IP address
at least until Plinth listens on IPv6 address.