### PR TITLE
minetest: Fix showing status block and diagnostics

### DIFF
--- a/plinth/modules/minetest/__init__.py
+++ b/plinth/modules/minetest/__init__.py
@@ -71,7 +71,7 @@ class MinetestServiceView(ServiceView):
     service_id = managed_services[0]
     diagnostics_module_name = "minetest"
     description = description
-    show_status_block = False
+    show_status_block = True
 
 
 def diagnose():


### PR DESCRIPTION
Currently we are not showing status block for the minetest app for some reason. This patch fixes it.