### PR TITLE
upgrades: Run status operations as non-root

### DIFF
--- a/actions/upgrades
+++ b/actions/upgrades
@@ -28,6 +28,8 @@ import sys
 
 CONF_FILE = '/etc/apt/apt.conf.d/50unattended-upgrades'
 AUTO_CONF_FILE = '/etc/apt/apt.conf.d/20auto-upgrades'
+LOCK_FILE = '/var/lib/dpkg/lock'
+LOG_FILE = '/var/log/unattended-upgrades/unattended-upgrades.log'
 
 
 def parse_arguments():
@@ -35,18 +37,14 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
-    # Run unattended-upgrades
     subparsers.add_parser('run', help='Upgrade packages on the system')
-
-    # Check if automatic upgrades are enabled
     subparsers.add_parser('check-auto',
                           help='Check if automatic upgrades are enabled')
-
-    # Enable automatic upgrades
     subparsers.add_parser('enable-auto', help='Enable automatic upgrades')
-
-    # Disable automatic upgrades
     subparsers.add_parser('disable-auto', help='Disable automatic upgrades.')
+    subparsers.add_parser('is-package-manager-busy',
+                          help='Return whether package manager is busy')
+    subparsers.add_parser('get-log', help='Print the automatic upgrades log')
 
     return parser.parse_args()
 
@@ -128,6 +126,23 @@ def setup():
             conffile.write(line)
             if re.match(r'\s*Unattended-Upgrade::Origins-Pattern\s+{', line):
                 conffile.write('        "origin=Debian";\n')
+
+
+def subcommand_is_package_manager_busy(_):
+    """Return whether package manager is busy."""
+    try:
+        subprocess.check_output(['lsof', LOCK_FILE])
+    except subprocess.CalledProcessError:
+        sys.exit(-1)
+
+
+def subcommand_get_log(_):
+    """Print the automatic upgrades log."""
+    try:
+        with open(LOG_FILE, 'r') as file_handle:
+            print(file_handle.read())
+    except IOError:
+        pass
 
 
 def main():

--- a/plinth/modules/upgrades/views.py
+++ b/plinth/modules/upgrades/views.py
@@ -36,9 +36,6 @@ subsubmenu = [{'url': reverse_lazy('upgrades:index'),
               {'url': reverse_lazy('upgrades:upgrade'),
                'text': ugettext_lazy('Upgrade Packages')}]
 
-LOG_FILE = '/var/log/unattended-upgrades/unattended-upgrades.log'
-LOCK_FILE = '/var/log/dpkg/lock'
-
 
 class UpgradesConfigurationView(FormView):
     """Serve configuration page."""
@@ -91,19 +88,15 @@ class UpgradesConfigurationView(FormView):
 def is_package_manager_busy():
     """Return whether a package manager is running."""
     try:
-        subprocess.check_output(['lsof', '/var/lib/dpkg/lock'])
+        actions.superuser_run('upgrades', ['is-package-manager-busy'])
         return True
-    except subprocess.CalledProcessError:
+    except actions.ActionError:
         return False
 
 
 def get_log():
     """Return the current log for unattended upgrades."""
-    try:
-        with open(LOG_FILE, 'r') as file_handle:
-            return file_handle.read()
-    except IOError:
-        return None
+    return actions.superuser_run('upgrades', ['get-log'])
 
 
 def upgrade(request):


### PR DESCRIPTION
Current check whether the package manager is busy and getting the
unattended upgrades log requires root.  This will not allow Plinth to
run as non-root.  Fix this by moving the operations to actions script.