### PR TITLE
fixed github issue 334:

### DIFF
--- a/plinth/network.py
+++ b/plinth/network.py
@@ -102,7 +102,9 @@ def get_status_from_connection(connection):
         status['wireless']['ssid'] = setting_wireless.get_ssid().get_data()
 
     primary_connection = nm.Client.new(None).get_primary_connection()
-    status['primary'] = (primary_connection.get_uuid() == connection.get_uuid())
+    if primary_connection:
+        status['primary'] = (primary_connection.get_uuid() ==
+                             connection.get_uuid())
 
     return status
 


### PR DESCRIPTION
Check if there is any primary connection available before accessing this connections parameter.
Otherwise Plinth will raise an exception because of non existing object.