### PR TITLE
Rudimentary support for BATMAN Adv mesh networks

### DIFF
--- a/data/etc/NetworkManager/dispatcher.d/10-freedombox-batman
+++ b/data/etc/NetworkManager/dispatcher.d/10-freedombox-batman
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+set -e  # Exit with code on error
+
+IFACE="$1"
+ACTION="$2"
+
+if [[ "$CONNECTION_ID" != *"BATMAN"* ]]; then
+    exit 0
+fi
+
+case ${ACTION} in
+    up)
+        logger "Setting up B.A.T.M.A.N. Advanced on interface $IFACE"
+        ip link set mtu 1560 dev ${IFACE}
+        modprobe batman-adv
+        echo "bat0" > /sys/class/net/${IFACE}/batman_adv/mesh_iface
+        ip link set up dev bat0
+        ;;
+    down)
+        logger "Clearing B.A.T.M.A.N. Advanced on interface $IFACE"
+        ip link set down dev bat0
+        echo "none" > /sys/class/net/${IFACE}/batman_adv/mesh_iface
+        ip link set mtu 1500 dev ${IFACE}
+        ;;
+    *)
+        ;;
+esac

--- a/plinth/modules/networks/forms.py
+++ b/plinth/modules/networks/forms.py
@@ -188,8 +188,9 @@ class PPPoEForm(EthernetForm):
 
 class WifiForm(ConnectionForm):
     """Form to create/edit a Wi-Fi connection."""
-    field_order = ['name', 'interface', 'zone', 'ssid', 'mode', 'auth_mode',
-                   'passphrase', 'ipv4_method', 'ipv4_address', 'ipv4_netmask',
+    field_order = ['name', 'interface', 'zone', 'ssid', 'mode', 'band',
+                   'channel', 'bssid', 'auth_mode', 'passphrase',
+                   'ipv4_method', 'ipv4_address', 'ipv4_netmask',
                    'ipv4_gateway', 'ipv4_dns', 'ipv4_second_dns']
 
     ssid = forms.CharField(
@@ -200,6 +201,27 @@ class WifiForm(ConnectionForm):
         choices=[('infrastructure', _('Infrastructure')),
                  ('ap', _('Access Point')),
                  ('adhoc', _('Ad-hoc'))])
+    band = forms.ChoiceField(
+        label=_('Frequency Band'),
+        choices=[('auto', _('Automatic')),
+                 ('a', _('A (5 GHz)')),
+                 ('bg', _('B/G (2.4 GHz)'))])
+    channel = forms.IntegerField(
+        label=_('Channel'),
+        help_text=_('Optional value. Wireless channel in the selected '
+                    'frequency band to restrict to. Blank or 0 value means '
+                    'automatic selection.'),
+        min_value=0,
+        max_value=255,
+        required=False)
+    bssid = forms.RegexField(
+        label=_('BSSID'),
+        help_text=_('Optional value. Unique identifier for the access point. '
+                    'When connecting to an access point, connect only if the '
+                    'BSSID of the access point matches the one provided. '
+                    'Example: 00:11:22:aa:bb:cc.'),
+        regex=r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$',
+        required=False)
     auth_mode = forms.ChoiceField(
         label=_('Authentication Mode'),
         help_text=_('Select WPA if the wireless network is secured and \
@@ -224,6 +246,9 @@ requires clients to have the password to connect.'),
         settings['wireless'] = {
             'ssid': self.cleaned_data['ssid'],
             'mode': self.cleaned_data['mode'],
+            'band': self.cleaned_data['band'],
+            'channel': self.cleaned_data['channel'],
+            'bssid': self.cleaned_data['bssid'],
             'auth_mode': self.cleaned_data['auth_mode'],
             'passphrase': self.cleaned_data['passphrase'],
         }

--- a/plinth/modules/networks/forms.py
+++ b/plinth/modules/networks/forms.py
@@ -124,6 +124,21 @@ available over this interfaces. Select Internal only for trusted networks.'),
         return ipv4
 
 
+class GenericForm(ConnectionForm):
+    """Form to create/edit a generic connection."""
+    def __init__(self, *args, **kwargs):
+        """Initialize the form, populate interface choices."""
+        super(GenericForm, self).__init__(*args, **kwargs)
+        choices = self._get_interface_choices(nm.DeviceType.GENERIC)
+        self.fields['interface'].choices = choices
+
+    def get_settings(self):
+        """Return settings dict from cleaned data."""
+        settings = super().get_settings()
+        settings['common']['type'] = 'generic'
+        return settings
+
+
 class EthernetForm(ConnectionForm):
     """Form to create/edit a ethernet connection."""
     def __init__(self, *args, **kwargs):

--- a/plinth/modules/networks/forms.py
+++ b/plinth/modules/networks/forms.py
@@ -45,7 +45,8 @@ class ConnectionForm(forms.Form):
         label=_('Firewall Zone'),
         help_text=_('The firewall zone will control which services are \
 available over this interfaces. Select Internal only for trusted networks.'),
-        choices=[('external', 'External'), ('internal', 'Internal')])
+        choices=[('external', _('External')),
+                 ('internal', _('Internal'))])
     ipv4_method = forms.ChoiceField(
         label=_('IPv4 Addressing Method'),
         help_text=format_lazy(
@@ -55,9 +56,10 @@ available over this interfaces. Select Internal only for trusted networks.'),
                 'method will make {box_name} act as a router, configure '
                 'clients on this network and share its Internet connection.'),
             box_name=ugettext_lazy(cfg.box_name)),
