### PR TITLE
users: Display error message if unable to set SSH keys

### DIFF
--- a/plinth/modules/users/forms.py
+++ b/plinth/modules/users/forms.py
@@ -207,9 +207,15 @@ class UserUpdateForm(ValidNewUsernameCheckMixin, forms.ModelForm):
                         messages.error(self.request,
                                        _('Failed to add user to group.'))
 
-            actions.superuser_run(
-                'ssh', ['set-keys', '--username', user.get_username(),
-                        '--keys', self.cleaned_data['ssh_keys'].strip()])
+            try:
+                actions.superuser_run(
+                    'ssh', ['set-keys', '--username', user.get_username(),
+                            '--keys', self.cleaned_data['ssh_keys'].strip()])
+            except ActionError:
+                messages.error(
+                    self.request,
+                    _('Unable to set SSH keys. Please wait a minute and then '
+                      'try again.'))
 
         return user
 


### PR DESCRIPTION
This handles the exception in #449 when setting the SSH keys (but doesn't fix the underlying issue).

If the username was recently changed, it might take up to a minute or so for the new username to be available for get_user_homedir. This change will display an error message so that the user knows the SSH key wasn't set, and asks them to try again after a minute.