### PR TITLE
Radicale CalDAV/CardDAV module

### DIFF
--- a/actions/radicale
+++ b/actions/radicale
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Configuration helper for Radicale.
+"""
+
+import argparse
+import augeas
+import subprocess
+
+from plinth import action_utils
+
+CONFIG_FILE = '/etc/radicale/config'
+DEFAULT_FILE = '/etc/default/radicale'
+
+
+def parse_arguments():
+    """Return parsed command line arguments as dictionary."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
+
+    subparsers.add_parser('setup', help='Setup Radicale configuration')
+    subparsers.add_parser('enable', help='Enable Radicale service')
+    subparsers.add_parser('disable', help='Disable Radicale service')
+
+    return parser.parse_args()
+
+
+def subcommand_setup(_):
+    """Setup Radicale configuration."""
+    aug = load_augeas()
+
+    aug.set('/files' + DEFAULT_FILE + '/ENABLE_RADICALE', 'yes')
+
+    aug.set('/files' + CONFIG_FILE + '/server/hosts',
+            '0.0.0.0:5232, [::]:5232')
+    aug.set('/files' + CONFIG_FILE + '/server/ssl', 'True')
+    aug.set('/files' + CONFIG_FILE + '/server/certificate',
+            '/etc/ssl/certs/ssl-cert-snakeoil.pem')
+    aug.set('/files' + CONFIG_FILE + '/server/key',
+            '/etc/ssl/private/ssl-cert-snakeoil.key')
+    aug.set('/files' + CONFIG_FILE + '/auth/type', 'LDAP')
+    aug.set('/files' + CONFIG_FILE + '/auth/ldap_base', 'ou=users,dc=thisbox')
+    aug.set('/files' + CONFIG_FILE + '/rights/type', 'authenticated')
+
+    aug.save()
+
+    subprocess.check_output(['usermod', '-a', '-G', 'ssl-cert', 'radicale'])
+    action_utils.service_restart('radicale')
+
+
+def subcommand_enable(_):
+    """Start service."""
+    action_utils.service_enable('radicale')
+
+
+def subcommand_disable(_):
+    """Stop service."""
+    action_utils.service_disable('radicale')
+
+
+def load_augeas():
+    """Initialize Augeas."""
+    aug = augeas.Augeas(flags=augeas.Augeas.NO_LOAD +
+                        augeas.Augeas.NO_MODL_AUTOLOAD)
+
+    # shell-script config file lens
+    aug.set('/augeas/load/Shellvars/lens', 'Shellvars.lns')
+    aug.set('/augeas/load/Shellvars/incl[last() + 1]', DEFAULT_FILE)
+
+    # INI file lens
+    aug.set('/augeas/load/Puppet/lens', 'Puppet.lns')
+    aug.set('/augeas/load/Puppet/incl[last() + 1]', CONFIG_FILE)
+
+    aug.load()
+    return aug
+
+
+def main():
+    """Parse arguments and perform all duties."""
+    arguments = parse_arguments()
+
+    subcommand = arguments.subcommand.replace('-', '_')
+    subcommand_method = globals()['subcommand_' + subcommand]
+    subcommand_method(arguments)
+
+
+if __name__ == '__main__':
+    main()

--- a/actions/radicale
+++ b/actions/radicale
@@ -50,28 +50,29 @@ def subcommand_setup(_):
 
     aug.set('/files' + CONFIG_FILE + '/server/hosts',
             '0.0.0.0:5232, [::]:5232')
-    aug.set('/files' + CONFIG_FILE + '/server/ssl', 'True')
-    aug.set('/files' + CONFIG_FILE + '/server/certificate',
-            '/etc/ssl/certs/ssl-cert-snakeoil.pem')
-    aug.set('/files' + CONFIG_FILE + '/server/key',
-            '/etc/ssl/private/ssl-cert-snakeoil.key')
-    aug.set('/files' + CONFIG_FILE + '/auth/type', 'LDAP')
-    aug.set('/files' + CONFIG_FILE + '/auth/ldap_base', 'ou=users,dc=thisbox')
-    aug.set('/files' + CONFIG_FILE + '/rights/type', 'authenticated')
+    aug.set('/files' + CONFIG_FILE + '/server/base_prefix', '/radicale/')
+    aug.set('/files' + CONFIG_FILE + '/well-known/caldav',
+            '/radicale/%(user)s/caldav/')
+    aug.set('/files' + CONFIG_FILE + '/well-known/carddav',
+            '/radicale/%(user)s/carddav/')
+    aug.set('/files' + CONFIG_FILE + '/auth/type', 'remote_user')
+    aug.set('/files' + CONFIG_FILE + '/rights/type', 'owner_only')
 
     aug.save()
 
-    subprocess.check_output(['usermod', '-a', '-G', 'ssl-cert', 'radicale'])
     action_utils.service_restart('radicale')
