### PR TITLE
datetime: Fix triggering install callback

### DIFF
--- a/plinth/modules/datetime/views.py
+++ b/plinth/modules/datetime/views.py
@@ -37,7 +37,7 @@ def on_install():
     datetime.service.notify_enabled(None, True)
 
 
-@package.required(['ntp'])
+@package.required(['ntp'], on_install=on_install)
 def index(request):
     """Serve configuration page."""
     status = get_status()


### PR DESCRIPTION
Fixes #219 .  Trigger on_install in datetime module after install.

I noticed an unexpected outcome of placing timezone configuration in datetime module: We can set the timezone without having ntp installed.  It may not be such a bad thing as we don't allow uninstall and ntp is installed by default.  We only allow disabling which is fine.