### PR TITLE
Quassel IRC module

### DIFF
--- a/actions/quassel
+++ b/actions/quassel
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for Quassel core
+"""
+
+import argparse
+
+from plinth import action_utils
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    subparsers.add_parser('enable', help='Enable Quassel core service')
+    subparsers.add_parser('disable', help='Disable Quassel core service')
+
+    return parser.parse_args()
+
+
+def subcommand_enable(_):
+    """Start service."""
+    action_utils.service_enable('quasselcore')
+
+
+def subcommand_disable(_):
+    """Stop service."""
+    action_utils.service_disable('quasselcore')
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/data/etc/plinth/modules-enabled/quassel
+++ b/data/etc/plinth/modules-enabled/quassel
@@ -1,0 +1,1 @@
+plinth.modules.quassel

--- a/data/usr/lib/firewalld/services/quassel-plinth.xml
+++ b/data/usr/lib/firewalld/services/quassel-plinth.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Quassel IRC</short>
+  <description>Quassel is a distributed IRC client, meaning that one or more clients can attach to and detach from the central core.</description>
+  <port protocol="tcp" port="4242"/>
+</service>

--- a/plinth/modules/quassel/__init__.py
+++ b/plinth/modules/quassel/__init__.py
@@ -1,0 +1,52 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module for quassel.
+"""
+
+from django.utils.translation import ugettext_lazy as _
+
+from plinth import action_utils
+from plinth import cfg
+from plinth import service as service_module
+
+depends = ['plinth.modules.apps']
+
+service = None
+
+
+def init():
+    """Initialize the quassel module."""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(_('IRC Client (Quassel)'), 'glyphicon-retweet',
+                     'quassel:index', 730)
+
+    global service
+    service = service_module.Service(
+        'quassel', _('Quassel IRC Client'),
+        is_external=True, enabled=is_enabled())
+
+
+def is_enabled():
+    """Return whether the service is enabled."""
+    return action_utils.service_is_enabled('quasselcore')
+
+
+def is_running():
+    """Return whether the service is running."""
+    return action_utils.service_is_running('quasselcore')

--- a/plinth/modules/quassel/forms.py
+++ b/plinth/modules/quassel/forms.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for quassel module.
+"""
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+
+class QuasselForm(forms.Form):
+    """Quassel configuration form."""
+    enabled = forms.BooleanField(
+        label=_('Enable Quassel core service'),
+        required=False)

--- a/plinth/modules/quassel/templates/quassel.html
+++ b/plinth/modules/quassel/templates/quassel.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+{% load i18n %}
+
+{% block content %}
+
+  <h2>{% trans "Quassel IRC" %}</h2>
+
+  <p>
+    {% blocktrans trimmed with box_name=cfg.box_name %}
+      Quassel is an IRC application that is split into two parts, a
+      "core" and a "client". This allows the core to remain connected
+      to IRC servers, and to continue receiving messages, even when
+      the client is disconnected. {{ box_name }} can run the Quassel
+      core service.
+    {% endblocktrans %}
+  </p>
+
+  <h3>{% trans "Status" %}</h3>
+
+  <p class="running-status-parent">
+    {% if status.is_running %}
+      <span class="running-status active"></span>
+      {% trans "Quassel core service is running" %}
+    {% else %}
+      <span class="running-status inactive"></span>
+      {% trans "Quassel core service is not running" %}
+    {% endif %}
+  </p>
+
+  <h3>{% trans "Configuration" %}</h3>
+
+  <form class="form" method="post">
+    {% csrf_token %}
+
+    {{ form|bootstrap }}
+
+    <input type="submit" class="btn btn-primary"
+	   value="{% trans "Update setup" %}"/>
+  </form>
+
+{% endblock %}

--- a/plinth/modules/quassel/urls.py
+++ b/plinth/modules/quassel/urls.py
@@ -1,0 +1,29 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the quassel module.
+"""
+
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = [
+    url(r'^apps/quassel/$', views.index, name='index'),
+]

--- a/plinth/modules/quassel/views.py
+++ b/plinth/modules/quassel/views.py
@@ -1,0 +1,78 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Views for quassel module.
+"""
+
+from django.contrib import messages
+from django.template.response import TemplateResponse
+from django.utils.translation import ugettext as _
+
+from .forms import QuasselForm
+from plinth import actions
+from plinth import package
+from plinth.modules import quassel
+
+
+def on_install():
+    """Notify that the service is now enabled."""
+    quassel.service.notify_enabled(None, True)
+
+
+@package.required(['quassel-core'], on_install=on_install)
+def index(request):
+    """Serve configuration page."""
+    status = get_status()
+
+    form = None
+
+    if request.method == 'POST':
+        form = QuasselForm(request.POST, prefix='quassel')
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = QuasselForm(initial=status, prefix='quassel')
+    else:
+        form = QuasselForm(initial=status, prefix='quassel')
+
+    return TemplateResponse(request, 'quassel.html',
+                            {'title': _('Quassel IRC'),
+                             'status': status,
+                             'form': form})
+
+
+def get_status():
+    """Get the current service status."""
+    return {'enabled': quassel.is_enabled(),
+            'is_running': quassel.is_running()}
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        sub_command = 'enable' if new_status['enabled'] else 'disable'
+        actions.superuser_run('quassel', [sub_command])
+        quassel.service.notify_enabled(None, new_status['enabled'])
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))


### PR DESCRIPTION
This is a module that simply installs and configures quassel-core.

I included a firewalld service file for quassel in this patch. If it gets merged into firewalld (https://github.com/t-woerner/firewalld/pull/58), then it can be removed from plinth.