+    action_utils.webserver_enable('radicale-plinth')
 
 
 def subcommand_enable(_):
     """Start service."""
     action_utils.service_enable('radicale')
+    action_utils.webserver_enable('radicale-plinth')
 
 
 def subcommand_disable(_):
     """Stop service."""
+    action_utils.webserver_disable('radicale-plinth')
     action_utils.service_disable('radicale')
 
 

--- a/data/etc/apache2/conf-available/radicale-plinth.conf
+++ b/data/etc/apache2/conf-available/radicale-plinth.conf
@@ -1,0 +1,18 @@
+##
+## On all sites, provide Radicale on a path: /radicale
+## Allow all valid users.
+##
+Redirect 301 /.well-known/carddav /radicale/.well-known/carddav
+Redirect 301 /.well-known/caldav /radicale/.well-known/caldav
+
+<Location /radicale>
+    ProxyPass http://localhost:5232
+
+    AuthType basic
+    AuthName "FreedomBox Login"
+    AuthBasicProvider ldap
+    AuthLDAPUrl "ldap:///ou=users,dc=thisbox?uid"
+    AuthLDAPGroupAttribute memberUid
+    AuthLDAPGroupAttributeIsDN off
+    Require valid-user
+</Location>

--- a/data/etc/plinth/modules-enabled/radicale
+++ b/data/etc/plinth/modules-enabled/radicale
@@ -1,0 +1,1 @@
+plinth.modules.radicale

--- a/data/usr/lib/firewalld/services/radicale-plinth.xml
+++ b/data/usr/lib/firewalld/services/radicale-plinth.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Radicale</short>
+  <description>Radicale is a CalDAV (calendar) and CardDAV (contact) server.</description>
+  <port protocol="tcp" port="5232"/>
+</service>

--- a/data/usr/lib/firewalld/services/radicale-plinth.xml
+++ b/data/usr/lib/firewalld/services/radicale-plinth.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<service>
-  <short>Radicale</short>
-  <description>Radicale is a CalDAV (calendar) and CardDAV (contact) server.</description>
-  <port protocol="tcp" port="5232"/>
-</service>

--- a/plinth/modules/radicale/__init__.py
+++ b/plinth/modules/radicale/__init__.py
@@ -56,7 +56,7 @@ def diagnose():
     """Run diagnostics and return the results."""
     results = []
 
-    results.append(action_utils.diagnose_port_listening(5232, 'tcp4'))
-    results.append(action_utils.diagnose_port_listening(5232, 'tcp6'))
+    results.extend(action_utils.diagnose_url_on_all(
+        'https://{host}/radicale', extra_options=['--no-check-certificate']))
 
     return results

--- a/plinth/modules/radicale/__init__.py
+++ b/plinth/modules/radicale/__init__.py
@@ -1,0 +1,62 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Plinth module for radicale.
+"""
+
+from django.utils.translation import ugettext_lazy as _
+
+from plinth import action_utils
+from plinth import cfg
+from plinth import service as service_module
+
+depends = ['plinth.modules.apps']
+
+service = None
+
+
+def init():
+    """Initialize the radicale module."""
+    menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(_('Calendar and Addressbook (Radicale)'),
+                     'glyphicon-calendar', 'radicale:index', 375)
+
+    global service
+    service = service_module.Service(
+        'radicale-plinth', _('Radicale CalDAV and CardDAV Server'),
+        is_external=True, enabled=is_enabled())
+
+
+def is_enabled():
+    """Return whether the service is enabled."""
+    return action_utils.service_is_enabled('radicale')
+
+
+def is_running():
+    """Return whether the service is running."""
+    return action_utils.service_is_running('radicale')
+
+
+def diagnose():
+    """Run diagnostics and return the results."""
+    results = []
+
+    results.append(action_utils.diagnose_port_listening(5232, 'tcp4'))
+    results.append(action_utils.diagnose_port_listening(5232, 'tcp6'))
+
+    return results

--- a/plinth/modules/radicale/forms.py
+++ b/plinth/modules/radicale/forms.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Forms for radicale module.
+"""
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+
+class RadicaleForm(forms.Form):
+    """Radicale configuration form."""
+    enabled = forms.BooleanField(
+        label=_('Enable Radicale service'),
+        required=False)

--- a/plinth/modules/radicale/templates/radicale.html
+++ b/plinth/modules/radicale/templates/radicale.html
@@ -31,9 +31,8 @@
     sharing of scheduling and contact data. To use Radicale, a
     <a href=
        "http://radicale.org/user_documentation/#idcaldav-and-carddav-clients">
-      supported client application</a> is needed. The client should be
-    configured to use HTTPS (SSL), and connect to port 5232. Radicale can be
-    accessed by any user with a {{ box_name }} login.
+      supported client application</a> is needed. Radicale can be accessed by
+    any user with a {{ box_name }} login.
     {% endblocktrans %}
   </p>
 

