### PR TITLE
travis: Require a specific version of pgi for fixing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - pip install Django$DJANGO_VERSION
   - pip install coverage==3.7
-  - pip install "pgi>=0.0.10.1"
+  - pip install "pgi==0.0.10.1"
   - pip install -r requirements.txt
 
 # Command to run tests


### PR DESCRIPTION
pgi 0.0.11.1 does not build successfully however 0.0.10.1 works.
Reported upstream issue https://github.com/lazka/pgi/issues/31.
Meanwile, to fix the builds, depend on older version.