### PR TITLE
Switch to official vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 Vagrant.configure(2) do |config|
-  config.vm.box = "jvalleroy/plinth-dev"
+  config.vm.box = "freedombox/plinth-dev"
   config.vm.network "forwarded_port", guest: 443, host: 4430
   config.vm.provision "shell", inline: <<-SHELL
     cd /vagrant/


### PR DESCRIPTION
- Use vagrant box from https://atlas.hashicorp.com/freedombox/boxes/plinth-dev
- v0.9.0 box for virtualbox provider has been uploaded.
- This was converted from FreedomBox 0.9 virtualbox-amd64 image.
- Used latest freedom-maker script, so it uses contrib but not non-free.