-        choices=[('auto', 'Automatic (DHCP)'),
-                 ('shared', 'Shared'),
-                 ('manual', 'Manual')])
+        choices=[('auto', _('Automatic (DHCP)')),
+                 ('shared', _('Shared')),
+                 ('manual', _('Manual')),
+                 ('disabled', _('Disabled'))])
     ipv4_address = forms.CharField(
         label=_('Address'),
         validators=[validators.validate_ipv4_address],
@@ -195,14 +197,15 @@ class WifiForm(ConnectionForm):
         help_text=_('The visible name of the network.'))
     mode = forms.ChoiceField(
         label=_('Mode'),
-        choices=[('infrastructure', 'Infrastructure'),
-                 ('ap', 'Access Point'),
-                 ('adhoc', 'Ad-hoc')])
+        choices=[('infrastructure', _('Infrastructure')),
+                 ('ap', _('Access Point')),
+                 ('adhoc', _('Ad-hoc'))])
     auth_mode = forms.ChoiceField(
         label=_('Authentication Mode'),
         help_text=_('Select WPA if the wireless network is secured and \
 requires clients to have the password to connect.'),
-        choices=[('wpa', 'WPA'), ('open', 'Open')])
+        choices=[('wpa', _('WPA')),
+                 ('open', _('Open'))])
     passphrase = forms.CharField(
         label=_('Passphrase'),
         validators=[validators.MinLengthValidator(8)],

--- a/plinth/modules/networks/networks.py
+++ b/plinth/modules/networks/networks.py
@@ -164,6 +164,9 @@ def edit(request, uuid):
             settings_wireless = connection.get_setting_wireless()
             form_data['ssid'] = settings_wireless.get_ssid().get_data()
             form_data['mode'] = settings_wireless.get_mode()
+            form_data['band'] = settings_wireless.get_band() or 'auto'
+            form_data['channel'] = settings_wireless.get_channel()
+            form_data['bssid'] = settings_wireless.get_bssid()
             try:
                 wifi_sec = connection.get_setting_wireless_security()
                 if wifi_sec:
@@ -328,6 +331,7 @@ def add_wifi(request, ssid=None, interface_name=None):
                      'zone': 'external',
                      'ssid': ssid,
                      'mode': 'infrastructure',
+                     'band': 'auto',
                      'auth_mode': 'wpa',
                      'ipv4_method': 'auto'}
 

