### PR TITLE
networks: Fix issue when looking up AP details

### DIFF
--- a/plinth/network.py
+++ b/plinth/network.py
@@ -172,7 +172,8 @@ def get_status_from_wifi_access_point(device, ssid):
         return status
 
     for access_point in device.get_access_points():
-        if access_point.get_ssid().get_data() == ssid:
+        if access_point and access_point.get_ssid() and \
+           access_point.get_ssid().get_data() == ssid:
             status['strength'] = access_point.get_strength()
             frequency = access_point.get_frequency()
             status['channel'] = _get_wifi_channel_from_frequency(frequency)


### PR DESCRIPTION
As reported by Jan Costermans, it is possible that for an access point
scanned by a Wi-Fi device, get_ssid() returns None.  The reported
issue is as follows:

  if access_point.get_ssid().get_data() == ssid:

  AttributeError: 'NoneType' object has no attribute 'get_data'