### PR TITLE
config: Update dev configuration default url path

### DIFF
--- a/plinth.config
+++ b/plinth.config
@@ -4,7 +4,7 @@ file_root = %(root)s
 config_dir = %(file_root)s/data/etc/plinth
 data_dir = %(file_root)s/data/var/lib/plinth
 log_dir = %(file_root)s/data/var/log/plinth
-server_dir = /
+server_dir = /plinth
 actions_dir = %(file_root)s/actions
 doc_dir = %(file_root)s/doc
 


### PR DESCRIPTION
I find that I am almost always during development runs using ./run
--debug --no-daemon --server_dir=/plinth .  The daemon part is gone due
to recent changes.  But without specifying --server_dir it will run on /
and since it is not the same as production run, it change this to
/plinth.  I am assuming this also the case with other people.  So,
change the default to /plinth.  I believe this reduces the entry to
development barrier by a tiny bit.