### PR TITLE
Remove #! sequence from ikiwiki setup automators.

### DIFF
--- a/data/etc/ikiwiki/plinth-blog.setup
+++ b/data/etc/ikiwiki/plinth-blog.setup
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+# -*- mode: perl -*-
 # Ikiwiki setup automator for Plinth (blog version).
 
 require IkiWiki::Setup::Automator;

--- a/data/etc/ikiwiki/plinth-wiki.setup
+++ b/data/etc/ikiwiki/plinth-wiki.setup
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+# -*- mode: perl -*-
 # Ikiwiki setup automator for Plinth.
 
 require IkiWiki::Setup::Automator;


### PR DESCRIPTION
These files are not executed directly, but through ikiwiki's setup command. Remove these lines to correct 2 lintian warnings.