### PR TITLE
Deal with ownCloud removal from Debian

### DIFF
--- a/plinth/modules/owncloud/__init__.py
+++ b/plinth/modules/owncloud/__init__.py
@@ -21,6 +21,7 @@ Plinth module to configure ownCloud
 
 from django.utils.translation import ugettext_lazy as _
 from functools import partial
+import os
 
 from plinth import actions
 from plinth import action_utils
@@ -53,6 +54,11 @@ service = None
 
 def init():
     """Initialize the ownCloud module"""
+    # XXX: ownCloud has been removed from Debian
+    if not os.path.isfile('/etc/owncloud/config.php') and \
+       not os.path.isfile('/etc/owncloud/autoconfig.php'):
+        return
+
     menu = cfg.main_menu.get('apps:index')
     menu.add_urlname(title, 'glyphicon-picture', 'owncloud:index', 700)
 

--- a/plinth/modules/owncloud/templates/owncloud.html
+++ b/plinth/modules/owncloud/templates/owncloud.html
@@ -23,6 +23,17 @@
 
 {% block configuration %}
 
+  <div class="alert alert-danger" role="alert">
+    <span class="glyphicon glyphicon-exclamation-sign"
+          aria-hidden="true"></span>
+    <span class="sr-only">Error:</span>
+    {% blocktrans trimmed %}
+      ownCloud is no longer supported by {{ box_name }} due it's
+      removal from Debian.  Please migrate your data to an alternative
+      solution or manage ownCloud manually from the command line.
+    {% endblocktrans %}
+  </div>
+
   {% include "diagnostics_button.html" with module="owncloud" %}
 
   <h3>{% trans "Configuration" %}</h3>


### PR DESCRIPTION
It has been decided that FreedomBox will no longer support ownCloud due
it's removal from Debian.  To deal with this:

- Don't show ownCloud in Plinth any more for new users.

- For users who have already installed ownCloud, show a warning message
  that they need to migrate away from ownCloud or need to manage it
  manually.