### PR TITLE
Fix garbage collection in case of DynamicDNS update URL

### DIFF
--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -311,7 +311,7 @@ doUpdate()
         if [ "${ignoreCertError}" = "enabled" ];then
             WGETOPTIONS="${WGETOPTIONS} --no-check-certificate "
         fi
-        local cmd="${WGET} ${WGETOPTIONS} ${updateurl}"
+        local cmd="${WGET} -O /dev/null ${WGETOPTIONS} ${updateurl}"
         $cmd
         # ToDo: check the returning text from WEB Server. User need to give expected string.
         if [ ${?} -eq 0 ];then


### PR DESCRIPTION
The wget command to push the current IP via update URL will download the update URL document
without deleting the HTML document afterwards. This will cause the script to flood "/root/" folder.