### PR TITLE
users: Fix checking restricted usernames

### DIFF
--- a/plinth/modules/users/forms.py
+++ b/plinth/modules/users/forms.py
@@ -52,12 +52,15 @@ GROUP_CHOICES = (
 
 class ValidNewUsernameCheckMixin(object):
     """Mixin to check if a username is valid for created new user."""
-    def clean(self):
+    def clean_username(self):
         """Check for username collisions with system users."""
-        if not self.is_valid_new_username():
-            raise ValidationError(_('Username is taken or is reserved'))
+        username = self.cleaned_data['username']
+        if self.instance.username != username and \
+           not self.is_valid_new_username():
+            raise ValidationError(_('Username is taken or is reserved.'),
+                                  code='invalid')
 
-        return super().clean()
+        return username
 
     def is_valid_new_username(self):
         """Check for username collisions with system users."""


### PR DESCRIPTION
When editing an existing user, error is being thrown due to restricted
usernames check.  This is due to the username matching existing
username.

Also:

- Raise the validation error on the field instead of the entire form.

- Send error code along with validation error message.

- End the validation error message with a full stop for consistency.