### PR TITLE
Run Plinth setup during FreedomBox setup

### DIFF
--- a/data/usr/lib/freedombox/setup.d/86_plinth
+++ b/data/usr/lib/freedombox/setup.d/86_plinth
@@ -16,6 +16,26 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+DBUS_STARTED_FOR_PLINTH=false
+
+start_dbus() {
+    local return_code
+
+    service dbus status > /dev/null
+    return_code=$?
+
+    if [ "$return_code" != "0" ]; then
+        service dbus start
+        DBUS_STARTED_FOR_PLINTH=true
+    fi
+}
+
+stop_dbus() {
+    if [ "$DBUS_STARTED_FOR_PLINTH" = "true" ]; then
+        service dbus stop
+    fi
+}
+
 # Enable Apache modules required for Plinth.
 
 echo "Configuring Apache for Plinth..."
@@ -31,3 +51,17 @@ a2ensite plinth.conf
 a2ensite plinth-ssl.conf
 
 echo "Done configuring Apache for Plinth."
+
+echo "Running Plinth setup..."
+
+# Ensure that DBus daemon is running so that Plinth can install
+# various packages via PackgeKit.
+start_dbus
+
+# Run plinth setup to install various necessary program
+plinth --setup
+
+# Stop DBus daemon if we have not started it
+stop_dbus
+
+echo "Done running Plinth setup."


### PR DESCRIPTION
Start DBus daemon to ensure PackageKit can use it.  Only start if it is
not already running.  Stop after setup.  Stop only if we have started
it.

I have done some manual unit testing on the patch.  However, i have not tested with either full image or installing through Debian package.  Not sure if I will get the time to do it in next few days.  I could use some help doing this.