### PR TITLE
Front page

### DIFF
--- a/plinth/frontpage.py
+++ b/plinth/frontpage.py
@@ -1,0 +1,42 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Manage application shortcuts on front page.
+"""
+
+shortcuts = {}
+
+
+def get_shortcuts():
+    """Return menu items in sorted order according to current locale."""
+    return sorted(shortcuts.values(), key=lambda x: x['label'])
+
+
+def add_shortcut(app, label, url, icon):
+    """Add shortcut to front page."""
+    shortcuts[app] = {
+        'label': label,
+        'url': url,
+        'icon': icon,
+    }
+
+
+def remove_shortcut(app):
+    """Remove shortcut from front page."""
+    if app in shortcuts:
+        del shortcuts[app]

--- a/plinth/frontpage.py
+++ b/plinth/frontpage.py
@@ -27,12 +27,14 @@ def get_shortcuts():
     return sorted(shortcuts.values(), key=lambda x: x['label'])
 
 
-def add_shortcut(app, label, url, icon):
+def add_shortcut(app, label, url, icon, details=None):
     """Add shortcut to front page."""
     shortcuts[app] = {
+        'app': app,
         'label': label,
         'url': url,
         'icon': icon,
+        'details': details,
     }
 
 

--- a/plinth/frontpage.py
+++ b/plinth/frontpage.py
@@ -19,23 +19,23 @@
 Manage application shortcuts on front page.
 """
 
-shortcuts = {}
+shortcuts = []
 
 
 def get_shortcuts():
     """Return menu items in sorted order according to current locale."""
-    return sorted(shortcuts.values(), key=lambda x: x['label'])
+    return sorted(shortcuts, key=lambda x: x['label'])
 
 
 def add_shortcut(app, label, url, icon, details=None):
     """Add shortcut to front page."""
-    shortcuts[app] = {
+    shortcuts.append({
         'app': app,
         'label': label,
         'url': url,
         'icon': icon,
         'details': details,
-    }
+    })
 
 
 def remove_shortcut(app):
