### PR TITLE
Issue 496, status message improvement:

### DIFF
--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -371,6 +371,12 @@ case ${cmd} in
         # if we know our WAN IP, only update if IP changes
         if [ "${dnsentry}" != "${wanip}" -a "${wanip}" != ${NOIP} ];then
             doUpdate
+        else
+            # if nothing has changed, nothing needs to be done
+            # but we need to write the success status (if no success was
+            # recorded yet because maybe DNS record was up to date when
+            # script is executed for the first time)
+            ${0} success ${wanip}
         fi
         # if we don't know our WAN IP do a blind update once a hour
         if [ "${wanip}" = ${NOIP} ];then
@@ -391,7 +397,7 @@ case ${cmd} in
     ;;
     success)
         date=$(date)
-        echo "last update done (${date})" > ${STATUSFILE}
+        echo "DNS record is up to date (${date})" > ${STATUSFILE}
         date +%s > ${LASTUPDATE}
         # if called from cronjob, the current IP is given as parameter
         if [ $# -eq 1 ];then


### PR DESCRIPTION
If no update is done because no update needs to be done, the success status needs to be written.
Because maybe the DNS record is up to date when the action script is executed for the first time.
In this case no success message was written and it looks like DynDNS is not executed.