--- a/plinth/modules/radicale/templates/radicale.html
+++ b/plinth/modules/radicale/templates/radicale.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load bootstrap %}
+{% load i18n %}
+
+{% block content %}
+
+  <h2>{% trans "Calendar and Addressbook (Radicale)" %}</h2>
+
+  <p>
+    {% blocktrans trimmed %}
+    Radicale is a CalDAV and CardDAV server. It allows synchronization and
+    sharing of scheduling and contact data. To use Radicale, a
+    <a href=
+       "http://radicale.org/user_documentation/#idcaldav-and-carddav-clients">
+      supported client application</a> is needed. The client should be
+    configured to use HTTPS (SSL), and connect to port 5232. Radicale can be
+    accessed by any user with a {{ box_name }} login.
+    {% endblocktrans %}
+  </p>
+
+  <h3>{% trans "Status" %}</h3>
+
+  <p class="running-status-parent">
+    {% if status.is_running %}
+      <span class="running-status active"></span>
+      {% trans "Radicale service is running" %}
+    {% else %}
+      <span class="running-status inactive"></span>
+      {% trans "Radicale service is not running" %}
+    {% endif %}
+  </p>
+
+  {% include "diagnostics_button.html" with module="radicale" %}
+
+
+  <h3>{% trans "Configuration" %}</h3>
+
+  <form class="form" method="post">
+    {% csrf_token %}
+
+    {{ form|bootstrap }}
+
+    <input type="submit" class="btn btn-primary"
+	   value="{% trans "Update setup" %}"/>
+  </form>
+
+{% endblock %}

--- a/plinth/modules/radicale/urls.py
+++ b/plinth/modules/radicale/urls.py
@@ -1,0 +1,29 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+URLs for the radicale module.
+"""
+
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = [
+    url(r'^apps/radicale/$', views.index, name='index'),
+]

--- a/plinth/modules/radicale/views.py
+++ b/plinth/modules/radicale/views.py
@@ -35,7 +35,7 @@ def on_install():
     radicale.service.notify_enabled(None, True)
 
 
-@package.required(['radicale', 'python-ldap'], on_install=on_install)
+@package.required(['radicale'], on_install=on_install)
 def index(request):
     """Serve configuration page."""
     status = get_status()

--- a/plinth/modules/radicale/views.py
+++ b/plinth/modules/radicale/views.py
@@ -1,0 +1,79 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Views for radicale module.
+"""
+
+from django.contrib import messages
+from django.template.response import TemplateResponse
+from django.utils.translation import ugettext as _
+
+from .forms import RadicaleForm
+from plinth import actions
+from plinth import package
+from plinth.modules import radicale
+
+
+def on_install():
+    """Notify that the service is now enabled."""
+    actions.superuser_run('radicale', ['setup'])
+    radicale.service.notify_enabled(None, True)
+
+
+@package.required(['radicale', 'python-ldap'], on_install=on_install)
+def index(request):
+    """Serve configuration page."""
+    status = get_status()
+
+    form = None
+
+    if request.method == 'POST':
+        form = RadicaleForm(request.POST, prefix='radicale')
+        if form.is_valid():
+            _apply_changes(request, status, form.cleaned_data)
+            status = get_status()
+            form = RadicaleForm(initial=status, prefix='radicale')
+    else:
+        form = RadicaleForm(initial=status, prefix='radicale')
+
+    return TemplateResponse(request, 'radicale.html',
+                            {'title': _('Calendar and Addressbook (Radicale)'),
+                             'status': status,
+                             'form': form})
+
+
+def get_status():
+    """Get the current service status."""
+    return {'enabled': radicale.is_enabled(),
+            'is_running': radicale.is_running()}
+
+
+def _apply_changes(request, old_status, new_status):
+    """Apply the changes."""
+    modified = False
+
+    if old_status['enabled'] != new_status['enabled']:
+        sub_command = 'enable' if new_status['enabled'] else 'disable'
+        actions.superuser_run('radicale', [sub_command])
+        radicale.service.notify_enabled(None, new_status['enabled'])
+        modified = True
+
+    if modified:
+        messages.success(request, _('Configuration updated'))
+    else:
+        messages.info(request, _('Setting unchanged'))


### PR DESCRIPTION
- Uses SSL with snakeoil certificate.
- Uses LDAP for user authentication, all valid users are authorized.
- Authenticated users have access to all calendars / addressbooks.
- Note when using DAVdroid, you first have to create an addressbook with another client program (I used Evolution).

Further improvements to consider:
- Use certificate from letsencrypt.
- Add LDAP group for caldav/carddav users.
- Add options to restrict access to "owner write" or "owner only".