### PR TITLE
Remove references to removed TODO file (GH: #245)

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -10,7 +10,6 @@ otherwise.
 - INSTALL :: -
 - plinth.config :: -
 - README :: -
-- TODO :: -
 - data/etc/apache2/plinth.conf :: -
 - data/etc/apache2/plinth-ssl.conf :: -
 - data/etc/sudoers.d/plinth :: -

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include TODO doc/TODO.mdwn


### PR DESCRIPTION
Removed MANIFEST.in as it contains only TODO file.  Removed TODO reference from LICENSES file.

I checked that there are no more references to TODO file. `./setup.py sdist` does not give any warnings.