### PR TITLE
Keep POT file when updating translations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,8 @@ class UpdateTranslations(DjangoCommand):
         DjangoCommand.run(self)
 
         from django.core.management import call_command
-        call_command('makemessages', all=True, domain='django', verbosity=1)
+        call_command('makemessages', all=True, domain='django', keep_pot=True,
+                     verbosity=1)
 
 
 class CustomBuild(build):


### PR DESCRIPTION
The `./setup.py update_translations` command will now generate a POT file in addition to updating the existing translations.  I have already push a commit to create the initial POT file.