### PR TITLE
Test on python 3.3 and 3.4 with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,13 @@
 
 language: python
 python:
-  - "3.2"
+  - "3.3.6"
+  - "3.4.3"
 
 # Debian packages required
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install python3-dbus python3-gi gir1.2-packagekitglib-1.0
-
-virtualenv:
-  system_site_packages: true
+  - sudo apt-get install python3-dbus gir1.2-packagekitglib-1.0
 
 # Command to install dependencies
 install:

--- a/plinth/modules/networks/forms.py
+++ b/plinth/modules/networks/forms.py
@@ -20,9 +20,9 @@ from django.core import validators
 from gettext import gettext as _
 
 from plinth import network
-import gi
-gi.require_version('NM', '1.0')
-from gi.repository import NM as nm
+import pgi
+pgi.require_version('NM', '1.0')
+from pgi.repository import NM as nm
 
 
 def _get_interface_choices(device_type):

--- a/plinth/network.py
+++ b/plinth/network.py
@@ -20,11 +20,11 @@ Helper functions for working with network manager.
 """
 
 import collections
-import gi
-gi.require_version('GLib', '2.0')
-from gi.repository import GLib as glib
-gi.require_version('NM', '1.0')
-from gi.repository import NM as nm
+import pgi
+pgi.require_version('GLib', '2.0')
+from pgi.repository import GLib as glib
+pgi.require_version('NM', '1.0')
+from pgi.repository import NM as nm
 import logging
 import socket
 import struct

--- a/plinth/package.py
+++ b/plinth/package.py
@@ -22,11 +22,11 @@ Framework for installing and updating distribution packages
 from django.contrib import messages
 import functools
 from gettext import gettext as _
-import gi
-gi.require_version('GLib', '2.0')
-from gi.repository import GLib as glib
-gi.require_version('PackageKitGlib', '1.0')
-from gi.repository import PackageKitGlib as packagekit
+import pgi
+pgi.require_version('GLib', '2.0')
+from pgi.repository import GLib as glib
+pgi.require_version('PackageKitGlib', '1.0')
+from pgi.repository import PackageKitGlib as packagekit
 import logging
 import threading
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-stronghold
 psutil
 python-augeas
 pyyaml
+pgi >= 0.0.10.1


### PR DESCRIPTION
Python 3.2.x is deprecated, so I thought it would be
good to get tests running on some newer pythons. I've
switched from the python3-gi package to using 'pgi' from
pypi, because the apt-installed python3-gi was having trouble
importing.

pgi requires python 3.3+ (see: https://pypi.python.org/pypi/pgi),
so I've removed python 3.2 from the test matrix. Let me know if
we're using python 3.2 anywhere, but as far as I know plinth is
run on python 3.4.3 with debian sid on the freedombox image.