### PR TITLE
Apache restart fix

### DIFF
--- a/plinth/package.py
+++ b/plinth/package.py
@@ -165,11 +165,11 @@ class Transaction(object):
 
     def _assert_success(self, results):
         """Check that the most recent operation was a success."""
-        # XXX: Untested code
         if results and results.get_error_code() is not None:
             error = results.get_error_code()
             error_code = error.get_code() if error else None
-            error_string = error_code.to_string() if error_code else None
+            error_string = packagekit.ErrorEnum.to_string(error_code) \
+                if error_code else None
             error_details = error.get_details() if error else None
             raise PackageException(error_string, error_details)
 
@@ -263,9 +263,10 @@ def _should_show_install_view(request, package_names):
                          _('Installed and configured packages successfully'))
         return False
     else:
-        messages.error(request, _('Error installing packages: {details}')
-                       .format(details=getattr(exception, 'error_string',
-                                               str(exception))))
+        error_string = getattr(exception, 'error_string', str(exception))
+        error_details = getattr(exception, 'error_details', '')
+        messages.error(request, _('Error installing packages: {string} {details}')
+                       .format(string=error_string, details=error_details))
         return True
 
 


### PR DESCRIPTION
Some of the important modules such as php5, cgi and authnz_ldap are
enabled by default in freedombox-setup.  However, when installing
ikiwiki we still restart the apache2 web server.  This patch fixes that
by restart or reloading only when the corresponding module/config/site
is not already in the state required.

An additional fix for error handling in packages module is also done.