### PR TITLE
Restrict usernames to avoid collision with system users

### DIFF
--- a/plinth/modules/first_boot/forms.py
+++ b/plinth/modules/first_boot/forms.py
@@ -35,7 +35,7 @@ from plinth import cfg
 from plinth.errors import ActionError, DomainRegistrationError
 from plinth.modules.pagekite.utils import PREDEFINED_SERVICES, run
 from plinth.modules.security import set_restricted_access
-from plinth.modules.users.forms import GROUP_CHOICES
+from plinth.modules.users.forms import GROUP_CHOICES, RESTRICTED_USERNAMES
 from plinth.utils import format_lazy
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,8 @@ class State1Form(auth.forms.UserCreationForm):
             # Exit code 0 means that the username is already in use.
             raise ValidationError(_('Username is reserved'))
         except subprocess.CalledProcessError:
-            pass
+            if username in RESTRICTED_USERNAMES:
+                raise ValidationError(_('Username is reserved'))
 
         return super().clean()
 

--- a/plinth/modules/users/forms.py
+++ b/plinth/modules/users/forms.py
@@ -27,6 +27,23 @@ from django.utils.translation import ugettext as _, ugettext_lazy
 from plinth import actions
 from plinth.errors import ActionError
 
+# Usernames used by optional services (that might not be installed yet).
+RESTRICTED_USERNAMES = [
+    'debian-deluged',
+    'Debian-minetest',
+    'debian-tor',
+    'debian-transmission',
+    'ejabberd',
+    'ez-ipupd',
+    'monkeysphere',
+    'mumble-server',
+    'node-restore',
+    'quasselcore',
+    'radicale',
+    'repro',
+    'privoxy',
+]
+
 GROUP_CHOICES = (
     ('admin', _('admin')),
     ('wiki', _('wiki')),
@@ -66,7 +83,8 @@ class CreateUserForm(UserCreationForm):
             # Exit code 0 means that the username is already in use.
             raise ValidationError(_('Username is reserved'))
         except subprocess.CalledProcessError:
-            pass
+            if username in RESTRICTED_USERNAMES:
+                raise ValidationError(_('Username is reserved'))
 
         return super().clean()
 
@@ -139,7 +157,8 @@ class UserUpdateForm(forms.ModelForm):
             # Exit code 0 means that the username is already in use.
             raise ValidationError(_('Username is reserved'))
         except subprocess.CalledProcessError:
-            pass
+            if username in RESTRICTED_USERNAMES:
+                raise ValidationError(_('Username is reserved'))
 
         return super().clean()
 


### PR DESCRIPTION
Fixes #491. This will check new usernames to make sure they are not currently in use, or used by optional services.

One issue, when renaming a user, although the name change is rejected, the form is returned showing the rejected username at the top (and an invalid link for "change password").