### PR TITLE
 News Feed Reader (Tiny Tiny RSS)

### DIFF
--- a/actions/ttrss
+++ b/actions/ttrss
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for News Feed Reader (Tiny Tiny RSS)
+"""
+import argparse
+
+from plinth import action_utils
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    subparsers.add_parser('enable', help='Enable Tiny Tiny RSS')
+    subparsers.add_parser('disable', help='Disable Tiny Tiny RSS')
+
+    return parser.parse_args()
+
+
+def subcommand_enable(_):
+    """Enable web configuration and reload."""
+    action_utils.webserver_enable('50-tt-rss')
+
+
+def subcommand_disable(_):
+    """Disable web configuration and reload."""
+    action_utils.webserver_disable('50-tt-rss')
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/data/etc/plinth/modules-enabled/ttrss
+++ b/data/etc/plinth/modules-enabled/ttrss
@@ -1,0 +1,1 @@
+plinth.modules.ttrss

--- a/plinth/modules/ttrss/__init__.py
+++ b/plinth/modules/ttrss/__init__.py
@@ -1,0 +1,46 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure Tiny Tiny RSS
+"""
+
+from gettext import gettext as _
+
+from plinth import cfg
+from plinth import action_utils
+
+def init():
+    """Intialize  Tiny Tiny RSS module."""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(_('News Feed Reader (Tiny Tiny RSS)'), 'glyphicon-envelope',
+                     'ttrss:index', 600)
+
+depends = ['plinth.modules.apps']
+
+def is_enabled():
+    """Return whether the module is enabled."""
+    return action_utils.webserver_is_enabled('50-tt-rss')
+
+def diagnose():
+    """Run diagnostics and return the results."""
+    results = []
+
+    results.extend(action_utils.diagnose_url_on_all(
+        'https://{host}/ttrss', extra_options=['--no-check-certificate']))
+
+    return results

--- a/plinth/modules/ttrss/forms.py
+++ b/plinth/modules/ttrss/forms.py
@@ -1,0 +1,28 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for configuring Tiny Tiny RSS
+"""
+
+from django import forms
+
+class TtrssForm(forms.Form):
+    """Tiny Tiny RSS configuration form."""
+    enabled = forms.BooleanField(
+        label='Enable Tiny Tiny RSS',
+        required=False)

--- a/plinth/modules/ttrss/templates/ttrss.html
+++ b/plinth/modules/ttrss/templates/ttrss.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+
+{% load bootstrap %}
+
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% block content %}
+
+<h2>News Feed Reader (Tiny Tiny RSS)</h2>
+
+<p>Tiny Tiny RSS is a news feed (RSS/Atom) reader and aggregator,
+  designed to allow you to read news from any location, while feeling
+  as close to a real desktop application as possible.</p>
+
+{% include "diagnostics_button.html" with module="ttrss" %}
+
+<h3>Configuration</h3>
+
+<form class="form" method="post">
+  {% csrf_token %}
+
+  {{ form|bootstrap }}
+
+  <input type="submit" class="btn btn-primary" value="Update setup"/>
+</form>
+
+{% endblock %}

--- a/plinth/modules/ttrss/urls.py
+++ b/plinth/modules/ttrss/urls.py
@@ -1,0 +1,28 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the ttrss module
+"""
+
+from django.conf.urls import patterns, url
+
+
+urlpatterns = patterns( 
+    'plinth.modules.ttrss.views',
+    url(r'^apps/ttrss/$', 'index', name='index'),
+    )

--- a/plinth/modules/ttrss/views.py
+++ b/plinth/modules/ttrss/views.py
@@ -1,0 +1,77 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module for configuring News Feed Reader (Tiny Tiny RSS)
+"""
+
+from django.contrib import messages
+from django.template.response import TemplateResponse
+from gettext import gettext as _
+import logging
+
+from plinth import actions
+from plinth import package
+from plinth.modules import ttrss
+from .forms import TtrssForm
+
+logger = logging.getLogger(__name__)
+
+
+@package.required(['tt-rss'])
+def index(request):
+    """Serve configuration page."""
+    status = get_status()
+
+    form = None
+
+    if request.method == 'POST':
+        form = TtrssForm(request.POST, prefix='ttrss')
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = TtrssForm(initial=status, prefix='ttrss')
+    else:
+        form = TtrssForm(initial=status, prefix='ttrss')
+
+    return TemplateResponse(request, 'ttrss.html',
+                            {'title': _('News Feed Reader (Tiny Tiny RSS)'),
+                             'status': status,
+                             'form': form})
+
+def get_status():
+    """Get the current status."""
+    return {'enabled': ttrss.is_enabled()}
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        sub_command = 'enable' if new_status['enabled'] else 'disable'
+        actions.superuser_run('ttrss', [sub_command])
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))
+
+
+
+


### PR DESCRIPTION
Support for tt-rss is now available in plinth. Right now we are not able to configure database automatically, One way to configure is as follows:
giving this command "dpkg-reconfigure tt-rss".

Rest everything is working fine.