### PR TITLE
issue 292 add irc link

### DIFF
--- a/plinth/modules/help/templates/help_index.html
+++ b/plinth/modules/help/templates/help_index.html
@@ -53,7 +53,7 @@
     {% blocktrans trimmed %}
       Many FreedomBox contributors and users are also available on the irc.oftc.net IRC network.
       Join and request help on the 
-      <a href="https://webchat.oftc.net/?randomnick=1&channels=freedombox&prompt=1&uio=MT11bmRlZmluZWQb1">
+      <a href="https://webchat.oftc.net/?randomnick=1&channels=freedombox&prompt=1">
       #freedombox</a> channel using the IRC web interface.
     {% endblocktrans %}
   </p>

--- a/plinth/modules/help/templates/help_index.html
+++ b/plinth/modules/help/templates/help_index.html
@@ -51,9 +51,10 @@
 
   <p>
     {% blocktrans trimmed %}
-      Many FreedomBox contributors and users are also available on the
+      Many FreedomBox contributors and users are also available on the irc.oftc.net IRC network.
+      Join and request help on the 
       <a href="https://webchat.oftc.net/?randomnick=1&channels=freedombox&prompt=1&uio=MT11bmRlZmluZWQb1">
-      #freedombox</a> channel of the irc.oftc.net IRC network.
+      #freedombox</a> channel using the IRC web interface.
     {% endblocktrans %}
   </p>
 

--- a/plinth/modules/help/templates/help_index.html
+++ b/plinth/modules/help/templates/help_index.html
@@ -52,7 +52,8 @@
   <p>
     {% blocktrans trimmed %}
       Many FreedomBox contributors and users are also available on the
-      #freedombox channel of the irc.oftc.net IRC network.
+      <a href="https://webchat.oftc.net/?randomnick=1&channels=freedombox&prompt=1&uio=MT11bmRlZmluZWQb1">
+      #freedombox</a> channel of the irc.oftc.net IRC network.
     {% endblocktrans %}
   </p>
 


### PR DESCRIPTION
I explored linking the "irc.oftc.net" text to something, but can't find anything particularly edifying for that.
Tested display and link in safari 9.0.1 and firefox 43.0.3.