### PR TITLE
networks: Add batctl as dependency

### DIFF
--- a/plinth/modules/networks/__init__.py
+++ b/plinth/modules/networks/__init__.py
@@ -34,7 +34,7 @@ is_essential = True
 
 depends = ['system']
 
-managed_packages = ['network-manager']
+managed_packages = ['network-manager', 'batctl']
 
 title = _('Networks')
 


### PR DESCRIPTION
This will be removed from freedombox-setup depedency list.