### PR TITLE
Exit with error if any of the setup steps fail

### DIFF
--- a/data/usr/lib/freedombox/first-run.d/90_firewall
+++ b/data/usr/lib/freedombox/first-run.d/90_firewall
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Exit with an error code on any failure
+set -e
+
 # Enable tracing to see the commands in
 # /var/log/freedombox-first-run.log
 set -x

--- a/data/usr/lib/freedombox/setup.d/86_plinth
+++ b/data/usr/lib/freedombox/setup.d/86_plinth
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+set -e
+
 # Enable Apache modules required for Plinth.
 
 echo "Configuring Apache for Plinth..."


### PR DESCRIPTION
We have been facing issues with Plinth failing silently during builds.  Make the entire build fail if any of the steps fail.  Internally, Plinth already exits with proper error code when the setup steps fail.