### PR TITLE
fix file permission for dynamic DNS user credentials

### DIFF
--- a/actions/dynamicdns
+++ b/actions/dynamicdns
@@ -322,6 +322,7 @@ doUpdate()
     fi
 }
 
+umask u=rw,g=,o=
 cmd=${1}
 shift
 # decide which config to use


### PR DESCRIPTION
The file which contains the credentials should not be readable for "others"