### PR TITLE
upgrades: Move Origins-Pattern configuration to separate file installed by plinth.

### DIFF
--- a/actions/upgrades
+++ b/actions/upgrades
@@ -26,7 +26,6 @@ import re
 import subprocess
 import sys
 
-CONF_FILE = '/etc/apt/apt.conf.d/50unattended-upgrades'
 AUTO_CONF_FILE = '/etc/apt/apt.conf.d/20auto-upgrades'
 
 
@@ -53,13 +52,6 @@ def parse_arguments():
 
 def subcommand_run(_):
     """Run unattended-upgrades"""
-    try:
-        setup()
-    except FileNotFoundError:
-        print('Error: Could not configure unattended-upgrades.',
-              file=sys.stderr)
-        sys.exit(1)
-
     try:
         output = subprocess.check_output(['unattended-upgrades', '-v'])
     except FileNotFoundError:
@@ -92,13 +84,6 @@ def subcommand_check_auto(_):
 
 def subcommand_enable_auto(_):
     """Enable automatic upgrades"""
-    try:
-        setup()
-    except FileNotFoundError:
-        print('Error: Could not configure unattended-upgrades.',
-              file=sys.stderr)
-        sys.exit(1)
-
     with open(AUTO_CONF_FILE, 'w') as conffile:
         conffile.write('APT::Periodic::Update-Package-Lists "1";\n')
         conffile.write('APT::Periodic::Unattended-Upgrade "1";\n')
@@ -110,22 +95,6 @@ def subcommand_disable_auto(_):
         os.rename(AUTO_CONF_FILE, AUTO_CONF_FILE + '.disabled')
     except FileNotFoundError:
         print('Already disabled.')
-
-
-def setup():
-    """Sets unattended-upgrades config to upgrade any package from Debian."""
-    with open(CONF_FILE, 'r') as conffile:
-        lines = conffile.readlines()
-
-    for line in lines:
-        if re.match(r'\s*"o(rigin)?=Debian";', line):
-            return  # already configured
-
-    with open(CONF_FILE, 'w') as conffile:
-        for line in lines:
-            conffile.write(line)
-            if re.match(r'\s*Unattended-Upgrade::Origins-Pattern\s+{', line):
-                conffile.write('        "origin=Debian";\n')
 
 
 def main():

--- a/data/etc/apt/apt.conf.d/51freedombox-upgrades
+++ b/data/etc/apt/apt.conf.d/51freedombox-upgrades
@@ -1,0 +1,4 @@
+// Upgrade any packages from Debian.
+Unattended-Upgrade::Origins-Pattern {
+        "origin=Debian";
+};

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,8 @@ setuptools.setup(
                  glob.glob('data/etc/apache2/conf-available/*.conf')),
                 ('/etc/apache2/sites-available',
                  glob.glob('data/etc/apache2/sites-available/*.conf')),
+                ('/etc/apt/apt.conf.d',
+                 ['data/etc/apt/apt.conf.d/51freedombox-upgrades']),
                 ('/etc/ikiwiki',
                  glob.glob('data/etc/ikiwiki/*.setup')),
                 ('/etc/sudoers.d', ['data/etc/sudoers.d/plinth']),


### PR DESCRIPTION
This will avoid the conffile prompt when upgrading unattended-upgrades.