### PR TITLE
networks: Add polkit rules for network management

### DIFF
--- a/data/usr/share/polkit-1/rules.d/50-plinth.rules
+++ b/data/usr/share/polkit-1/rules.d/50-plinth.rules
@@ -1,0 +1,25 @@
+/*
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+*/
+
+polkit.addRule(function(action, subject) {
+    if (action.id.indexOf("org.freedesktop.NetworkManager.") == 0 &&
+        subject.user == "plinth") {
+        return polkit.Result.YES;
+    }
+});

--- a/data/var/lib/polkit-1/localauthority/10-vendor.d/org.freedombox.NetworkManager.pkla
+++ b/data/var/lib/polkit-1/localauthority/10-vendor.d/org.freedombox.NetworkManager.pkla
@@ -1,0 +1,4 @@
+[Allow Plinth to manage NetworkManager connections]
+Identity=unix-user:plinth
+Action=org.freedesktop.NetworkManager.*
+ResultAny=yes

--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,8 @@ setuptools.setup(
                  ['data/lib/systemd/system/plinth.service']),
                 ('/usr/share/plinth/actions',
                  glob.glob(os.path.join('actions', '*'))),
+                ('/usr/share/polkit-1/rules.d',
+                 ['data/usr/share/polkit-1/rules.d/50-plinth.rules']),
                 ('/usr/share/man/man1', ['doc/plinth.1']),
                 ('/etc/plinth', ['data/etc/plinth/plinth.config']),
                 ('/usr/share/augeas/lenses',
@@ -223,7 +225,10 @@ setuptools.setup(
                  glob.glob('data/usr/share/pam-configs/*-freedombox')),
                 ('/etc/plinth/modules-enabled',
                  glob.glob(os.path.join('data/etc/plinth/modules-enabled',
-                                        '*')))],
+                                        '*'))),
+                ('/var/lib/polkit-1/localauthority/10-vendor.d',
+                 ['data/var/lib/polkit-1/localauthority/10-vendor.d/'
+                  'org.freedombox.NetworkManager.pkla'])],
     cmdclass={
         'build': CustomBuild,
         'clean': CustomClean,


### PR DESCRIPTION
Allow Plinth to manage network connections even when running as 'plinth'
user and not root user.  This is done by adding polkit rules that
Network Manager checks

- Add new style Javascript based rules file for newer versions of
  polkit (>105). This is not fuly tested.

- Add old style .pkla file for older versions of polkit (<=105).