### PR TITLE
Add Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist/
 .coverage
 plinth/tests/coverage/report/
 *.mo
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure(2) do |config|
+  config.vm.box = "jvalleroy/plinth-dev"
+  config.vm.network "forwarded_port", guest: 443, host: 4430
+  config.vm.provision "shell", inline: <<-SHELL
+    cp -R /vagrant /home/vagrant/plinth
+    cd /home/vagrant/plinth
+    python3 setup.py install
+    systemctl daemon-reload
+    systemctl restart plinth
+  SHELL
+end


### PR DESCRIPTION
Note that this needs the change in #450 (for HTTPS port forwarding). "vagrant up" should download the image and start the VM.

I've only uploaded a virtualbox VM, but Vagrant also supports a number of providers like qemu, libvirt, lxc. If there is interest in maintaining more providers, we could set up an organization at https://atlas.hashicorp.com.