@@ -44,10 +44,8 @@ def remove_shortcut(app):
 
     If app ends with *, remove all shortcuts with that prefix.
     """
+    match = lambda x: x['app'] == app
     if app[-1] == '*':
-        remove = [k for k in shortcuts if k.startswith(app[:-1])]
-        for k in remove:
-            del shortcuts[k]
+        match = lambda x: x['app'].startswith(app[:-1])
 
-    elif app in shortcuts:
-        del shortcuts[app]
+    shortcuts[:] = [shortcut for shortcut in shortcuts if not match(shortcut)]

--- a/plinth/frontpage.py
+++ b/plinth/frontpage.py
@@ -37,6 +37,15 @@ def add_shortcut(app, label, url, icon):
 
 
 def remove_shortcut(app):
-    """Remove shortcut from front page."""
-    if app in shortcuts:
+    """
+    Remove shortcut from front page.
+
+    If app ends with *, remove all shortcuts with that prefix.
+    """
+    if app[-1] == '*':
+        remove = [k for k in shortcuts if k.startswith(app[:-1])]
+        for k in remove:
+            del shortcuts[k]
+
+    elif app in shortcuts:
         del shortcuts[app]

--- a/plinth/modules/deluge/__init__.py
+++ b/plinth/modules/deluge/__init__.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 
 
@@ -59,12 +60,20 @@ def init():
         managed_services[0], title, ports=['http', 'https'], is_external=True,
         is_enabled=is_enabled, enable=enable, disable=disable)
 
+    if is_enabled():
+        add_shortcut()
+
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
     helper.call('post', actions.superuser_run, 'deluge', ['enable'])
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('deluge', title, '/deluge', 'glyphicon-magnet')
 
 
 def is_enabled():
@@ -76,11 +85,13 @@ def is_enabled():
 def enable():
     """Enable the module."""
     actions.superuser_run('deluge', ['enable'])
+    add_shortcut()
 
 
 def disable():
     """Disable the module."""
     actions.superuser_run('deluge', ['disable'])
+    frontpage.remove_shortcut('deluge')
 
 
 def diagnose():

--- a/plinth/modules/ikiwiki/__init__.py
+++ b/plinth/modules/ikiwiki/__init__.py
@@ -60,7 +60,7 @@ def init():
         is_enabled=is_enabled, enable=enable, disable=disable)
 
     if is_enabled():
-        add_shortcut()
+        add_shortcuts()
 
 
 def setup(helper, old_version=None):
@@ -68,11 +68,14 @@ def setup(helper, old_version=None):
     helper.install(managed_packages)
     helper.call('post', actions.superuser_run, 'ikiwiki', ['setup'])
     helper.call('post', service.notify_enabled, None, True)
-    helper.call('post', add_shortcut)
 
 
-def add_shortcut():
-    frontpage.add_shortcut('ikiwiki', title, '/ikiwiki', 'glyphicon-edit')
+def add_shortcuts():
+    sites = actions.run('ikiwiki', ['get-sites']).split('\n')
+    sites = [name for name in sites if name != '']
+    for site in sites:
+        frontpage.add_shortcut(
+            'ikiwiki_' + site, site, '/ikiwiki/' + site, 'glyphicon-edit')
 
 
 def is_enabled():
@@ -83,13 +86,13 @@ def is_enabled():
 def enable():
     """Enable the module."""
     actions.superuser_run('ikiwiki', ['enable'])
-    add_shortcut()
+    add_shortcuts()
 
 
 def disable():
     """Enable the module."""
     actions.superuser_run('ikiwiki', ['disable'])
-    frontpage.remove_shortcut('ikiwiki')
+    frontpage.remove_shortcut('ikiwiki*')
 
 
 def diagnose():

--- a/plinth/modules/ikiwiki/__init__.py
+++ b/plinth/modules/ikiwiki/__init__.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 
 
@@ -58,12 +59,20 @@ def init():
         'ikiwiki', title, ports=['http', 'https'], is_external=True,
         is_enabled=is_enabled, enable=enable, disable=disable)
 
+    if is_enabled():
+        add_shortcut()
+
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
     helper.call('post', actions.superuser_run, 'ikiwiki', ['setup'])
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('ikiwiki', title, '/ikiwiki', 'glyphicon-edit')
 
 
 def is_enabled():
@@ -74,11 +83,13 @@ def is_enabled():
 def enable():
     """Enable the module."""
     actions.superuser_run('ikiwiki', ['enable'])
+    add_shortcut()
 
 
 def disable():
     """Enable the module."""
     actions.superuser_run('ikiwiki', ['disable'])
+    frontpage.remove_shortcut('ikiwiki')
 
 
 def diagnose():

--- a/plinth/modules/ikiwiki/views.py
+++ b/plinth/modules/ikiwiki/views.py
@@ -26,6 +26,7 @@ from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _, ugettext_lazy
 
 from plinth import actions
+from plinth import frontpage
 from plinth import views
 from plinth.modules import ikiwiki
 
@@ -81,6 +82,10 @@ def create(request):
                              form.cleaned_data['admin_name'],
                              form.cleaned_data['admin_password'])
 
+            site = form.cleaned_data['name'].replace(' ', '')
+            frontpage.add_shortcut('ikiwiki_' + site, site,
+                                   '/ikiwiki/' + site, 'glyphicon-edit')
+
             return redirect(reverse_lazy('ikiwiki:manage'))
     else:
         form = IkiwikiCreateForm(prefix='ikiwiki')
@@ -129,6 +134,7 @@ def delete(request, name):
         try:
             actions.superuser_run('ikiwiki', ['delete', '--name', name])
             messages.success(request, _('{name} deleted.').format(name=name))
+            frontpage.remove_shortcut('ikiwiki_' + name)
         except actions.ActionError as error:
             messages.error(request, _('Could not delete {name}: {error}')
                            .format(name=name, error=error))

--- a/plinth/modules/minetest/__init__.py
+++ b/plinth/modules/minetest/__init__.py
@@ -21,8 +21,10 @@ Plinth module for minetest.
 
 from django.utils.translation import ugettext_lazy as _
 
+from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 from plinth.utils import format_lazy
 from plinth.views import ServiceView
@@ -58,13 +60,34 @@ def init():
     global service
     service = service_module.Service(
         managed_services[0], title, ports=['minetest-plinth'],
-        is_external=True)
+        is_external=True, enable=enable, disable=disable)
+
+    if service.is_enabled():
+        add_shortcut()
 
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('minetest', title, '?selected=minetest',
+                           'glyphicon-th-large', description)
+
+
+def enable():
+    """Enable the module."""
+    actions.superuser_run('service', ['enable', managed_services[0]])
+    add_shortcut()
+
+
+def disable():
+    """Disable the module."""
+    actions.superuser_run('service', ['disable', managed_services[0]])
+    frontpage.remove_shortcut('minetest')
 
 
 class MinetestServiceView(ServiceView):

--- a/plinth/modules/mumble/__init__.py
+++ b/plinth/modules/mumble/__init__.py
@@ -21,8 +21,10 @@ Plinth module to configure Mumble server
 
 from django.utils.translation import ugettext_lazy as _
 
+from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 from plinth.views import ServiceView
 
@@ -56,7 +58,11 @@ def init():
 
     global service
     service = service_module.Service(
-        managed_services[0], title, ports=['mumble-plinth'], is_external=True)
+        managed_services[0], title, ports=['mumble-plinth'], is_external=True,
+        enable=enable, disable=disable)
+
+    if service.is_enabled():
+        add_shortcut()
 
 
 class MumbleServiceView(ServiceView):
@@ -69,6 +75,24 @@ def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('mumble', title, '?selected=mumble',
+                           'glyphicon-headphones', description)
+
+
+def enable():
+    """Enable the module."""
+    actions.superuser_run('service', ['enable', managed_services[0]])
+    add_shortcut()
+
+
+def disable():
+    """Disable the module."""
+    actions.superuser_run('service', ['disable', managed_services[0]])
+    frontpage.remove_shortcut('mumble')
 
 
 def diagnose():

--- a/plinth/modules/privoxy/__init__.py
+++ b/plinth/modules/privoxy/__init__.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 from plinth.utils import format_lazy
 from plinth.views import ServiceView
@@ -66,7 +67,11 @@ def init():
 
     global service
     service = service_module.Service(
-        managed_services[0], title, ports=['privoxy'], is_external=False)
+        managed_services[0], title, ports=['privoxy'], is_external=False,
+        enable=enable, disable=disable)
+
+    if service.is_enabled():
+        add_shortcut()
 
 
 def setup(helper, old_version=None):
@@ -74,6 +79,24 @@ def setup(helper, old_version=None):
     helper.call('pre', actions.superuser_run, 'privoxy', ['pre-install'])
     helper.install(managed_packages)
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('privoxy', title, '?selected=privoxy',
+                           'glyphicon-cloud-upload', description)
+
+
+def enable():
+    """Enable the module."""
+    actions.superuser_run('service', ['enable', managed_services[0]])
+    add_shortcut()
+
+
+def disable():
+    """Disable the module."""
+    actions.superuser_run('service', ['disable', managed_services[0]])
+    frontpage.remove_shortcut('privoxy')
 
 
 class PrivoxyServiceView(ServiceView):

--- a/plinth/modules/quassel/__init__.py
+++ b/plinth/modules/quassel/__init__.py
@@ -21,8 +21,10 @@ Plinth module for Quassel.
 
 from django.utils.translation import ugettext_lazy as _
 
+from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 from plinth.utils import format_lazy
 from plinth.views import ServiceView
@@ -64,7 +66,11 @@ def init():
 
     global service
     service = service_module.Service(
-        managed_services[0], title, ports=['quassel-plinth'], is_external=True)
+        managed_services[0], title, ports=['quassel-plinth'], is_external=True,
+        enable=enable, disable=disable)
+
+    if service.is_enabled():
+        add_shortcut()
 
 
 class QuasselServiceView(ServiceView):
@@ -77,6 +83,24 @@ def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('quassel', title, '?selected=quassel',
+                           'glyphicon-retweet', description)
+
+
+def enable():
+    """Enable the module."""
+    actions.superuser_run('service', ['enable', managed_services[0]])
+    add_shortcut()
+
+
+def disable():
+    """Disable the module."""
+    actions.superuser_run('service', ['disable', managed_services[0]])
+    frontpage.remove_shortcut('quassel')
 
 
 def diagnose():

--- a/plinth/modules/radicale/__init__.py
+++ b/plinth/modules/radicale/__init__.py
@@ -25,6 +25,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 from plinth.utils import format_lazy
 
@@ -63,22 +64,33 @@ def init():
         managed_services[0], title, ports=['http', 'https'], is_external=True,
         enable=enable, disable=disable)
 
+    if service.is_enabled():
+        add_shortcut()
+
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
     helper.call('post', actions.superuser_run, 'radicale', ['setup'])
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('radicale', title, '?selected=radicale',
+                           'glyphicon-calendar', description)
 
 
 def enable():
     """Enable the module."""
     actions.superuser_run('radicale', ['enable'])
+    add_shortcut()
 
 
 def disable():
     """Disable the module."""
     actions.superuser_run('radicale', ['disable'])
+    frontpage.remove_shortcut('radicale')
 
 
 def load_augeas():

--- a/plinth/modules/repro/__init__.py
+++ b/plinth/modules/repro/__init__.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 from plinth.views import ServiceView
 
@@ -69,7 +70,10 @@ def init():
     global service
     service = service_module.Service(
         managed_services[0], title, ports=['sip-plinth', 'sip-tls-plinth'],
-        is_external=True)
+        is_external=True, enable=enable, disable=disable)
+
+    if service.is_enabled():
+        add_shortcut()
 
 
 class ReproServiceView(ServiceView):
@@ -83,6 +87,24 @@ def setup(helper, old_version=None):
     helper.install(managed_packages)
     helper.call('post', actions.superuser_run, 'repro', ['setup'])
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('repro', title, '?selected=repro',
+                           'glyphicon-phone-alt', description)
+
+
+def enable():
+    """Enable the module."""
+    actions.superuser_run('service', ['enable', managed_services[0]])
+    add_shortcut()
+
+
+def disable():
+    """Disable the module."""
+    actions.superuser_run('service', ['disable', managed_services[0]])
+    frontpage.remove_shortcut('repro')
 
 
 def diagnose():

--- a/plinth/modules/roundcube/__init__.py
+++ b/plinth/modules/roundcube/__init__.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 
 
@@ -70,12 +71,21 @@ def init():
         'roundcube', title, ports=['http', 'https'], is_external=True,
         is_enabled=is_enabled, enable=enable, disable=disable)
 
+    if is_enabled():
+        add_shortcut()
+
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.call('pre', actions.superuser_run, 'roundcube', ['pre-install'])
     helper.install(managed_packages)
     helper.call('post', actions.superuser_run, 'roundcube', ['setup'])
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut(
+        'roundcube', title, '/roundcube', 'glyphicon-envelope')
 
 
 def is_enabled():
@@ -86,11 +96,13 @@ def is_enabled():
 def enable():
     """Enable the module."""
     actions.superuser_run('roundcube', ['enable'])
+    add_shortcut()
 
 
 def disable():
     """Enable the module."""
     actions.superuser_run('roundcube', ['disable'])
+    frontpage.remove_shortcut('roundcube')
 
 
 def diagnose():

--- a/plinth/modules/shaarli/__init__.py
+++ b/plinth/modules/shaarli/__init__.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 
 
@@ -57,11 +58,19 @@ def init():
         'shaarli', title, ports=['http', 'https'], is_external=True,
         is_enabled=is_enabled, enable=enable, disable=disable)
 
+    if is_enabled():
+        add_shortcut()
+
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('shaarli', title, '/shaarli', 'glyphicon-bookmark')
 
 
 def is_enabled():
@@ -72,8 +81,10 @@ def is_enabled():
 def enable():
     """Enable the module."""
     actions.superuser_run('shaarli', ['enable'])
+    add_shortcut()
 
 
 def disable():
     """Enable the module."""
     actions.superuser_run('shaarli', ['disable'])
+    frontpage.remove_shortcut('shaarli')

--- a/plinth/modules/transmission/__init__.py
+++ b/plinth/modules/transmission/__init__.py
@@ -25,6 +25,7 @@ import json
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 
 
@@ -58,6 +59,9 @@ def init():
         managed_services[0], title, ports=['http', 'https'], is_external=True,
         is_enabled=is_enabled, enable=enable, disable=disable)
 
+    if is_enabled():
+        add_shortcut()
+
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
@@ -70,6 +74,12 @@ def setup(helper, old_version=None):
 
     helper.call('post', actions.superuser_run, 'transmission', ['enable'])
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut(
+            'transmission', title, '/transmission', 'glyphicon-save')
 
 
 def is_enabled():
@@ -81,11 +91,13 @@ def is_enabled():
 def enable():
     """Enable the module."""
     actions.superuser_run('transmission', ['enable'])
+    add_shortcut()
 
 
 def disable():
     """Enable the module."""
     actions.superuser_run('transmission', ['disable'])
+    frontpage.remove_shortcut('transmission')
 
 
 def diagnose():

--- a/plinth/modules/ttrss/__init__.py
+++ b/plinth/modules/ttrss/__init__.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 
 
@@ -59,6 +60,9 @@ def init():
         managed_services[0], title, ports=['http', 'https'], is_external=True,
         is_enabled=is_enabled, enable=enable, disable=disable)
 
+    if is_enabled():
+        add_shortcut()
+
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
@@ -66,6 +70,11 @@ def setup(helper, old_version=None):
     helper.install(managed_packages)
     helper.call('post', actions.superuser_run, 'ttrss', ['setup'])
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('ttrss', title, '/tt-rss', 'glyphicon-envelope')
 
 
 def is_enabled():
@@ -77,11 +86,13 @@ def is_enabled():
 def enable():
     """Enable the module."""
     actions.superuser_run('ttrss', ['enable'])
+    add_shortcut()
 
 
 def disable():
     """Enable the module."""
     actions.superuser_run('ttrss', ['disable'])
+    frontpage.remove_shortcut('ttrss')
 
 
 def diagnose():

--- a/plinth/modules/xmpp/__init__.py
+++ b/plinth/modules/xmpp/__init__.py
@@ -91,7 +91,10 @@ def setup(helper, old_version=None):
 
 
 def add_shortcut():
-    frontpage.add_shortcut('xmpp', title, '/jwchat', 'glyphicon-comment')
+    frontpage.add_shortcut('jwchat', _('Chat Client (JWChat)'), '/jwchat',
+                           'glyphicon-comment')
+    frontpage.add_shortcut('xmpp', title, '?selected=xmpp',
+                           'glyphicon-comment', description)
 
 
 class EjabberdServiceView(ServiceView):
@@ -127,6 +130,7 @@ def enable():
 def disable():
     """Enable the module."""
     actions.superuser_run('xmpp', ['disable'])
+    frontpage.remove_shortcut('jwchat')
     frontpage.remove_shortcut('xmpp')
 
 

--- a/plinth/modules/xmpp/__init__.py
+++ b/plinth/modules/xmpp/__init__.py
@@ -26,6 +26,7 @@ import socket
 from plinth import actions
 from plinth import action_utils
 from plinth import cfg
+from plinth import frontpage
 from plinth import service as service_module
 from plinth.views import ServiceView
 from plinth.signals import pre_hostname_change, post_hostname_change
@@ -72,6 +73,9 @@ def init():
     post_hostname_change.connect(on_post_hostname_change)
     domainname_change.connect(on_domainname_change)
 
+    if is_enabled():
+        add_shortcut()
+
 
 def setup(helper, old_version=None):
     """Install and configure the module."""
@@ -83,6 +87,11 @@ def setup(helper, old_version=None):
     helper.install(managed_packages)
     helper.call('post', actions.superuser_run, 'xmpp', ['setup'])
     helper.call('post', service.notify_enabled, None, True)
+    helper.call('post', add_shortcut)
+
+
+def add_shortcut():
+    frontpage.add_shortcut('xmpp', title, '/jwchat', 'glyphicon-comment')
 
 
 class EjabberdServiceView(ServiceView):
@@ -112,11 +121,13 @@ def get_domainname():
 def enable():
     """Enable the module."""
     actions.superuser_run('xmpp', ['enable'])
+    add_shortcut()
 
 
 def disable():
     """Enable the module."""
     actions.superuser_run('xmpp', ['disable'])
+    frontpage.remove_shortcut('xmpp')
 
 
 def on_pre_hostname_change(sender, old_hostname, new_hostname, **kwargs):

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -86,11 +86,13 @@
           <span class="icon-bar"></span>
         </button>
         {% block mainmenu_left %}
-          <span class="navbar-brand">
+          <a href="{% url 'index' %}"  class="navbar-brand"
+             title="{{ box_name }}">
             <img src="{% static 'theme/img/freedombox-logo-32px.png' %}"
                  alt="{{ box_name }}" />
-          </span>
-          <a href="{% url 'index' %}" class="navbar-brand" title="{% trans "Applications" %}">
+          </a>
+          <a href="{% url 'apps:index' %}" class="navbar-brand"
+             title="{% trans "Applications" %}">
             <span class="glyphicon glyphicon-th"></span>
           </a>
         {% endblock %}

--- a/plinth/templates/index.html
+++ b/plinth/templates/index.html
@@ -87,10 +87,10 @@
   <p>
     {% blocktrans trimmed %}
 
-      {{ box_name }} is a 100% free software self-hosting web server
-      to deploy social applications on small machines. It provides
-      online communication tools respecting your privacy and data
-      ownership.
+      {{ box_name }}, a Debian pure blend, is a 100% free software
+      self-hosting web server to deploy social applications on small
+      machines. It provides online communication tools respecting your
+      privacy and data ownership.
 
     {% endblocktrans %}
   </p>

--- a/plinth/templates/index.html
+++ b/plinth/templates/index.html
@@ -56,11 +56,11 @@
 
 {% block sidebar %}
 
-    <h4>
-      {% blocktrans trimmed %}
-        Welcome to {{ box_name }}!
-      {% endblocktrans %}
-    </h4>
+  <h4>
+    {% blocktrans trimmed %}
+      Welcome to {{ box_name }}!
+    {% endblocktrans %}
+  </h4>
 
   <p>
     {% blocktrans trimmed %}

--- a/plinth/templates/index.html
+++ b/plinth/templates/index.html
@@ -22,17 +22,23 @@
 
 {% block content %}
 
+  <div class="row">
   {% if shortcuts %}
 
     {% for shortcut in shortcuts %}
       <div class="col-sm-4">
         <ul class="nav nav-pills nav-stacked">
-          <li>
-            <a href="{{ shortcut.url }}">
-              <span class="{{ shortcut.icon }} glyphicon"></span>
-              {{ shortcut.label }}
-            </a>
-          </li>
+          {% if selected_app == shortcut.app %}
+            <li class="active">
+              <a href="{{ shortcut.url }}" class="active">
+          {% else %}
+            <li>
+              <a href="{{ shortcut.url }}">
+          {% endif %}
+                <span class="{{ shortcut.icon }} glyphicon"></span>
+                {{ shortcut.label }}
+              </a>
+            </li>
         </ul>
       </div>
     {% endfor %}
@@ -49,6 +55,22 @@
       {% endblocktrans %}
     </h4>
 
+  {% endif %}
+  </div>
+
+  <br>
+  {% if details %}
+    <div class="panel panel-primary">
+      <div class="panel-heading">
+        <h3 class="panel-title">{{ details_label }}</h3>
+      </div>
+
+      {% for paragraph in details %}
+        <div class="panel-body">
+	  {{ paragraph|safe }}
+        </div>
+      {% endfor %}
+    </div>
   {% endif %}
 
 {% endblock %}

--- a/plinth/templates/index.html
+++ b/plinth/templates/index.html
@@ -1,0 +1,96 @@
+{% extends 'base.html' %}
+{% comment %}
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+{% endcomment %}
+
+{% load i18n %}
+
+{% block content %}
+
+  {% if shortcuts %}
+
+    {% for shortcut in shortcuts %}
+      <div class="col-sm-4">
+        <ul class="nav nav-pills nav-stacked">
+          <li>
+            <a href="{{ shortcut.url }}">
+              <span class="{{ shortcut.icon }} glyphicon"></span>
+              {{ shortcut.label }}
+            </a>
+          </li>
+        </ul>
+      </div>
+    {% endfor %}
+
+  {% else %}
+
+    <h4>
+      {% url 'apps:index' as apps_url %}
+      {% blocktrans trimmed %}
+
+        Enable some <a href="{{ apps_url }}">applications</a> to add
+        shortcuts to this page.
+
+      {% endblocktrans %}
+    </h4>
+
+  {% endif %}
+
+{% endblock %}
+
+
+{% block sidebar %}
+
+    <h4>
+      {% blocktrans trimmed %}
+        Welcome to {{ box_name }}!
+      {% endblocktrans %}
+    </h4>
+
+  <p>
+    {% blocktrans trimmed %}
+
+      {{ box_name }} is a 100% free software self-hosting web server
+      to deploy social applications on small machines. It provides
+      online communication tools respecting your privacy and data
+      ownership.
+
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+
+      More info about {{ box_name }} is available on the
+      project <a href="https://freedombox.org">homepage</a>
+      and <a href="https://wiki.debian.org/FreedomBox">wiki</a>.
+
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+
+      This portal is a part of Plinth, the {{ box_name }} web
+      interface. Plinth is free software, distributed under the GNU
+      Affero General Public License, Version 3 or later.
+
+    {% endblocktrans %}
+  </p>
+
+{% endblock %}

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -21,20 +21,23 @@ Main Plinth views
 
 from django.contrib import messages
 from django.core.exceptions import ImproperlyConfigured
-from django.http.response import HttpResponseRedirect
+from django.template.response import TemplateResponse
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
-from django.urls import reverse
 from django.utils.translation import ugettext as _
+from stronghold.decorators import public
 import time
 
-from . import forms
+from . import forms, frontpage
 import plinth
 
 
+@public
 def index(request):
     """Serve the main index page."""
-    return HttpResponseRedirect(reverse('apps:index'))
+    return TemplateResponse(request, 'index.html',
+                            {'title': _('FreedomBox'),
+                             'shortcuts': frontpage.get_shortcuts()})
 
 
 class ServiceView(FormView):

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -35,9 +35,20 @@ import plinth
 @public
 def index(request):
     """Serve the main index page."""
+    shortcuts = frontpage.get_shortcuts()
+    selection = request.GET.get('selected')
+
+    details, details_label = None, None
+    if selection in frontpage.shortcuts:
+        details = frontpage.shortcuts[selection]['details']
+        details_label = frontpage.shortcuts[selection]['label']
+
     return TemplateResponse(request, 'index.html',
                             {'title': _('FreedomBox'),
-                             'shortcuts': frontpage.get_shortcuts()})
+                             'shortcuts': shortcuts,
+                             'selected_app': selection,
+                             'details': details,
+                             'details_label': details_label})
 
 
 class ServiceView(FormView):


### PR DESCRIPTION
This is an attempt to implement the front page discussed in #540 and the last progress call.

![Plinth front page](https://jvalleroy.mooo.com/~jvalleroy/plinth_frontpage.png)

Currently only shortcuts to the web apps are added, and one shortcut for each wiki or blog. They link directly to the web application.

The front page is viewable without requiring login. Also, the FreedomBox logo now links to the front page, and the grid button beside it still links to the apps page.

I am thinking about adding shortcuts for available services also. These probably wouldn't link anywhere, but a text box would display details about how to connect to that service. (Similar to what Dietmar suggested in #511.)