### PR TITLE
Require older version of coverage for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ virtualenv:
   system_site_packages: true
 
 # Command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - pip install coverage==3.7
+  - pip install -r requirements.txt
 
 # Command to run tests
 script: python3 setup.py test


### PR DESCRIPTION
@BobGirard , you are right about latest version of coverage causing the problem.  However, instead of upgrading Python version (which is still not possible for us unfortunately), I have installed particular coverage version.  Please review this change.

This patch installs coverage 3.7 instead of latest coverage 4.0 on
Travis before a build. Coverage 4.0 does not support Python 3.2.  Due to
need for system-installed, python-dependency packages and due to Travis
infrastructure using Ubuntu 12.04, we can only build on Python 3.2 in
Travis.

