### PR TITLE
xmpp: Fix regression, initial letsencrypt support

### DIFF
--- a/actions/xmpp
+++ b/actions/xmpp
@@ -104,8 +104,6 @@ def subcommand_setup(_):
         conf = ruamel.yaml.round_trip_load(file_handle, preserve_quotes=True)
 
     for listen_port in conf['listen']:
-        if 'starttls' in listen_port:
-            listen_port['starttls'] = False
         if 'tls' in listen_port:
             listen_port['tls'] = False
 

--- a/actions/xmpp
+++ b/actions/xmpp
@@ -25,6 +25,7 @@ import argparse
 import os
 import shutil
 import socket
+import stat
 import subprocess
 import re
 import ruamel.yaml
@@ -36,6 +37,7 @@ JWCHAT_CONFIG = '/etc/jwchat/config.js'
 EJABBERD_CONFIG = '/etc/ejabberd/ejabberd.yml'
 EJABBERD_BACKUP = '/var/log/ejabberd/ejabberd.dump'
 EJABBERD_BACKUP_NEW = '/var/log/ejabberd/ejabberd_new.dump'
+EJABBERD_ORIG_CERT = '/etc/ejabberd/ejabberd.pem'
 
 
 def parse_arguments():
@@ -43,7 +45,6 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
-    # Preseed debconf values before packages are installed.
     pre_install = subparsers.add_parser(
         'pre-install',
         help='Preseed debconf values before packages are installed.')
@@ -51,13 +52,10 @@ def parse_arguments():
         '--domainname',
         help='The domain name that will be used by the XMPP service.')
 
-    # Setup jwchat apache conf
     subparsers.add_parser('setup', help='Setup jwchat apache conf')
-
     subparsers.add_parser('enable', help='Enable XMPP service')
     subparsers.add_parser('disable', help='Disable XMPP service')
 
-    # Prepare ejabberd for hostname change
     pre_hostname_change = subparsers.add_parser(
         'pre-change-hostname',
         help='Prepare ejabberd for nodename change')
@@ -66,7 +64,6 @@ def parse_arguments():
     pre_hostname_change.add_argument('--new-hostname',
                                      help='New hostname')
 
