### PR TITLE
Layout and description changes; removed the word 'Plinth' from the UI

### DIFF
--- a/data/etc/plinth/plinth.config
+++ b/data/etc/plinth/plinth.config
@@ -1,7 +1,3 @@
-[Name]
-product_name = Plinth
-box_name = FreedomBox
-
 [Path]
 # directory locations
 file_root = /usr/share/plinth
@@ -39,6 +35,7 @@ use_x_forwarded_host = True
 secure_proxy_ssl_header = HTTP_X_FORWARDED_PROTO
 
 [Misc]
+box_name = FreedomBox
 # The danube_edition changes the firstboot process and offers entering a
 # voucher for a freedombox.me sub-domain. This functionality requires
 # additional debian packages to be installed:

--- a/plinth.config
+++ b/plinth.config
@@ -1,7 +1,3 @@
-[Name]
-product_name = Plinth
-box_name = FreedomBox
-
 [Path]
 # directory locations
 file_root = %(root)s
@@ -39,6 +35,7 @@ use_x_forwarded_host = True
 secure_proxy_ssl_header = HTTP_X_FORWARDED_PROTO
 
 [Misc]
+box_name = FreedomBox
 # The danube_edition changes the firstboot process and offers entering a
 # voucher for a freedombox.me sub-domain. This functionality requires
 # additional debian packages to be installed:

--- a/plinth/cfg.py
+++ b/plinth/cfg.py
@@ -20,7 +20,6 @@ import os
 
 from plinth.menu import Menu
 
-product_name = None
 box_name = None
 root = None
 file_root = None
@@ -67,9 +66,7 @@ def read():
         })
     parser.read(CONFIG_FILE)
 
