### PR TITLE
transmission: Read configuration as super user

### DIFF
--- a/actions/transmission
+++ b/actions/transmission
@@ -37,13 +37,10 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
-    # Enable service
     subparsers.add_parser('enable', help='Enable Transmission service')
-
-    # Disable service
     subparsers.add_parser('disable', help='Disable Transmission service')
-
-    # Merge given JSON configration with existing
+    subparsers.add_parser(
+        'get-configuration', help='Return the current configuration')
     subparsers.add_parser(
         'merge-configuration',
         help='Merge JSON configuration from stdin with existing')
@@ -61,6 +58,12 @@ def subcommand_disable(_):
     """Stop Transmission service."""
     action_utils.webserver_disable('transmission-plinth')
     action_utils.service_disable('transmission-daemon')
+
+
+def subcommand_get_configuration(_):
+    """Return the current configuration in JSON format."""
+    configuration = open(TRANSMISSION_CONFIG, 'r').read()
+    print(configuration)
 
 
 def subcommand_merge_configuration(arguments):

--- a/plinth/modules/transmission/__init__.py
+++ b/plinth/modules/transmission/__init__.py
@@ -47,8 +47,6 @@ description = [
 
 service = None
 
-TRANSMISSION_CONFIG = '/etc/transmission-daemon/settings.json'
-
 
 def init():
     """Intialize the Transmission module."""

--- a/plinth/modules/transmission/views.py
+++ b/plinth/modules/transmission/views.py
@@ -42,7 +42,8 @@ class TransmissionServiceView(views.ServiceView):
 
     def get_initial(self):
         """Get the current settings from Transmission server."""
-        configuration = open(transmission.TRANSMISSION_CONFIG, 'r').read()
+        configuration = actions.superuser_run(
+            'transmission', ['get-configuration'])
         status = json.loads(configuration)
         status = {key.translate(str.maketrans({'-': '_'})): value
                   for key, value in status.items()}


### PR DESCRIPTION
Due to permission restrictions on the configuration file (due to stored
password), it is not possible to read it as plinth user.  Read it using
sudo instead.