### PR TITLE
Add apps menu with categories to /apps page

### DIFF
--- a/plinth/cfg.py
+++ b/plinth/cfg.py
@@ -42,6 +42,7 @@ server_dir = '/'
 danube_edition = False
 
 main_menu = Menu()
+apps_menu = Menu()
 
 config_file = None
 

--- a/plinth/menu.py
+++ b/plinth/menu.py
@@ -56,6 +56,14 @@ class Menu(object):
 
         raise KeyError('Menu item not found')
 
+    def get_by_label(self, label):
+        """Return a menu item with given label."""
+        for item in self.items:
+            if item.label == label:
+                return item
+
+        raise KeyError('Menu item not found')
+
     def sorted_items(self):
         """Return menu items in sorted order according to current locale."""
         return sorted(self.items, key=lambda x: (x.order, x.label))

--- a/plinth/modules/apps/apps.py
+++ b/plinth/modules/apps/apps.py
@@ -29,4 +29,6 @@ def init():
 
 def index(request):
     """Serve the apps index page"""
-    return TemplateResponse(request, 'apps.html', {'title': _('Applications')})
+    return TemplateResponse(request, 'apps.html',
+                            {'title': _('Applications'),
+                             'apps_menu': cfg.apps_menu})

--- a/plinth/modules/apps/templates/apps.html
+++ b/plinth/modules/apps/templates/apps.html
@@ -41,4 +41,15 @@
     {% endblocktrans %}
   </p>
 
+  {% for item in apps_menu.sorted_items %}
+    <div class="row-sm">
+      <div class="col-sm-4">
+          <h4>{{ item.label }}</h4>
+          {% if item.items %}
+            {% include "menu.html" with menu=item %}
+          {% endif %}
+      </div>
+    </div>
+  {% endfor %}
+
 {% endblock %}

--- a/plinth/modules/deluge/__init__.py
+++ b/plinth/modules/deluge/__init__.py
@@ -39,6 +39,8 @@ managed_packages = ['deluged', 'deluge-web']
 
 title = _('BitTorrent Web Client (Deluge)')
 
