### PR TITLE
Added a missing dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -30,7 +30,8 @@
     python3-requests \
     python3-setuptools \
     python3-yaml \
-    xmlto
+    xmlto \
+    docbook-utils
 
 2. Install Plinth:
 
@@ -46,3 +47,14 @@
 4. Access Plinth UI:
 
     Plinth UI should be accessible at http://localhost:8000
+
+Note:- 
+Django 1.9 is required to run plinth
+You can check the version by running django-admin --version in terminal
+If apt-get provided django<=1.9 then follow the below steps
+i) Uninstall Older django versions
+	sudo apt-get remove python3-django python3-django-stronghold python3-bootstrap 
+ii) Install Python3 pip
+	sudo apt-get install python3-pip 
+iii) Install django1.9 through pip 
+	sudo pip3 install django django-bootstrap-form django-stronghold  --upgrade


### PR DESCRIPTION
docbook-utils package is needed to install plinth in some of the debain bases systems. So Needed to add it . Also Simple_tag functionality is not working properly in django 1.8 we need django1.9 for it So I added it as an extra dependency and steps to install it.