### PR TITLE
Revert "Apply workaround to SSL config for mod_gnutls"

### DIFF
--- a/data/etc/apache2/sites-available/plinth-ssl.conf
+++ b/data/etc/apache2/sites-available/plinth-ssl.conf
@@ -6,11 +6,10 @@
 ##
 ## Requires the following Apache modules to be enabled:
 ##   mod_rewrite
-##   mod_gnutls
+##   mod_ssl or mod_gnutls
 ##
 <Location /plinth>
     RewriteEngine on
-    # FIXME: Workaround for mod_gnutls (Debian Bug #514005)
-    RewriteCond %{SERVER_PORT} !^443$
+    ReWriteCond %{HTTPS} !=on
     RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </Location>


### PR DESCRIPTION
Debian bug #514005 is resolved in mod_gnutls 0.7.4-1.