--- a/plinth/modules/networks/templates/connections_edit.html
+++ b/plinth/modules/networks/templates/connections_edit.html
@@ -68,9 +68,12 @@
                 ipv4_required(false, ['address']);
                 ipv4_readonly(false, ['address', 'netmask']);
                 ipv4_readonly(true, ['gateway', 'dns', 'second_dns']);
-            } else {
+            } else if ($("#id_ipv4_method").prop("value") == "auto") {
                 ipv4_readonly(true, ['address', 'netmask', 'gateway']);
                 ipv4_readonly(false, ['dns', 'second_dns']);
+            } else {
+                ipv4_readonly(true, ['address', 'netmask', 'gateway', 'dns',
+                                     'second_dns']);
             }
         }
 

--- a/plinth/modules/networks/urls.py
+++ b/plinth/modules/networks/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
         name='deactivate'),
     url(r'^sys/networks/scan/$', views.scan, name='scan'),
     url(r'^sys/networks/add/$', views.add, name='add'),
+    url(r'^sys/networks/add/generic/$', views.add_generic, name='add_generic'),
     url(r'^sys/networks/add/ethernet/$', views.add_ethernet,
         name='add_ethernet'),
     url(r'^sys/networks/add/pppoe/$', views.add_pppoe, name='add_pppoe'),

--- a/plinth/network.py
+++ b/plinth/network.py
@@ -36,7 +36,8 @@ logger = logging.getLogger(__name__)
 CONNECTION_TYPE_NAMES = collections.OrderedDict([
     ('802-3-ethernet', _('Ethernet')),
     ('802-11-wireless', _('Wi-Fi')),
-    ('pppoe', _('PPPoE'))
+    ('pppoe', _('PPPoE')),
+    ('generic', _('Generic')),
 ])
 
 

--- a/plinth/network.py
+++ b/plinth/network.py
@@ -383,6 +383,14 @@ def _update_wireless_settings(connection, wireless):
     ssid_gbytes = glib.Bytes.new(wireless['ssid'].encode())
     settings.set_property(nm.SETTING_WIRELESS_SSID, ssid_gbytes)
     settings.set_property(nm.SETTING_WIRELESS_MODE, wireless['mode'])
+    band = wireless['band'] if wireless['band'] != 'auto' else None
+    settings.set_property(nm.SETTING_WIRELESS_BAND, band)
+    channel = wireless['channel']
+    if wireless['band'] == 'auto' or not wireless['channel']:
+        channel = 0
+
+    settings.set_property(nm.SETTING_WIRELESS_CHANNEL, channel)
+    settings.set_property(nm.SETTING_WIRELESS_BSSID, wireless['bssid'] or None)
 
     # Wireless Security
     if wireless['auth_mode'] == 'wpa' and wireless['passphrase']:

--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,8 @@ setuptools.setup(
                  glob.glob('data/etc/apache2/sites-available/*.conf')),
                 ('/etc/ikiwiki',
                  glob.glob('data/etc/ikiwiki/*.setup')),
+                ('/etc/NetworkManager/dispatcher.d/',
+                 ['data/etc/NetworkManager/dispatcher.d/10-freedombox-batman']),
                 ('/etc/sudoers.d', ['data/etc/sudoers.d/plinth']),
                 ('/lib/systemd/system',
                  ['data/lib/systemd/system/plinth.service']),


### PR DESCRIPTION
Most of the changes are about adding additional fields/types for configuration with network manager.  The final patch is a small NetworkManager dispatcher script to configure interfaces as BATMAN adv interfaces.

To configure a batman-adv mesh network: first create a connection with a Wi-Fi device, mode as ad-hoc, with a known frequency and BSSID.  The name of the connection should have contain `BATMAN` in it.  It should also have IPv4 method as disabled.  Second connection should be created for 'bat0' interface after the first one is successful.  It can be with method 'shared' for sharing internet connection and answering DHCP requests or 'auto' for acquiring IP address from another node in the mesh network.