### PR TITLE
tor: switch to obfs4proxy

### DIFF
--- a/actions/tor
+++ b/actions/tor
@@ -74,7 +74,7 @@ Exitpolicy reject *:*
 Exitpolicy reject6 *:*
 
 # Enable obfsproxy
-ServerTransportPlugin obfs3,scramblesuit exec /usr/bin/obfsproxy managed
+ServerTransportPlugin obfs3,obfs4 exec /usr/bin/obfs4proxy
 ExtORPort auto
 
 # Enable transparent proxy

--- a/plinth/modules/tor/__init__.py
+++ b/plinth/modules/tor/__init__.py
@@ -61,11 +61,11 @@ def diagnose():
         results.append(action_utils.diagnose_port_listening(ports['obfs3'],
                                                             'tcp4'))
 
-    results.append([_('Scramblesuit transport registered'),
-                    'passed' if 'scramblesuit' in ports else 'failed'])
-    if 'scramblesuit' in ports:
+    results.append([_('Obfs4 transport registered'),
+                    'passed' if 'obfs4' in ports else 'failed'])
+    if 'obfs4' in ports:
         results.append(action_utils.diagnose_port_listening(
-            ports['scramblesuit'], 'tcp4'))
+            ports['obfs4'], 'tcp4'))
 
     results.append(_diagnose_url_via_tor('http://www.debian.org', '4'))
     results.append(_diagnose_url_via_tor('http://www.debian.org', '6'))

--- a/plinth/modules/tor/tor.py
+++ b/plinth/modules/tor/tor.py
@@ -71,7 +71,9 @@ def on_install():
     actions.superuser_run('tor', ['enable-apt-transport-tor'])
 
 
-@package.required(['tor', 'obfsproxy', 'torsocks', 'apt-transport-tor'],
+@package.required(['tor', 'tor-geoipdb', 'torsocks',
+                   'obfs4proxy',
+                   'apt-transport-tor'],
                   on_install=on_install)
 def index(request):
     """Service the index page"""


### PR DESCRIPTION
obfs4proxy supports obfs3 and obfs4 (which replaces scramblesuit).
Also add tor-geoipdb which is useful for bridges.