### PR TITLE
First boot improvements

### DIFF
--- a/plinth/modules/first_boot/templates/firstboot_navbar.html
+++ b/plinth/modules/first_boot/templates/firstboot_navbar.html
@@ -1,0 +1,26 @@
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+<ul class="nav navbar-nav navbar-right">
+  <li>
+    <a href="{% url 'help:index' %}">
+      <span class="glyphicon-question-sign glyphicon nav-icon"></span>
+    </a>
+  </li>
+</ul>

--- a/plinth/modules/first_boot/templates/firstboot_state0.html
+++ b/plinth/modules/first_boot/templates/firstboot_state0.html
@@ -31,13 +31,7 @@
 {% endblock %}
 
 {% block add_nav_and_login %}
-  <ul class="nav navbar-nav navbar-right">
-    <li>
-      <a href="{% url 'help:index' %}">
-        <span class="glyphicon-question-sign glyphicon nav-icon"></span>
-      </a>
-    </li>
-  </ul>
+  {% include "firstboot_navbar.html" %}
 {% endblock %}
 
 {% block content_row %}

--- a/plinth/modules/first_boot/templates/firstboot_state0.html
+++ b/plinth/modules/first_boot/templates/firstboot_state0.html
@@ -40,19 +40,15 @@
          alt="FreedomBox" width="640"/>
   </p>
 
-  <h3 class="text-center">
-    {% trans "Congratulations! Your FreedomBox is up and running!" %}
-  </h3>
-
-  <p class="text-center">
-    {% blocktrans trimmed %}
-      Please provide the following basic information to complete the
-      setup process.
-    {% endblocktrans %}
-  </p>
-
   <p class="text-center">
     <a href="{% url 'first_boot:state1' %}"
-       class="btn btn-primary btn-large">{% trans "Next" %}</a>
+       class="btn btn-primary btn-lg">{% trans "Start Setup" %}</a>
+  </p>
+
+  <p class="text-center" style="font-size: larger">
+    {% blocktrans trimmed with box_name=cfg.box_name %}
+      To complete the setup of your {{ box_name }}, please provide
+      some basic information.
+    {% endblocktrans %}
   </p>
 {% endblock %}

--- a/plinth/modules/first_boot/templates/firstboot_state1.html
+++ b/plinth/modules/first_boot/templates/firstboot_state1.html
@@ -62,6 +62,6 @@
 
 {% block page_js %}
   <script>
-    $('#id_hostname').focus();
+    $('#id_username').focus();
   </script>
 {% endblock %}

--- a/plinth/modules/first_boot/templates/firstboot_state1.html
+++ b/plinth/modules/first_boot/templates/firstboot_state1.html
@@ -22,14 +22,16 @@
 {% load i18n %}
 {% load static %}
 
+{% block page_head %}
+  <style type="text/css">
+   .navbar-brand .glyphicon {
+       display: none;
+   }
+  </style>
+{% endblock %}
+
 {% block add_nav_and_login %}
-  <ul class="nav navbar-nav navbar-right">
-    <li>
-      <a href="{% url 'help:index' %}">
-        <span class="glyphicon-question-sign glyphicon nav-icon"></span>
-      </a>
-    </li>
-  </ul>
+  {% include "firstboot_navbar.html" %}
 {% endblock %}
 
 {% block content_row %}

--- a/plinth/modules/first_boot/templates/firstboot_state10.html
+++ b/plinth/modules/first_boot/templates/firstboot_state10.html
@@ -29,35 +29,32 @@
     <h2>{% trans "Setup Complete!" %}</h2>
 
     <p>
-      {% blocktrans trimmed %}
-        FreedomBox setup is now complete.  However, you should check
-        the network setup and modify it if necessary.  Do not forget
-        to change the default Wi-Fi passwords.
+      {% blocktrans trimmed with box_name=cfg.box_name %}
+        {{ box_name }} setup is now complete.  To make your FreedomBox
+        functional, you need some applications.  Applications will be
+        installed the first time you access them.
       {% endblocktrans %}
     </p>
+
+    <div class="text-center">
+      <a class="btn btn-lg btn-primary" href="{% url 'apps:index' %}">
+        {% trans "Go to Apps" %}</a>
+    </div>
+
+    <h3>{% trans "Current Network Configuration" %}</h3>
 
     <p>
       {% blocktrans trimmed %}
-        To make your FreedomBox functional, you need some
-        applications.  Applications will be installed the first time
-        you access them.
+        You should check the network setup and modify it if necessary.
+        Do not forget to change the default Wi-Fi passwords!
       {% endblocktrans %}
     </p>
 
-    <h3>{% trans "Network Configuration" %}</h3>
-
     {% include "connections_diagram.html" %}
 
-    <div class="row">
-      <div class="col-xs-6 text-center">
-        <a class="btn btn-lg btn-primary" href="{% url 'networks:index' %}">
-          {% trans "Go to Networks" %}</a>
-      </div>
-
-      <div class="col-xs-6 text-center">
-        <a class="btn btn-lg btn-primary" href="{% url 'apps:index' %}">
-          {% trans "Go to Apps" %}</a>
-      </div>
+    <div class="text-center">
+      <a class="btn btn-lg btn-primary" href="{% url 'networks:index' %}">
+        {% trans "Go to Networks" %}</a>
     </div>
   </div>
 


### PR DESCRIPTION
This pull request is originally from @fonfon . I made some modifications.  This pull request should be merged only after tagging 0.7.2.

Here are some comments/updates on @fonfon 's proposal.
- Brand should not be shown in state0 but should be shown state1.
- Applications icon should not be shown in state0 and state1.
- 'Start Setup' is better than 'Next'.
- Removing congratulations and pushing the basic details message down are good in state0.
- In the final page, you are right about the confusion with the two buttons.  However, instead of removing, I placed one button in one section and another button in another section.
- Fixed issue with {{ cfg.box_name }} and `blocktrans` tag.
- Chaging 'Network Configuration' to 'Current Network Configuraion' is nice.