### PR TITLE
Start without tor installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 # Debian packages required
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install gir1.2-packagekitglib-1.0
+  - sudo apt-get install augeas-tools gir1.2-packagekitglib-1.0
 
 # Command to install dependencies
 install:

--- a/actions/tor
+++ b/actions/tor
@@ -167,12 +167,15 @@ def get_hidden_service():
     hs_dir = None
     hs_ports = []
 
-    with open(TOR_CONFIG, 'r') as conf_file:
-        for line in conf_file:
-            if line.startswith('HiddenServiceDir'):
-                hs_dir = line.split()[1]
-            elif line.startswith('HiddenServicePort'):
-                hs_ports.append(line.split()[1])
+    try:
+        with open(TOR_CONFIG, 'r') as conf_file:
+            for line in conf_file:
+                if line.startswith('HiddenServiceDir'):
+                    hs_dir = line.split()[1]
+                elif line.startswith('HiddenServicePort'):
+                    hs_ports.append(line.split()[1])
+    except FileNotFoundError:
+        return 'error'
 
     if not hs_dir:
         return ''
@@ -193,12 +196,15 @@ def subcommand_get_ports(_):
     except Exception:
         pass
 
-    with open(TOR_STATE_FILE, 'r') as state_file:
-        for line in state_file:
-            matches = re.match(r'^\s*TransportProxy\s+(\S*)\s+\S+:(\d+)\s*$',
-                               line)
-            if matches:
-                print('{0} {1}'.format(matches.group(1), matches.group(2)))
+    try:
+        with open(TOR_STATE_FILE, 'r') as state_file:
+            for line in state_file:
+                matches = re.match(
+                    r'^\s*TransportProxy\s+(\S*)\s+\S+:(\d+)\s*$', line)
+                if matches:
+                    print('{0} {1}'.format(matches.group(1), matches.group(2)))
+    except FileNotFoundError:
+        pass
 
 
 def subcommand_enable_apt_transport_tor(_):

--- a/plinth/modules/tor/tests/test_tor.py
+++ b/plinth/modules/tor/tests/test_tor.py
@@ -1,0 +1,49 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Tests for tor module.
+"""
+
+import unittest
+
+from ..tor import is_apt_transport_tor_enabled, get_hs, get_status
+
+
+class TestTor(unittest.TestCase):
+    """Test cases for testing the tor module."""
+    def test_is_apt_transport_tor_enabled(self):
+        """Test that is_apt_transport_tor_enabled does not raise any unhandled
+        exceptions.
+        """
+        is_apt_transport_tor_enabled()
+
+    def test_get_hs(self):
+        """Test that get_hs does not raise any unhandled exceptions.
+
+        This should work regardless of whether tor is installed, or
+        /etc/tor/torrc exists.
+        """
+        get_hs()
+
+    def test_get_status(self):
+        """Test that get_status does not raise any unhandled exceptions.
+
+        This should work regardless of whether tor is installed, or
+        /etc/tor/torrc exists.
+        """
+        get_status()

--- a/plinth/modules/tor/tests/test_tor.py
+++ b/plinth/modules/tor/tests/test_tor.py
@@ -19,19 +19,24 @@
 Tests for tor module.
 """
 
+import os
 import unittest
 
-from ..tor import is_apt_transport_tor_enabled, get_hs, get_status
+euid = os.geteuid()
+if euid == 0:
+    from ..tor import is_apt_transport_tor_enabled, get_hs, get_status
 
 
 class TestTor(unittest.TestCase):
     """Test cases for testing the tor module."""
+    @unittest.skipUnless(euid == 0, 'Needs to be root')
     def test_is_apt_transport_tor_enabled(self):
         """Test that is_apt_transport_tor_enabled does not raise any unhandled
         exceptions.
         """
         is_apt_transport_tor_enabled()
 
+    @unittest.skipUnless(euid == 0, 'Needs to be root')
     def test_get_hs(self):
         """Test that get_hs does not raise any unhandled exceptions.
 
@@ -40,6 +45,7 @@ class TestTor(unittest.TestCase):
         """
         get_hs()
 
+    @unittest.skipUnless(euid == 0, 'Needs to be root')
     def test_get_status(self):
         """Test that get_status does not raise any unhandled exceptions.
 


### PR DESCRIPTION
- Handle error where /etc/tor/torrc does not exist when checking hidden service config.
- Handle error where tor state file does not exist when getting list of ports.
- Add test for checking if apt-transport-tor is enabled.