### PR TITLE
Use ugettext_lazy during init of config and power modules.

### DIFF
--- a/plinth/modules/config/config.py
+++ b/plinth/modules/config/config.py
@@ -149,7 +149,8 @@ def init():
         domainname_services = None
 
     domain_added.send_robust(sender='config', domain_type='domainname',
-                             name=domainname, description=_('Domain Name'),
+                             name=domainname,
+                             description=ugettext_lazy('Domain Name'),
                              services=domainname_services)
 
 

--- a/plinth/modules/power/__init__.py
+++ b/plinth/modules/power/__init__.py
@@ -19,7 +19,7 @@
 Plinth module for power controls.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from plinth import cfg
 


### PR DESCRIPTION
This fixes 2 remaining issues of #347.