### PR TITLE
Adds missing calls to service.notify_enabled() from on_install handlers.

### DIFF
--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -43,6 +43,7 @@ subsubmenu = [{'url': reverse_lazy('ikiwiki:index'),
 def on_install():
     """Enable Ikiwiki on install."""
     actions.superuser_run('ikiwiki', ['setup'])
+    ikiwiki.service.notify_enabled(None, True)
 
 
 @package.required(['ikiwiki',

--- a/plinth/modules/privoxy/views.py
+++ b/plinth/modules/privoxy/views.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 def on_install():
     """Notify that the service is now enabled."""
     actions.superuser_run('privoxy', ['setup'])
+    privoxy.service.notify_enabled(None, True)
 
 
 @package.required(['privoxy'], on_install=on_install)

--- a/plinth/modules/transmission/views.py
+++ b/plinth/modules/transmission/views.py
@@ -39,6 +39,7 @@ TRANSMISSION_CONFIG = '/etc/transmission-daemon/settings.json'
 def on_install():
     """Enable transmission as soon as it is installed."""
     actions.superuser_run('transmission', ['enable'])
+    transmission.service.notify_enabled(None, True)
 
 
 @package.required(['transmission-daemon'], on_install=on_install)

--- a/plinth/modules/xmpp/views.py
+++ b/plinth/modules/xmpp/views.py
@@ -50,6 +50,7 @@ def before_install():
 def on_install():
     """Setup jwchat apache conf"""
     actions.superuser_run('xmpp', ['setup'])
+    xmpp.service.notify_enabled(None, True)
 
 
 @package.required(['jwchat', 'ejabberd'],


### PR DESCRIPTION
Fixes https://github.com/freedombox/Plinth/issues/175
"Many services do not show as enabled in Firewall after install"