### PR TITLE
Use icon for applications button intead of text

### DIFF
--- a/plinth/modules/names/__init__.py
+++ b/plinth/modules/names/__init__.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 def init():
     """Initialize the names module."""
     menu = cfg.main_menu.get('system:index')
-    menu.add_urlname(ugettext_lazy('Name Services'), 'glyphicon-th',
+    menu.add_urlname(ugettext_lazy('Name Services'), 'glyphicon-tag',
                      'names:index', 19)
 
     domain_added.connect(on_domain_added)

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -83,10 +83,10 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a href="{% url 'index' %}" class="navbar-brand" title="{% trans "FreedomBox" %}">
+        <span class="navbar-brand">
           <img src="{% static 'theme/img/freedombox-logo-32px.png' %}"
                alt="{% trans "FreedomBox" %}" />
-        </a>
+        </span>
         <a href="{% url 'index' %}" class="navbar-brand" title="{% trans "Applications" %}">
           <span class="glyphicon glyphicon-th"></span>
         </a>

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -83,10 +83,12 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a href="{% url 'index' %}" class="navbar-brand" title="{% trans "Applications" %}">
+        <a href="{% url 'index' %}" class="navbar-brand" title="{% trans "FreedomBox" %}">
           <img src="{% static 'theme/img/freedombox-logo-32px.png' %}"
                alt="{% trans "FreedomBox" %}" />
-          {% trans "Applications" %}
+        </a>
+        <a href="{% url 'index' %}" class="navbar-brand" title="{% trans "Applications" %}">
+          <span class="glyphicon glyphicon-th"></span>
         </a>
       </div>
       <div class="collapse navbar-collapse">


### PR DESCRIPTION
The concern that people are unable to find a way to get back to
applications is a correct one.  The recent changes does fix the problem.

However, it takes a step back in the design.  The 'Applications' text is
too prominent.  I propose that we replace it with the commonly used
icon.  Featured in mobile interfaces and on Google home page, users
should have no difficulty identifing it as applications icon.

After experimenting with the placement of the icon, it seems more
asthetically pleasing to have it at the place of 'Applications' text and
not at the center etc.