### PR TITLE
letsencrypt: Depend on the new certbot package

### DIFF
--- a/plinth/modules/letsencrypt/__init__.py
+++ b/plinth/modules/letsencrypt/__init__.py
@@ -33,7 +33,7 @@ is_essential = True
 
 depends = ['apps', 'names']
 
-managed_packages = ['letsencrypt']
+managed_packages = ['certbot']
 
 title = _('Certificates (Let\'s Encrypt)')
 


### PR DESCRIPTION
Instead of the transitional package 'letsencrypt'.

I believe, there is no need to rename the entire module to certbo since
letsencrypt is stil a more apt name for the module.  Let's Encrypt is a
strong brand that people know.  The service is still called Let's
Encrypt.  Only the automation tool has been renamed to certbot to avoid
confusion of the service name.

Fixes #576.