### PR TITLE
travis: Use trusty and pygobject instead of pgi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # Travis-CI configuration file for Plinth
 
-language: python
-python:
-  - "3.4"
+dist: trusty
+sudo: required
+language: generic
 
 env:
   - DJANGO_VERSION=">=1.7.0,<1.8.0"
@@ -12,13 +12,14 @@ env:
 # Debian packages required
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install augeas-tools gir1.2-packagekitglib-1.0
+  - sudo apt-get -y install augeas-tools gir1.2-packagekitglib-1.0 python3-dev python3-gi
 
 # Command to install dependencies
 install:
+  - virtualenv --python=python3 --system-site-packages _venv
+  - source _venv/bin/activate
   - pip install Django$DJANGO_VERSION
   - pip install coverage==3.7
-  - pip install "pgi==0.0.10.1"
   - pip install -r requirements.txt
 
 # Command to run tests


### PR DESCRIPTION
- Run tests on Ubuntu Trusty (14.04) instead of Ubuntu Precise (12.04).

- Use pygobject instead of pgi to test what we actually use in
  production.

- Use a virtualenv trick to make sure that Python actually picks up
  system packages (python3-gi).
  https://pygobject.readthedocs.org/en/latest/testing.html#example-travis-ci-configuration

- Don't let apt-get hang for user input. Specify -y.