### PR TITLE
owncloud: Add packages for external storage

### DIFF
--- a/plinth/modules/owncloud/owncloud.py
+++ b/plinth/modules/owncloud/owncloud.py
@@ -58,8 +58,8 @@ def on_install():
     service.notify_enabled(None, True)
 
 
-@package.required(['postgresql', 'php5-pgsql', 'owncloud'],
-                  on_install=on_install)
+@package.required(['postgresql', 'php5-pgsql', 'owncloud', 'php-dropbox',
+                   'php-google-api-php-client'], on_install=on_install)
 def index(request):
     """Serve the ownCloud configuration page"""
     status = get_status()


### PR DESCRIPTION
The two packages are required when External Storage plugin in ownCloud
is enabled.  Since this has been a frequently asked question, add it to
the dependencies list.