### PR TITLE
users: Fix editing users without SSH keys

### DIFF
--- a/plinth/modules/users/views.py
+++ b/plinth/modules/users/views.py
@@ -88,8 +88,13 @@ class UserUpdate(ContextMixin, SuccessMessageMixin, UpdateView):
     def get_initial(self):
         """Return the data for initial form load."""
         initial = super(UserUpdate, self).get_initial()
-        initial['ssh_keys'] = actions.superuser_run(
-            'ssh', ['get-keys', '--username', self.object.username]).strip()
+        try:
+            ssh_keys = actions.superuser_run(
+                'ssh', ['get-keys', '--username', self.object.username])
+            initial['ssh_keys'] = ssh_keys.strip()
+        except ActionError:
+            pass
+
         return initial
 
     def get_success_url(self):


### PR DESCRIPTION
When SSH keys are not available for a user, the current user edit form
errors out.  Fix this by ignoring ssh key load errors.

This fixes part of the bug #449.