### PR TITLE
Added reStore module/application

### DIFF
--- a/actions/restore
+++ b/actions/restore
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for reStore.
+"""
+
+import argparse
+
+from plinth import action_utils
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    subparsers.add_parser('enable', help='Enable reStore')
+    subparsers.add_parser('disable', help='Disable reStore')
+
+    return parser.parse_args()
+
+
+def subcommand_enable(_):
+    """Enable reStore."""
+    action_utils.service_enable('node-restore')
+
+
+def subcommand_disable(_):
+    """Disable reStore."""
+    action_utils.service_disable('node-restore')
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/data/etc/plinth/modules-enabled/restore
+++ b/data/etc/plinth/modules-enabled/restore
@@ -1,0 +1,1 @@
+plinth.modules.restore

--- a/plinth/modules/restore/__init__.py
+++ b/plinth/modules/restore/__init__.py
@@ -1,0 +1,47 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module to configure reStore
+"""
+
+from gettext import gettext as _
+from plinth import action_utils, cfg
+from plinth import service as service_module
+
+service = None
+
+__all__ = ['init']
+
+depends = ['plinth.modules.apps']
+
+
+def init():
+    """Initialize the reStore module"""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(_('Unhosted storage (reStore)'), 'glyphicon-hdd',
+                     'restore:index', 750)
+
+    global service
+    service = service_module.Service(
+        'node-restore', _('reStore'),
+        is_external=False, enabled=is_enabled())
+
+
+def is_enabled():
+    """Return whether the module is enabled."""
+    return action_utils.service_is_enabled('node-restore')

--- a/plinth/modules/restore/forms.py
+++ b/plinth/modules/restore/forms.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for configuring reStore.
+"""
+
+from django import forms
+from gettext import gettext as _
+
+
+class ReStoreForm(forms.Form):
+    """reStore configuration form."""
+    enabled = forms.BooleanField(
+        label=_('Enable reStore'),
+        required=False)

--- a/plinth/modules/restore/templates/restore_index.html
+++ b/plinth/modules/restore/templates/restore_index.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+
+{% block content %}
+
+<h2>reStore</h2>
+<p>reStore is a server for <a href='https://unhosted.org/'>unhosted</a>
+web applications.  The idea is to uncouple web applications from the
+data, and thus the data can be stored on any unhosted storage server.</p>
+
+<p>You can create and edit accounts in the
+<a href='/restore/'>reStore web-interface</a>.</p>
+
+<h3>Configuration</h3>
+
+<form class="form" method="post">
+  {% csrf_token %}
+
+  {{ form|bootstrap }}
+
+  <input type="submit" class="btn btn-primary" value="Update setup"/>
+</form>
+
+{% endblock %}

--- a/plinth/modules/restore/urls.py
+++ b/plinth/modules/restore/urls.py
@@ -1,0 +1,29 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the reStore module
+"""
+
+from django.conf.urls import patterns, url
+from .views import index
+
+
+urlpatterns = patterns(
+    'plinth.modules.restore.views',
+    url(r'^apps/restore/$', index, name='index')
+)

--- a/plinth/modules/restore/views.py
+++ b/plinth/modules/restore/views.py
@@ -1,0 +1,67 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from django.contrib import messages
+from django.template.response import TemplateResponse
+from gettext import gettext as _
+
+from .forms import ReStoreForm
+from plinth import actions, package
+from plinth.modules import restore
+
+
+@package.required(['node-restore'])
+def index(request):
+    """Serve configuration page."""
+
+    status = get_status()
+
+    if request.method == 'POST':
+        form = ReStoreForm(request.POST, prefix='restore')
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = ReStoreForm(initial=status, prefix='restore')
+    else:
+        form = ReStoreForm(initial=status, prefix='restore')
+
+    return TemplateResponse(request, 'restore_index.html',
+                            {'title': _('Unhosted storage (reStore)'),
+                             'status': status,
+                             'form': form})
+
+
+def get_status():
+    """Get the current settings."""
+    status = {'enabled': restore.is_enabled()}
+    return status
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        sub_command = 'enable' if new_status['enabled'] else 'disable'
+        actions.superuser_run('restore', [sub_command])
+        restore.service.notify_enabled(None, new_status['enabled'])
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))


### PR DESCRIPTION
reStore is a server for unhosted web applications (https://unhosted.org/). The idea is to uncouple web applications from the data, and thus the data can be stored on any unhosted storage server.

reStore does not support ldap, so freedombox users have to create an account via the web interface that comes with the reStore package.