### PR TITLE
Migrate to Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ sudo: required
 language: generic
 
 env:
-  - DJANGO_VERSION=">=1.7.0,<1.8.0"
-  - DJANGO_VERSION=">=1.8.0,<1.9.0"
-  - DJANGO_VERSION=">=1.9.0"
+  - DJANGO_VERSION=">=1.10.0"
 
 # Debian packages required
 before_install:

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -217,7 +217,6 @@ def configure_django():
         LOGGING=logging_configuration,
         LOGIN_URL='users:login',
         LOGIN_REDIRECT_URL='apps:index',
-        LOGOUT_URL='users:logout',
         MESSAGE_TAGS={message_constants.ERROR: 'danger'},
         MIDDLEWARE_CLASSES=(
             'django.contrib.sessions.middleware.SessionMiddleware',

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -197,6 +197,13 @@ def configure_django():
     if cfg.secure_proxy_ssl_header:
         secure_proxy_ssl_header = (cfg.secure_proxy_ssl_header, 'https')
 
+    # XXX: We want use STRONGHOLD_PUBLIC_NAMED_URLS, however, due to a
+    # bug in stronghold, it compares request.path_info with reversed
+    # URLs.  This leads to a mismatch when script_prefix is set.
+    # Remove this hack once the bug is fixed.  See:
+    # https://github.com/mgrouchy/django-stronghold/issues/52
+    public_urls = ('/accounts/login/', '/accounts/logout/')
+
     django.conf.settings.configure(
         ALLOWED_HOSTS=['*'],
         CACHES={'default':
@@ -229,7 +236,7 @@ def configure_django():
         SESSION_ENGINE='django.contrib.sessions.backends.file',
         SESSION_FILE_PATH=sessions_directory,
         STATIC_URL='/'.join([cfg.server_dir, 'static/']).replace('//', '/'),
-        STRONGHOLD_PUBLIC_NAMED_URLS=('users:login', 'users:logout'),
+        STRONGHOLD_PUBLIC_URLS=public_urls,
         TEMPLATES=templates,
         USE_L10N=True,
         USE_X_FORWARDED_HOST=cfg.use_x_forwarded_host)

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -138,12 +138,6 @@ def setup_server():
 
 def configure_django():
     """Setup Django configuration in the absense of .settings file"""
-
-    # In module_loader.py we reverse URLs for the menu before having a proper
-    # request. In this case, get_script_prefix (used by reverse) returns the
-    # wrong prefix. Set it here manually to have the correct prefix right away.
-    django.core.urlresolvers.set_script_prefix(cfg.server_dir)
-
     logging_configuration = {
         'version': 1,
         'disable_existing_loggers': False,
@@ -211,6 +205,7 @@ def configure_django():
                    {'ENGINE': 'django.db.backends.sqlite3',
                     'NAME': cfg.store_file}},
         DEBUG=cfg.debug,
+        FORCE_SCRIPT_NAME=cfg.server_dir,
         INSTALLED_APPS=applications,
         LOGGING=logging_configuration,
         LOGIN_URL='users:login',
@@ -238,7 +233,7 @@ def configure_django():
         TEMPLATES=templates,
         USE_L10N=True,
         USE_X_FORWARDED_HOST=cfg.use_x_forwarded_host)
-    django.setup()
+    django.setup(set_prefix=True)
 
     logger.info('Configured Django with applications - %s', applications)
 

--- a/plinth/menu.py
+++ b/plinth/menu.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class Menu(object):

--- a/plinth/middleware.py
+++ b/plinth/middleware.py
@@ -19,8 +19,8 @@
 Django middleware to show pre-setup message and setup progress.
 """
 
+from django import urls
 from django.contrib import messages
-from django.core import urlresolvers
 from django.utils.translation import ugettext_lazy as _
 import logging
 
@@ -41,8 +41,8 @@ class SetupMiddleware(object):
         # Perform a URL resolution. This is slightly inefficient as
         # Django will do this resolution again.
         try:
-            resolver_match = urlresolvers.resolve(request.path_info)
-        except urlresolvers.Resolver404:
+            resolver_match = urls.resolve(request.path_info)
+        except urls.Resolver404:
             return
 
         if not resolver_match.namespaces or not len(resolver_match.namespaces):

--- a/plinth/modules/disks/views.py
+++ b/plinth/modules/disks/views.py
@@ -20,9 +20,9 @@ Views for disks module.
 """
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from plinth.modules import disks as disks_module

--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -18,7 +18,7 @@
 from django import forms
 from django.contrib import messages
 from django.core import validators
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django.template.response import TemplateResponse
 import logging

--- a/plinth/modules/first_boot/middleware.py
+++ b/plinth/modules/first_boot/middleware.py
@@ -20,8 +20,8 @@ Django middleware to redirect to firstboot wizard if it has not be run
 yet.
 """
 
-from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
+from django.urls import reverse
 import logging
 
 from plinth import kvstore
@@ -48,7 +48,8 @@ class FirstBootMiddleware(object):
         if state >= 10 and user_requests_firstboot:
             return HttpResponseRedirect(reverse('index'))
 
-        # Setup is not complete: Forbid accessing anything but firstboot or help
+        # Setup is not complete: Forbid accessing anything but
+        # firstboot or help
         if state < 10 and not user_requests_firstboot and \
            not user_requests_help:
             return HttpResponseRedirect(reverse('first_boot:state%d' % state))

--- a/plinth/modules/first_boot/views.py
+++ b/plinth/modules/first_boot/views.py
@@ -17,9 +17,9 @@
 
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse_lazy
 from django.http.response import HttpResponseRedirect
 from django.shortcuts import render
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _
 from django.views.generic import CreateView, FormView, TemplateView
 

--- a/plinth/modules/first_boot/views.py
+++ b/plinth/modules/first_boot/views.py
@@ -19,8 +19,7 @@ from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse_lazy
 from django.http.response import HttpResponseRedirect
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 from django.utils.translation import ugettext as _
 from django.views.generic import CreateView, FormView, TemplateView
 
@@ -67,10 +66,9 @@ def state10(request):
 
     connections = network.get_connection_list()
 
-    return render_to_response('firstboot_state10.html',
-                              {'title': _('Setup Complete'),
-                               'connections': connections},
-                              context_instance=RequestContext(request))
+    return render(request, 'firstboot_state10.html',
+                  {'title': _('Setup Complete'),
+                   'connections': connections})
 
 
 class State5View(FormView):

--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -20,9 +20,9 @@ Plinth module for configuring ikiwiki
 """
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _, ugettext_lazy
 
 from plinth import actions

--- a/plinth/modules/letsencrypt/views.py
+++ b/plinth/modules/letsencrypt/views.py
@@ -20,9 +20,9 @@ Plinth module for using Let's Encrypt.
 """
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 import json

--- a/plinth/modules/monkeysphere/views.py
+++ b/plinth/modules/monkeysphere/views.py
@@ -20,9 +20,9 @@ Views for the monkeysphere module.
 """
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 import json

--- a/plinth/modules/networks/networks.py
+++ b/plinth/modules/networks/networks.py
@@ -16,9 +16,9 @@
 #
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django.views.decorators.http import require_POST
 from logging import Logger

--- a/plinth/modules/pagekite/views.py
+++ b/plinth/modules/pagekite/views.py
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.http.response import HttpResponseRedirect
 from django.template.response import TemplateResponse
+from django.urls import reverse, reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import View, TemplateView
 from django.views.generic.edit import FormView

--- a/plinth/modules/power/views.py
+++ b/plinth/modules/power/views.py
@@ -20,9 +20,9 @@ Plinth module for power module.
 """
 
 from django.forms import Form
-from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from plinth import actions

--- a/plinth/modules/upgrades/views.py
+++ b/plinth/modules/upgrades/views.py
@@ -20,8 +20,8 @@ Plinth module for upgrades
 """
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse_lazy
 from django.template.response import TemplateResponse
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django.views.generic.edit import FormView
 import subprocess

--- a/plinth/modules/users/urls.py
+++ b/plinth/modules/users/urls.py
@@ -21,7 +21,7 @@ URLs for the Users module
 
 from django.conf.urls import url
 from django.contrib.auth import views as auth_views
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 from . import views
 

--- a/plinth/modules/users/views.py
+++ b/plinth/modules/users/views.py
@@ -19,7 +19,7 @@ from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.models import User
 from django.contrib.messages.views import SuccessMessageMixin
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.views.generic.edit import (CreateView, DeleteView, UpdateView,
                                        FormView)
 from django.views.generic import ListView

--- a/plinth/tests/test_menu.py
+++ b/plinth/tests/test_menu.py
@@ -19,9 +19,9 @@
 Test module for menus.
 """
 
-from django.core.urlresolvers import reverse
 from django.http import HttpRequest
 from django.test import TestCase
+from django.urls import reverse
 import random
 
 from plinth.menu import Menu

--- a/plinth/tests/test_middleware.py
+++ b/plinth/tests/test_middleware.py
@@ -67,7 +67,7 @@ class TestSetupMiddleware(TestCase):
         self.assertEqual(response, None)
 
     @patch('plinth.module_loader.loaded_modules')
-    @patch('django.core.urlresolvers.resolve')
+    @patch('django.urls.resolve')
     def test_module_is_up_to_date(self, resolve, loaded_modules):
         """Test that none is returned when module is up-to-date."""
         resolve.return_value.namespaces = ['mockapp']
@@ -84,7 +84,7 @@ class TestSetupMiddleware(TestCase):
 
     @patch('plinth.views.SetupView')
     @patch('plinth.module_loader.loaded_modules')
-    @patch('django.core.urlresolvers.resolve')
+    @patch('django.urls.resolve')
     def test_module_view(self, resolve, loaded_modules, setup_view):
         """Test that setup view is returned."""
         resolve.return_value.namespaces = ['mockapp']
@@ -102,7 +102,7 @@ class TestSetupMiddleware(TestCase):
 
     @patch('django.contrib.messages.success')
     @patch('plinth.module_loader.loaded_modules')
-    @patch('django.core.urlresolvers.resolve')
+    @patch('django.urls.resolve')
     def test_install_result_collection(self, resolve, loaded_modules,
                                        messages_success):
         """Test that module installation result is collected properly."""

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -21,10 +21,10 @@ Main Plinth views
 
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 import time
 

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ setuptools.setup(
     setup_requires=['setuptools-git'],
     install_requires=[
         'cherrypy >= 3.0',
-        'django >= 1.7.0',
+        'django >= 1.10.0',
         'django-bootstrap-form',
         'django-stronghold',
         'psutil',


### PR DESCRIPTION
This patch is based on @harry-7 's fix for #544 which is #546 .

I went through the complete Django 1.10 release notes for deprecations and removals.  I fixed all that noticed.  Also, since testing also has Django 1.10, this patch proposes depending on it as minimum version.