### PR TITLE
Compile and install translation files

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,10 +7,14 @@
     $ sudo apt-get install \
     augeas-tools \
     dblatex \
+    gettext \
+    gir1.2-glib-2.0 \
+    gir1.2-networkmanager-1.0 \
+    gir1.2-packagekitglib-1.0 \
     ldapscripts \
+    libjs-bootstrap \
     libjs-jquery \
     libjs-modernizr \
-    libjs-bootstrap \
     make \
     network-manager \
     ppp \
@@ -26,9 +30,6 @@
     python3-psutil \
     python3-setuptools \
     python3-yaml \
-    gir1.2-glib-2.0 \
-    gir1.2-networkmanager-1.0 \
-    gir1.2-packagekitglib-1.0 \
     xmlto
 
 2. Install Plinth:


### PR DESCRIPTION
- Add gettext as build dependency

- Add setup.py commands for compiling and updating .po files.

- Clean compiled .mo files on ./setup.py clean

- Install .po and .mo files to destination on ./setup.py install

- Compile .po files when running ./setup.py build

There doesn't seem to be a simple way to integrate Django .po file
dealing with ./setup.py mechanism.