-    # Update ejabberd nodename
     hostname_change = subparsers.add_parser('change-hostname',
                                             help='Update ejabberd nodename')
     hostname_change.add_argument('--old-hostname',
@@ -74,11 +71,20 @@ def parse_arguments():
     hostname_change.add_argument('--new-hostname',
                                  help='New hostname')
 
-    # Update ejabberd and jwchat with new domainname
     domainname_change = subparsers.add_parser(
         'change-domainname',
         help='Update ejabberd and jwchat with new domainname')
     domainname_change.add_argument('--domainname', help='New domainname')
+
+    add_letsencrypt = subparsers.add_parser(
+        'add-letsencrypt', help='Start using letsencrypt certificate if it '
+        'matches configured domain')
+    add_letsencrypt.add_argument('--domain', help='Certificate domain')
+
+    drop_letsencrypt = subparsers.add_parser(
+        'drop-letsencrypt', help='Stop using letsencrypt certificate if it '
+        'matches configured domain')
+    drop_letsencrypt.add_argument('--domain', help='Certificate domain')
 
     return parser.parse_args()
 
@@ -226,6 +232,67 @@ def subcommand_change_domainname(arguments):
         ruamel.yaml.round_trip_dump(conf, file_handle)
 
     action_utils.service_start('ejabberd')
+
+
+def subcommand_add_letsencrypt(arguments):
+    """Start using letsencrypt certificate if it matches configured domain."""
+    with open(EJABBERD_CONFIG, 'r') as file_handle:
+        conf = ruamel.yaml.round_trip_load(file_handle, preserve_quotes=True)
+
+    if arguments.domain in conf['hosts']:
+        cert_folder = '/etc/ejabberd/letsencrypt/' + arguments.domain
+        if not os.path.exists(cert_folder):
+            os.makedirs(cert_folder)
+            shutil.chown(cert_folder, 'ejabberd', 'ejabberd')
+
+        cert_file = cert_folder + '/ejabberd.pem'
+        le_folder = '/etc/letsencrypt/live/' + arguments.domain
+        with open(cert_file, 'w') as outfile:
+            with open(le_folder + '/privkey.pem', 'r') as infile:
+                for line in infile:
+                    if line.strip():
+                        outfile.write(line)
+            with open(le_folder + '/fullchain.pem', 'r') as infile:
+                for line in infile:
+                    if line.strip():
+                        outfile.write(line)
+        shutil.chown(cert_file, 'ejabberd', 'ejabberd')
+        os.chmod(cert_file, stat.S_IRUSR | stat.S_IWUSR)
+
+        cert_file = ruamel.yaml.scalarstring.DoubleQuotedScalarString(
+            cert_file)
+        for listen_port in conf['listen']:
+            if 'certfile' in listen_port:
+                listen_port['certfile'] = cert_file
+        conf['s2s_certfile'] = cert_file
+
+        with open(EJABBERD_CONFIG, 'w') as file_handle:
+            ruamel.yaml.round_trip_dump(conf, file_handle)
+
+        action_utils.service_restart('ejabberd')
+
+
+def subcommand_drop_letsencrypt(arguments):
+    """Stop using letsencrypt certificate if it matches configured domain."""
+    with open(EJABBERD_CONFIG, 'r') as file_handle:
+        conf = ruamel.yaml.round_trip_load(file_handle, preserve_quotes=True)
+
+    cert_folder = '/etc/ejabberd/letsencrypt/' + arguments.domain
+    cert_file = cert_folder + '/ejabberd.pem'
+    orig_cert_file = ruamel.yaml.scalarstring.DoubleQuotedScalarString(
+        EJABBERD_ORIG_CERT)
+
+    for listen_port in conf['listen']:
+        if 'certfile' in listen_port and listen_port['certfile'] == cert_file:
+            listen_port['certfile'] = orig_cert_file
+
+    if conf['s2s_certfile'] == cert_file:
+        conf['s2s_certfile'] = orig_cert_file
+
+    with open(EJABBERD_CONFIG, 'w') as file_handle:
+        ruamel.yaml.round_trip_dump(conf, file_handle)
+
+    action_utils.service_restart('ejabberd')
 
 
 def main():

--- a/plinth/modules/letsencrypt/views.py
+++ b/plinth/modules/letsencrypt/views.py
@@ -32,6 +32,7 @@ from plinth import actions
 from plinth.errors import ActionError
 from plinth.modules import letsencrypt
 from plinth.modules import names
+from plinth.signals import letsencrypt_cert_obtained, letsencrypt_cert_revoked
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,8 @@ def revoke(request, domain):
         messages.success(
             request, _('Certificate successfully revoked for domain {domain}')
             .format(domain=domain))
+        letsencrypt_cert_revoked.send_robust(
+            sender='letsencrypt', domain=domain)
     except ActionError as exception:
         messages.error(
             request,
@@ -71,6 +74,8 @@ def obtain(request, domain):
         messages.success(
             request, _('Certificate successfully obtained for domain {domain}')
             .format(domain=domain))
+        letsencrypt_cert_obtained.send_robust(
+            sender='letsencrypt', domain=domain)
     except ActionError as exception:
         messages.error(
             request,

--- a/plinth/modules/xmpp/__init__.py
+++ b/plinth/modules/xmpp/__init__.py
@@ -30,6 +30,7 @@ from plinth import service as service_module
 from plinth.views import ServiceView
 from plinth.signals import pre_hostname_change, post_hostname_change
 from plinth.signals import domainname_change
+from plinth.signals import letsencrypt_cert_obtained, letsencrypt_cert_revoked
 
 
 version = 1
@@ -71,6 +72,8 @@ def init():
     pre_hostname_change.connect(on_pre_hostname_change)
     post_hostname_change.connect(on_post_hostname_change)
     domainname_change.connect(on_domainname_change)
+    letsencrypt_cert_obtained.connect(on_letsencrypt_cert_obtained)
+    letsencrypt_cert_revoked.connect(on_letsencrypt_cert_revoked)
 
 
 def setup(helper, old_version=None):
@@ -158,6 +161,18 @@ def on_domainname_change(sender, old_domainname, new_domainname, **kwargs):
                           ['change-domainname',
                            '--domainname', new_domainname],
                           async=True)
+
+
+def on_letsencrypt_cert_obtained(sender, domain, **kwargs):
+    """Start using letsencrypt certificate if it matches configured domain."""
+    actions.superuser_run(
+        'xmpp', ['add-letsencrypt', '--domain', domain], async=True)
+
+
+def on_letsencrypt_cert_revoked(sender, domain, **kwargs):
+    """Stop using letsencrypt certificate if it matches configured domain."""
+    actions.superuser_run(
+        'xmpp', ['drop-letsencrypt', '--domain', domain], async=True)
 
 
 def diagnose():

--- a/plinth/signals.py
+++ b/plinth/signals.py
@@ -31,3 +31,5 @@ domainname_change = Signal(providing_args=['old_domainname', 'new_domainname'])
 domain_added = Signal(providing_args=['domain_type', 'name', 'description',
                                       'services'])
 domain_removed = Signal(providing_args=['domain_type', 'name'])
+letsencrypt_cert_obtained = Signal(providing_args=['domain'])
+letsencrypt_cert_revoked = Signal(providing_args=['domain'])


### PR DESCRIPTION
The 1st commit fixes an error that I introduced :( when switching to ruamel.yaml. Only tls should be set to false (on http bind port, for jwchat), not starttls.

The 2nd commit adds preliminary support for using a letsencrypt certificate with ejabberd. The configuration is done automatically when the LE cert is obtained, if the domain for the cert matches ejabberd's host list.