-    config_items = {('Name', 'product_name', 'string'),
-                    ('Name', 'box_name', 'string'),
-                    ('Path', 'root', 'string'),
+    config_items = {('Path', 'root', 'string'),
                     ('Path', 'file_root', 'string'),
                     ('Path', 'config_dir', 'string'),
                     ('Path', 'data_dir', 'string'),
@@ -84,6 +81,7 @@ def read():
                     ('Network', 'port', 'int'),
                     ('Network', 'secure_proxy_ssl_header', 'string'),
                     ('Network', 'use_x_forwarded_host', 'bool'),
+                    ('Misc', 'box_name', 'string'),
                     ('Misc', 'danube_edition', 'bool')}
 
     for section, name, datatype in config_items:

--- a/plinth/modules/apps/templates/apps.html
+++ b/plinth/modules/apps/templates/apps.html
@@ -20,12 +20,12 @@
 
 {% block content %}
 
-<h2>Apps</h2>
+<h2>Services and Applications</h2>
 
-<p>User Applications are web apps hosted on your
-{{ cfg.product_name }}.</p>
+<p>You can install and run various services and applications on your
+{{ cfg.box_name }}.</p>
 
-<p>Eventually this box could be your photo sharing site, your instant
+<p>This box can be your photo sharing site, your instant
 messaging site, your social networking site, your news site.  Remember
 web portals?  We can be one of those too.  Many of the services you
 use on the web could soon be on site and under your control!</p>

--- a/plinth/modules/system/templates/system.html
+++ b/plinth/modules/system/templates/system.html
@@ -20,12 +20,11 @@
 
 {% block content %}
 
-<h2>System</h2>
+<h2>System Configuration</h2>
 
-<p>In this section, you can control the {{ cfg.product_name }}'s
-underlying system, as opposed to its various applications and
-services.  These options affect the {{ cfg.product_name }} at its most
-general level.  This is where you add/remove users, install
-applications, reboot, etc.</p>
+<p>Here you can administrate the underlying system of your {{ cfg.box_name }}.
+</p>
+<p>The options affect the {{ cfg.box_name }} at its most
+general level, so be careful!</p>
 
 {% endblock %}

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -98,7 +98,7 @@
 
           {% if user.is_authenticated %}
             <li>
-              <a href="{% url 'system:index' %}" title="Configuration">
+              <a href="{% url 'system:index' %}" title="System Configuration">
                 <span class="glyphicon-cog glyphicon nav-icon"></span>
               </a>
             </li>

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -84,7 +84,7 @@
         <a href="{% url 'index' %}" class="navbar-brand" title="Applications">
           <img src="{% static 'theme/img/freedombox-logo-32px.png' %}"
                alt="FreedomBox" />
-          FreedomBox
+          Applications
         </a>
       </div>
       <div class="collapse navbar-collapse">

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -81,7 +81,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a href="{% url 'index' %}" class="navbar-brand">
+        <a href="{% url 'index' %}" class="navbar-brand" title="Applications">
           <img src="{% static 'theme/img/freedombox-logo-32px.png' %}"
                alt="FreedomBox" />
           FreedomBox
@@ -91,14 +91,14 @@
       {% block add_nav_and_login %}
         <ul class="nav navbar-nav navbar-right">
           <li>
-            <a href="{% url 'help:index' %}">
+            <a href="{% url 'help:index' %}" title="Help">
               <span class="glyphicon-question-sign glyphicon nav-icon"></span>
             </a>
           </li>
 
           {% if user.is_authenticated %}
             <li>
-              <a href="{% url 'system:index' %}">
+              <a href="{% url 'system:index' %}" title="Configuration">
                 <span class="glyphicon-cog glyphicon nav-icon"></span>
               </a>
             </li>

--- a/plinth/tests/data/plinth.config.with_missing_options
+++ b/plinth/tests/data/plinth.config.with_missing_options
@@ -1,5 +1,4 @@
-[Name]
-product_name = Plinth
+[Misc]
 box_name = FreedomBox
 
 [Path]

--- a/plinth/tests/data/plinth.config.with_missing_sections
+++ b/plinth/tests/data/plinth.config.with_missing_sections
@@ -1,4 +1,3 @@
-[Name]
-product_name = Plinth
+[Misc]
 box_name = FreedomBox
 

--- a/plinth/tests/test_cfg.py
+++ b/plinth/tests/test_cfg.py
@@ -198,10 +198,6 @@ class CfgTestCase(unittest.TestCase):
         """Compare two sets of configuration values."""
         # Note that the count of items within each section includes the number
         # of default items (1, for 'root').
-        self.assertEqual(3, len(parser.items('Name')))
-        self.assertEqual(parser.get('Name', 'product_name'), cfg.product_name)
-        self.assertEqual(parser.get('Name', 'box_name'), cfg.box_name)
-
         self.assertEqual(13, len(parser.items('Path')))
         self.assertEqual(parser.get('Path', 'root'), cfg.root)
         self.assertEqual(parser.get('Path', 'file_root'), cfg.file_root)
@@ -225,8 +221,10 @@ class CfgTestCase(unittest.TestCase):
         self.assertIsInstance(cfg.use_x_forwarded_host, bool)
         self.assertEqual(parser.get('Network', 'use_x_forwarded_host'),
                          str(cfg.use_x_forwarded_host))
+        self.assertEqual(3, len(parser.items('Misc')))
         self.assertEqual(parser.get('Misc', 'danube_edition'),
                          str(cfg.danube_edition))
+        self.assertEqual(parser.get('Misc', 'box_name'), cfg.box_name)
 
     def read_temp_config_file(self, test_file):
         """Read the specified test configuration file."""

--- a/plinth/tests/test_context_processors.py
+++ b/plinth/tests/test_context_processors.py
@@ -40,7 +40,6 @@ class ContextProcessorsTestCase(TestCase):
 
         config = response['cfg']
         self.assertIsNotNone(config)
-        self.assertEqual('Plinth', config.product_name)
         self.assertEqual('FreedomBox', config.box_name)
 
         submenu = response['submenu']


### PR DESCRIPTION
- added titles to the main menu items (visible in many browsers when hovering the link [w/o js])
- adapted the descriptions of the main section landing pages
- changed the menu item from 'FreedomBox' to 'Applications' because I think it's misleading, and hoping that 'Applications' fits better. We can re-introduce the 'FreedomBox' menu item when we have a 'proper landing page' (thinking about the dashboard).
- removed `cfg.product_name` (Plinth). I do no think that users should be shown this name, so I removed it and adapted the tests. In every place where it was used, 'FreedomBox' was the more appropriate term instead of 'Plinth'.
- removed the `[Name]` section and moved `cfg.box_name` to `[Misc]`, because `cfg.box_name` was the  only item left in there.

Feel free to pick only some of my commits if others are too controversial and should be discussed first.