### PR TITLE
Fix quoted values in nslcd config

### DIFF
--- a/actions/users
+++ b/actions/users
@@ -52,11 +52,11 @@ def subcommand_pre_install(_):
         check=True)
     subprocess.run(
         ['debconf-set-selections'],
-        input=b'nslcd nslcd/ldap-uris string "ldapi:///"',
+        input=b'nslcd nslcd/ldap-uris string ldapi:///',
         check=True)
     subprocess.run(
         ['debconf-set-selections'],
-        input=b'nslcd nslcd/ldap-base string "dc=thisbox"',
+        input=b'nslcd nslcd/ldap-base string dc=thisbox',
         check=True)
     subprocess.run(
         ['debconf-set-selections'],


### PR DESCRIPTION
These values were copied from freedombox-setup, but we need to drop the quotes. Otherwise nslcd cannot find the LDAP server.

I built an image with this change patched in, and confirmed that the user's edit page can now be accessed, and the user can login through console or SSH.