### PR TITLE
Require library version for GObject introspection

### DIFF
--- a/plinth/modules/networks/forms.py
+++ b/plinth/modules/networks/forms.py
@@ -20,6 +20,8 @@ from django.core import validators
 from gettext import gettext as _
 
 from plinth import network
+import gi
+gi.require_version('NM', '1.0')
 from gi.repository import NM as nm
 
 

--- a/plinth/network.py
+++ b/plinth/network.py
@@ -20,7 +20,10 @@ Helper functions for working with network manager.
 """
 
 import collections
+import gi
+gi.require_version('GLib', '2.0')
 from gi.repository import GLib as glib
+gi.require_version('NM', '1.0')
 from gi.repository import NM as nm
 import logging
 import socket

--- a/plinth/package.py
+++ b/plinth/package.py
@@ -22,7 +22,10 @@ Framework for installing and updating distribution packages
 from django.contrib import messages
 import functools
 from gettext import gettext as _
+import gi
+gi.require_version('GLib', '2.0')
 from gi.repository import GLib as glib
+gi.require_version('PackageKitGlib', '1.0')
 from gi.repository import PackageKitGlib as packagekit
 import logging
 import threading


### PR DESCRIPTION
Specify the version of a library before importing it using GObject
introspection.  Mainly to avoid warnings with recent version of
pygobject.  Closes #247.