### PR TITLE
Adds a 'language' dropdown field to the system configuration

### DIFF
--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -213,6 +213,17 @@ def configure_django():
     if cfg.secure_proxy_ssl_header:
         secure_proxy_ssl_header = (cfg.secure_proxy_ssl_header, 'https')
 
+    # Read translated languages from the 'locale' directory
+    languages = [('en', 'English')]
+    locale_dir = os.path.join(os.path.dirname(__file__), 'locale')
+    if os.path.isdir(locale_dir):
+        translated_language_codes = next(os.walk(locale_dir))[1]
+        all_languages = dict(django.conf.global_settings.LANGUAGES)
+        for code in translated_language_codes:
+            if code in all_languages:
+                languages.append((code, all_languages[code]))
+        languages = sorted(languages, key=lambda tup: tup[1])
+
     django.conf.settings.configure(
         ALLOWED_HOSTS=['*'],
         CACHES={'default':
@@ -222,6 +233,7 @@ def configure_django():
                     'NAME': cfg.store_file}},
         DEBUG=cfg.debug,
         INSTALLED_APPS=applications,
+        LANGUAGES=languages,
         LOGGING=logging_configuration,
         LOGIN_URL='users:login',
         LOGIN_REDIRECT_URL='apps:index',

--- a/plinth/modules/config/config.py
+++ b/plinth/modules/config/config.py
@@ -59,8 +59,9 @@ def get_language(request):
     # taking care of setting language on login, and adapting kvstore when
     # renaming/deleting users
 
-    # The session contains more accurate information than request.LANGUAGE_CODE
-    return request.session[translation.LANGUAGE_SESSION_KEY]
+    # The information from the session is more accurate but not always present
+    return request.session.get(translation.LANGUAGE_SESSION_KEY,
+                               request.LANGUAGE_CODE)
 
 
 class TrimmedCharField(forms.CharField):

--- a/plinth/modules/config/tests/test_config.py
+++ b/plinth/modules/config/tests/test_config.py
@@ -19,7 +19,10 @@
 Tests for config module.
 """
 
+import os
 import unittest
+
+from plinth import __main__ as plinth_main
 
 from ..config import ConfigurationForm
 
@@ -65,3 +68,12 @@ class TestConfig(unittest.TestCase):
             form = ConfigurationForm({'hostname': 'example',
                                       'domainname': domainname})
             self.assertFalse(form.is_valid())
+
+    def test_locale_path(self):
+        """
+        Test that the 'locale' directory is in the same folder as __main__.py.
+        This is required for detecting translated languages.
+        """
+        plinth_dir = os.path.dirname(plinth_main.__file__)
+        locale_dir = os.path.join(plinth_dir, 'locale')
+        self.assertTrue(os.path.isdir(locale_dir))


### PR DESCRIPTION
- The language choice is stored within the session, not persistently (in kvstore)
- This removes confirmation messages if nothing was changed

Maybe there is a better way to detect the plinth / locale directory than this:
https://github.com/fonfon/Plinth/blob/language-detect/plinth/__main__.py#L218

If a user chooses a certain language his setting survives login/logout with the same browser, but won't survive using another browser or device. Thus we should use kvstore in the long run to store user language choices.