### PR TITLE
Apply workaround to ssl config for mod_gnutls.

### DIFF
--- a/data/etc/apache2/sites-available/plinth-ssl.conf
+++ b/data/etc/apache2/sites-available/plinth-ssl.conf
@@ -6,10 +6,11 @@
 ##
 ## Requires the following Apache modules to be enabled:
 ##   mod_rewrite
-##   mod_ssl
+##   mod_gnutls
 ##
 <Location /plinth>
     RewriteEngine on
-    ReWriteCond %{HTTPS} !=on
+    # workaround for mod_gnutls (Debian Bug #514005)
+    RewriteCond %{SERVER_PORT} !^443$
     RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </Location>


### PR DESCRIPTION
We will need to switch from mod_ssl to mod_gnutls to (eventually) enable PGP client certificate authentication (https://wiki.debian.org/FreedomBox/ConfiguringModGnuTLS). I'm working on a patch to freedombox-setup to make this switch.

However there's an old open issue in mod_gnutls, where the HTTPS environment variable is not set properly by mod_gnutls (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=514005). This leads to a redirect loop for plinth.

This patch works around the issue by checking the SERVER_PORT variable instead of HTTPS. You can test it with mod_gnutls with the following setup:
```
a2dismod ssl
a2dissite default-ssl
apt install -y libapache2-mod-gnutls
a2enmod gnutls
a2ensite default-tls
service apache2 restart
```