### PR TITLE
Added explicit port setting to pagekite configuration

### DIFF
--- a/actions/pagekite
+++ b/actions/pagekite
@@ -52,6 +52,9 @@ def parse_arguments():
     subparsers.add_parser('start-and-enable', help='Enable PageKite service')
     subparsers.add_parser('stop-and-disable', help='Disable PageKite service')
     subparsers.add_parser('restart', help='Restart PageKite service')
+    subparsers.add_parser('is-disabled',
+                          help=('Wether PageKite is disabled in the file '
+                                '/etc/pagekite.d/10_accounts.rc'))
 
     # Frontend
     subparsers.add_parser('get-frontend', help='Get pagekite frontend')
@@ -84,6 +87,13 @@ def subcommand_restart(_):
     """Restart the pagekite service"""
     action_utils.service_restart('pagekite')
     print('restarted')
+
+
+def subcommand_is_disabled(_):
+    if aug.match(PATHS['abort_not_configured']):
+        print('true')
+    else:
+        print('false')
 
 
 def subcommand_start_and_enable(_):

--- a/actions/pagekite
+++ b/actions/pagekite
@@ -112,7 +112,8 @@ def subcommand_get_frontend(_):
 
 def subcommand_set_frontend(arguments):
     """Set pagekite frontend url, taking care of defaults and pagekite.net"""
-    if arguments.url in ('pagekite.net', 'defaults', 'default'):
+    frontend_domain = arguments.url.split(':')[0]
+    if frontend_domain in ('pagekite.net', 'defaults', 'default'):
         enable_pagekitenet_frontend()
     else:
         aug.remove(PATHS['defaults'])

--- a/plinth/modules/pagekite/forms.py
+++ b/plinth/modules/pagekite/forms.py
@@ -45,12 +45,14 @@ class ConfigurationForm(forms.Form):
 
     enabled = forms.BooleanField(label=_('Enable PageKite'), required=False)
 
-    server = forms.CharField(
-        label=_('Server'), required=False,
-        help_text=_('Select your pagekite.net server. Set "pagekite.net" to '
+    server_domain = forms.CharField(
+        label=_('Server domain'), required=False,
+        help_text=_('Select your pagekite server. Set "pagekite.net" to '
                     'use the default pagekite.net server'),
         widget=forms.TextInput())
-
+    server_port = forms.IntegerField(
+        label=_('Server port'), required=False,
+        help_text=_('Port of your pagekite server (default: 80)'))
     kite_name = TrimmedCharField(
         label=_('Kite name'),
         help_text=_('Example: mybox.pagekite.me'),
@@ -79,8 +81,10 @@ for your account if no secret is set on the kite'))
                 messages.success(request, _('Kite details set'))
                 config_changed = True
 
-            if old['server'] != new['server']:
-                utils.run(['set-frontend', new['server']])
+            if old['server_domain'] != new['server_domain'] or \
+                    old['server_port'] != new['server_port']:
+                server = "%s:%s" % (new['server_domain'], new['server_port'])
+                utils.run(['set-frontend', server])
                 messages.success(request, _('Pagekite server set'))
                 config_changed = True
 

--- a/plinth/modules/pagekite/templates/pagekite_configure.html
+++ b/plinth/modules/pagekite/templates/pagekite_configure.html
@@ -30,7 +30,8 @@
     <div id='pagekite-post-enabled-form'
          style='display: {{ form.enabled.value|yesno:'block,none' }};'>
       <h3>PageKite Account</h3>
-      {{ form.server|bootstrap_horizontal }}
+      {{ form.server_domain|bootstrap_horizontal }}
+      {{ form.server_port|bootstrap_horizontal }}
       {{ form.kite_name|bootstrap_horizontal }}
       {{ form.kite_secret|bootstrap_horizontal }}
 

--- a/plinth/modules/pagekite/utils.py
+++ b/plinth/modules/pagekite/utils.py
@@ -91,8 +91,12 @@ def get_pagekite_config():
     status = {}
 
     # PageKite service enabled/disabled
-    # This assumes that if pagekite is running it's also enabled as a service
-    status['enabled'] = action_utils.service_is_running('pagekite')
+    # To enable PageKite two things are necessary:
+    # 1) pagekite not being disabled in /etc/pagekite.d/10_account.rc
+    # 2) the pagekite service running
+    is_disabled = run(['is-disabled']).strip()=='true'
+    service_running = action_utils.service_is_running('pagekite')
+    status['enabled'] = service_running and not is_disabled
 
     # PageKite kite details
     status.update(get_kite_details())

--- a/plinth/modules/pagekite/utils.py
+++ b/plinth/modules/pagekite/utils.py
@@ -99,7 +99,15 @@ def get_pagekite_config():
 
     # PageKite frontend server
     server = run(['get-frontend'])
-    status['server'] = server.replace('\n', '')
+    # Frontend-Entries are only considered valid if there's a ':' in them
+    # otherwise, pagekite refuses to work, and we only set values with ':'.
+    if ':' in server:
+        server_domain, server_port = server.strip().split(':')
+        status['server_domain'] = server_domain
+        status['server_port'] = server_port
+    else:
+        # no valid entry exists, default to port 80
+        status['server_port'] = 80
 
     return status
 


### PR DESCRIPTION
This fixes #180 

*update*
I added a fix for #179 (I think), the `abort_not_configured` line not being removed from `10_accounts.rc`:
The reason was that Plinth thought that pagekite is enabled when the service is running. But additionally to that it's necessary that the `abort_not_configured` line does not exist, which we check now.