### PR TITLE
Avahi should now display {box_name}. Fixes #414

### DIFF
--- a/plinth/modules/avahi/__init__.py
+++ b/plinth/modules/avahi/__init__.py
@@ -39,8 +39,8 @@ title = _('Service Discovery')
 description = [
     format_lazy(
         _('Service discovery allows other devices on the network to '
-          'discover your {{ box_name }} and services running on it.  It '
-          'also allows {{ box_name }} to discover other devices and '
+          'discover your {box_name} and services running on it.  It '
+          'also allows {box_name} to discover other devices and '
           'services running on your local network.  Service discovery is '
           'not essential and works only on internal networks.  It may be '
           'disabled to improve security especially when connecting to a '


### PR DESCRIPTION
I changed {{ box_name }} to {box_name} to match the OpenVPN module, and now it displays the {box_name} correctly.