### PR TITLE
fixes #263

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-% Plinth User Manual
-
 [![Build Status](https://travis-ci.org/freedombox/Plinth.svg?branch=master)](https://travis-ci.org/freedombox/Plinth)
 
 # Introduction
 
 ## Name
 
-plinth - a web front end for administering FreedomBox
+[Plinth](https://wiki.debian.org/FreedomBox/Plinth) - a web front end for administering [FreedomBox](https://freedomboxfoundation.org/)
 
 ## Description
 
-FreedomBox is a community project to develop, design and promote
+[FreedomBox](https://freedomboxfoundation.org/) is a community project to develop, design and promote
 personal servers running free software for private, personal
 communications.  It is a networking appliance designed to allow
 interfacing with the rest of the Internet under conditions of
@@ -19,12 +17,12 @@ blog, wiki, website, social network, email, web proxy and a Tor relay
 on a device that can replace your Wi-Fi router so that your data stays
 with you.
 
-Plinth is a web interface to administer the functions of the
-FreedomBox.  It is extensible and provides various applications of
-FreedomBox as modules.  Each module or application provides simplified
-user interface to control the underlying functionality.  As FreedomBox
+[Plinth](https://wiki.debian.org/FreedomBox/Plinth) is a web interface to administer the functions of the
+[FreedomBox](https://freedomboxfoundation.org/).  It is extensible and provides various applications of
+[FreedomBox](https://freedomboxfoundation.org/) as modules.  Each module or application provides simplified
+user interface to control the underlying functionality.  As [FreedomBox](https://freedomboxfoundation.org/)
 can act as a wireless router, it is possible to configure networking
-from Plinth.  Plinth also allows configuration of basic system
+from [Plinth](https://wiki.debian.org/FreedomBox/Plinth).  [Plinth](https://wiki.debian.org/FreedomBox/Plinth) also allows configuration of basic system
 parameters such as time zone, hostname and automatic upgrades.
 
 ## Getting Started


### PR DESCRIPTION
Removes erroneous first line and adds links to Plinth wiki and Freedombox homepage.