### PR TITLE
add Dockerfile for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,12 @@
 
 language: python
 python:
-  - "3.2"
+  - "3.4.3"
 
 # Debian packages required
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install python3-dbus python3-gi gir1.2-packagekitglib-1.0
-
-virtualenv:
-  system_site_packages: true
 
 # Command to install dependencies
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+FROM debian:sid
+RUN apt-get update
+# Ignore recommended packages for latex, so the big
+# documentation packages aren't installed.
+RUN apt-get install --no-install-recommends -y dblatex
+RUN apt-get install -y \
+    apache2 \
+    libapache2-mod-gnutls \
+    ntp \
+    privoxy \
+    mumble-server \
+    ejabberd \
+    transmission-daemon \
+    avahi-daemon \
+    augeas-tools \
+    debhelper \
+    dh-buildinfo \
+    ldapscripts \
+    libjs-jquery \
+    libjs-modernizr \
+    libjs-bootstrap \
+    make \
+    gcc \
+    network-manager \
+    nodejs \
+    npm \
+    libjs-ejs \
+    node-ejs \
+    node-redis \
+    ppp \
+    pppoe \
+    python3 \
+    python3-dev \
+    python3-venv \
+    python3-augeas \
+    python3-bootstrapform \
+    python3-cherrypy3 \
+    python3-coverage \
+    python3-django \
+    python3-django-stronghold \
+    python3-gi \
+    python3-psutil \
+    python3-setuptools \
+    python3-yaml \
+    gir1.2-glib-2.0 \
+    gir1.2-networkmanager-1.0 \
+    gir1.2-packagekitglib-1.0 \
+    wget \
+    xmlto
+ENV PYTHONUNBUFFERED 1
+
+# Install node-restore
+RUN wget https://github.com/peacekeeper/debian-node-restore/archive/debian.tar.gz
+RUN tar xzf debian.tar.gz
+WORKDIR debian-node-restore-debian
+RUN dpkg-buildpackage -rfakeroot -uc -b
+RUN dpkg -i ../node-restore_*.deb
+RUN service node-restore restart
+WORKDIR ..
+
+RUN mkdir -p /plinth
+RUN mkdir -p /usr/share/plinth
+COPY actions /usr/share/plinth/
+COPY requirements.txt /plinth/
+RUN pyvenv /plinth/ve
+WORKDIR /plinth
+COPY . /plinth
+RUN /plinth/ve/bin/pip install -r /plinth/requirements.txt
+RUN /plinth/ve/bin/python setup.py install
+RUN a2enmod proxy
+RUN a2enmod proxy_http
+RUN a2enmod rewrite
+RUN a2enmod headers
+RUN a2enmod gnutls
+RUN a2ensite default-tls
+RUN a2ensite plinth
+RUN a2ensite plinth-ssl
+RUN service apache2 restart
+EXPOSE 443
+ADD docker-run.sh /run.sh
+CMD ["/run.sh"]

--- a/INSTALL
+++ b/INSTALL
@@ -45,3 +45,10 @@
 4. Access Plinth UI:
 
     Plinth UI should be accessible at http://localhost:8000
+
+Or, to run it in docker, do:
+
+    $ docker build .
+    $ docker run -p 127.0.0.1:443:443 [image-hash]
+
+Then visit https://localhost/plinth in your browser.

--- a/data/etc/apache2/sites-available/plinth-ssl.conf
+++ b/data/etc/apache2/sites-available/plinth-ssl.conf
@@ -13,4 +13,6 @@
     # FIXME: Workaround for mod_gnutls (Debian Bug #514005)
     RewriteCond %{SERVER_PORT} !^443$
     RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+    Require all granted
 </Location>

--- a/data/etc/apache2/sites-available/plinth.conf
+++ b/data/etc/apache2/sites-available/plinth.conf
@@ -38,4 +38,6 @@
         ## IPv6 private addresses
         Require ip fc00::/7
     </RequireAny>
+
+    Require all granted
 </Location>

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd /plinth
+service apache2 restart
+source ve/bin/activate
+exec plinth --no-daemon

--- a/plinth/action_utils.py
+++ b/plinth/action_utils.py
@@ -91,7 +91,7 @@ def webserver_is_enabled(name, kind='config'):
         subprocess.check_output(['a2query', option_map[kind], name],
                                 stderr=subprocess.STDOUT)
         return True
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return False
 
 

--- a/plinth/modules/networks/forms.py
+++ b/plinth/modules/networks/forms.py
@@ -20,9 +20,9 @@ from django.core import validators
 from gettext import gettext as _
 
 from plinth import network
-import gi
-gi.require_version('NM', '1.0')
-from gi.repository import NM as nm
+import pgi
+pgi.require_version('NM', '1.0')
+from pgi.repository import NM as nm
 
 
 def _get_interface_choices(device_type):

--- a/plinth/network.py
+++ b/plinth/network.py
@@ -20,11 +20,11 @@ Helper functions for working with network manager.
 """
 
 import collections
-import gi
-gi.require_version('GLib', '2.0')
-from gi.repository import GLib as glib
-gi.require_version('NM', '1.0')
-from gi.repository import NM as nm
+import pgi
+pgi.require_version('GLib', '2.0')
+from pgi.repository import GLib as glib
+pgi.require_version('NM', '1.0')
+from pgi.repository import NM as nm
 import logging
 import socket
 import struct

--- a/plinth/package.py
+++ b/plinth/package.py
@@ -22,11 +22,11 @@ Framework for installing and updating distribution packages
 from django.contrib import messages
 import functools
 from gettext import gettext as _
-import gi
-gi.require_version('GLib', '2.0')
-from gi.repository import GLib as glib
-gi.require_version('PackageKitGlib', '1.0')
-from gi.repository import PackageKitGlib as packagekit
+import pgi
+pgi.require_version('GLib', '2.0')
+from pgi.repository import GLib as glib
+pgi.require_version('PackageKitGlib', '1.0')
+from pgi.repository import PackageKitGlib as packagekit
 import logging
 import threading
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ django-stronghold
 psutil
 python-augeas
 pyyaml
+pgi >= 0.0.10.1


### PR DESCRIPTION
This adds a Dockerfile so you don't have to install all of Plinth's
required debian packages on your host machine in order to run it.

Let me know if you have any suggestions.. I just thought this could
be a good alternative to VirtualBox / KVM. It also provides a place
to document what's actually needed to get Plinth running.

I've added some instructions on how to run this to the INSTALL file.

    docker build .
    docker run -p 127.0.0.1:443:443 [image-hash]