+category = _('File Transfer')
+
 description = [
     _('Deluge is a BitTorrent client that features a Web UI.'),
 
@@ -52,6 +54,12 @@ description = [
 def init():
     """Initialize the Deluge module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-magnet', 'deluge:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-magnet', 'deluge:index')
 
     global service

--- a/plinth/modules/ikiwiki/__init__.py
+++ b/plinth/modules/ikiwiki/__init__.py
@@ -39,6 +39,8 @@ service = None
 
 title = _('Wiki and Blog (ikiwiki)')
 
+category = _('Publishing')
+
 description = [
     _('ikiwiki is a simple wiki and blog application. It supports '
       'several lightweight markup languages, including Markdown, and '
@@ -51,6 +53,12 @@ description = [
 def init():
     """Initialize the ikiwiki module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-edit', 'ikiwiki:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-edit', 'ikiwiki:index')
 
     global service

--- a/plinth/modules/minetest/__init__.py
+++ b/plinth/modules/minetest/__init__.py
@@ -40,6 +40,8 @@ managed_packages = ['minetest-server']
 
 title = _('Block Sandbox (Minetest)')
 
+category = _('Games')
+
 description = [
     format_lazy(
         _('Minetest is a multiplayer infinite-world block sandbox. This '
@@ -53,6 +55,12 @@ description = [
 def init():
     """Initialize the module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-th-large', 'minetest:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-th-large', 'minetest:index')
 
     global service

--- a/plinth/modules/mumble/__init__.py
+++ b/plinth/modules/mumble/__init__.py
@@ -33,6 +33,8 @@ depends = ['apps']
 
 title = _('Voice Chat (Mumble)')
 
+category = _('Voice')
+
 service = None
 
 managed_services = ['mumble-server']
@@ -52,6 +54,12 @@ description = [
 def init():
     """Intialize the Mumble module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-headphones', 'mumble:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-headphones', 'mumble:index')
 
     global service

--- a/plinth/modules/openvpn/__init__.py
+++ b/plinth/modules/openvpn/__init__.py
@@ -40,6 +40,8 @@ managed_packages = ['openvpn', 'easy-rsa']
 
 title = _('Virtual Private Network (OpenVPN)')
 
+category = _('Network')
+
 description = [
     format_lazy(
         _('Virtual Private Network (VPN) is a technique for securely '
@@ -55,6 +57,12 @@ description = [
 def init():
     """Intialize the OpenVPN module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-lock', 'openvpn:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-lock', 'openvpn:index')
 
     global service

--- a/plinth/modules/privoxy/__init__.py
+++ b/plinth/modules/privoxy/__init__.py
@@ -41,6 +41,8 @@ managed_packages = ['privoxy']
 
 title = _('Web Proxy (Privoxy)')
 
+category = _('Network')
+
 description = [
     _('Privoxy is a non-caching web proxy with advanced filtering '
       'capabilities for enhancing privacy, modifying web page data and '
@@ -62,6 +64,12 @@ service = None
 def init():
     """Intialize the module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-cloud-upload', 'privoxy:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-cloud-upload', 'privoxy:index')
 
     global service

--- a/plinth/modules/quassel/__init__.py
+++ b/plinth/modules/quassel/__init__.py
@@ -39,6 +39,8 @@ managed_packages = ['quassel-core']
 
 title = _('IRC Client (Quassel)')
 
+category = _('Chat')
+
 description = [
     format_lazy(
         _('Quassel is an IRC application that is split into two parts, a '
@@ -60,6 +62,12 @@ description = [
 def init():
     """Initialize the quassel module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-retweet', 'quassel:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-retweet', 'quassel:index')
 
     global service

--- a/plinth/modules/radicale/__init__.py
+++ b/plinth/modules/radicale/__init__.py
@@ -41,6 +41,8 @@ managed_packages = ['radicale']
 
 title = _('Calendar and Addressbook (Radicale)')
 
+category = _('Organizer')
+
 description = [
     format_lazy(
         _('Radicale is a CalDAV and CardDAV server. It allows synchronization '
@@ -55,6 +57,12 @@ description = [
 def init():
     """Initialize the radicale module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-calendar', 'radicale:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-calendar', 'radicale:index')
 
     global service

--- a/plinth/modules/repro/__init__.py
+++ b/plinth/modules/repro/__init__.py
@@ -37,6 +37,8 @@ managed_packages = ['repro']
 
 title = _('SIP Server (repro)')
 
+category = _('Voice')
+
 description = [
     _('repro provides various SIP services that a SIP softphone can utilize '
       'to provide audio and video calls as well as presence and instant '
@@ -64,6 +66,12 @@ service = None
 def init():
     """Initialize the repro module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-phone-alt', 'repro:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-phone-alt', 'repro:index')
 
     global service

--- a/plinth/modules/restore/__init__.py
+++ b/plinth/modules/restore/__init__.py
@@ -36,6 +36,8 @@ managed_packages = ['node-restore']
 
 title = _('Unhosted Storage (reStore)')
 
+category = _('Data')
+
 description = [
     format_lazy(
         _('reStore is a server for <a href=\'https://unhosted.org/\'>'
@@ -55,6 +57,12 @@ service = None
 def init():
     """Initialize the reStore module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-hdd', 'restore:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-hdd', 'restore:index')
 
     global service

--- a/plinth/modules/roundcube/__init__.py
+++ b/plinth/modules/roundcube/__init__.py
@@ -35,6 +35,8 @@ managed_packages = ['sqlite3', 'roundcube', 'roundcube-sqlite3']
 
 title = _('Email Client (Roundcube)')
 
+category = _('Email')
+
 description = [
     _('Roundcube webmail is a browser-based multilingual IMAP '
       'client with an application-like user interface. It provides '
@@ -63,6 +65,12 @@ service = None
 def init():
     """Intialize the module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-envelope', 'roundcube:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-envelope', 'roundcube:index')
 
     global service

--- a/plinth/modules/shaarli/__init__.py
+++ b/plinth/modules/shaarli/__init__.py
@@ -35,6 +35,8 @@ managed_packages = ['shaarli']
 
 title = _('Bookmarks (Shaarli)')
 
+category = _('Organizer')
+
 description = [
     _('Shaarli allows you to save and share bookmarks.'),
 
@@ -50,6 +52,12 @@ service = None
 def init():
     """Initialize the module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-bookmark', 'shaarli:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-bookmark', 'shaarli:index')
 
     global service

--- a/plinth/modules/tor/__init__.py
+++ b/plinth/modules/tor/__init__.py
@@ -41,6 +41,8 @@ managed_packages = ['tor', 'tor-geoipdb', 'torsocks', 'obfs4proxy',
 
 title = _('Anonymity Network (Tor)')
 
+category = _('Network')
+
 description = [
     _('Tor is an anonymous communication system. You can learn more '
       'about it from the <a href="https://www.torproject.org/">Tor '
@@ -57,6 +59,12 @@ bridge_service = None
 def init():
     """Initialize the module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-eye-close', 'tor:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-eye-close', 'tor:index')
 
     global socks_service

--- a/plinth/modules/transmission/__init__.py
+++ b/plinth/modules/transmission/__init__.py
@@ -38,6 +38,8 @@ managed_packages = ['transmission-daemon']
 
 title = _('BitTorrent (Transmission)')
 
+category = _('File Transfer')
+
 description = [
     _('BitTorrent is a peer-to-peer file sharing protocol. '
       'Transmission daemon handles Bitorrent file sharing.  Note that '
@@ -53,6 +55,12 @@ TRANSMISSION_CONFIG = '/etc/transmission-daemon/settings.json'
 def init():
     """Intialize the Transmission module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-save', 'transmission:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-save', 'transmission:index')
 
     global service

--- a/plinth/modules/ttrss/__init__.py
+++ b/plinth/modules/ttrss/__init__.py
@@ -37,6 +37,8 @@ managed_packages = ['tt-rss', 'postgresql', 'dbconfig-pgsql', 'php-pgsql']
 
 title = _('News Feed Reader (Tiny Tiny RSS)')
 
+category = _('Publishing')
+
 description = [
     _('Tiny Tiny RSS is a news feed (RSS/Atom) reader and aggregator, '
       'designed to allow reading news from any location, while feeling as '
@@ -52,6 +54,12 @@ service = None
 def init():
     """Intialize the module."""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-envelope', 'ttrss:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-envelope', 'ttrss:index')
 
     global service

--- a/plinth/modules/xmpp/__init__.py
+++ b/plinth/modules/xmpp/__init__.py
@@ -42,6 +42,8 @@ managed_packages = ['jwchat', 'ejabberd']
 
 title = _('Chat Server (XMPP)')
 
+category = _('Chat')
+
 description = [
     _('XMPP is an open and standardized communication protocol. Here '
       'you can run and configure your XMPP server, called ejabberd.'),
@@ -60,6 +62,12 @@ logger = logging.getLogger(__name__)
 def init():
     """Initialize the XMPP module"""
     menu = cfg.main_menu.get('apps:index')
+    menu.add_urlname(title, 'glyphicon-comment', 'xmpp:index')
+
+    try:
+        menu = cfg.apps_menu.get_by_label(category)
+    except KeyError:
+        menu = cfg.apps_menu.add_item(category, '', '#')
     menu.add_urlname(title, 'glyphicon-comment', 'xmpp:index')
 
     global service

--- a/plinth/templates/menu.html
+++ b/plinth/templates/menu.html
@@ -20,7 +20,7 @@
 {% load i18n %}
 
 <ul class="nav nav-pills nav-stacked">
-  {% for item in menu.items %}
+  {% for item in menu.sorted_items %}
 
     {% if item.url in active_menu_urls %}
       <li class="active">


### PR DESCRIPTION
This is a first implementation of https://github.com/freedombox/Plinth/issues/267. I started with the categories recommended by @phylophyl but made a few changes.

The layout looks a bit uneven, maybe someone has an idea how to improve that.

![plinth_apps_categories](https://cloud.githubusercontent.com/assets/178876/16636797/5a44f196-43a8-11e6-8864-147b58d0b2ba.png)
