### PR TITLE
Tor upstream bridges

### DIFF
--- a/actions/tor
+++ b/actions/tor
@@ -135,6 +135,9 @@ def subcommand_configure(arguments):
 
     _use_upstream_bridges(arguments.use_upstream_bridges, aug=aug)
 
+    if arguments.use_upstream_bridges == 'enable':
+        arguments.relay = 'disable'
+        arguments.bridge_relay = 'disable'
     _enable_relay(arguments.relay, arguments.bridge_relay, aug=aug)
 
     if arguments.hidden_service == 'enable':
@@ -327,12 +330,14 @@ def _enable_relay(relay=None, bridge=None, aug=None):
     if not aug:
         aug = augeas_load()
 
-    if relay == 'enable':
+    use_upstream_bridges = aug.get(TOR_CONFIG + '/UseBridges') == '1'
+
+    if relay == 'enable' and not use_upstream_bridges:
         aug.set(TOR_CONFIG + '/ORPort', 'auto')
     elif relay == 'disable':
         aug.remove(TOR_CONFIG + '/ORPort')
 
-    if bridge == 'enable':
+    if bridge == 'enable' and not use_upstream_bridges:
         aug.set(TOR_CONFIG + '/BridgeRelay', '1')
         aug.set(TOR_CONFIG + '/ServerTransportPlugin',
                 'obfs3,obfs4 exec /usr/bin/obfs4proxy')

--- a/actions/tor
+++ b/actions/tor
@@ -62,6 +62,16 @@ def parse_arguments():
     configure.add_argument('--apt-transport-tor',
                            choices=['enable', 'disable'],
                            help='Configure package download over Tor')
+    configure.add_argument('--use-upstream-bridges',
+                           choices=['enable', 'disable'],
+                           help='Configure use of upstream bridges')
+
+    upstream = subparsers.add_parser(
+        'set-upstream-bridges', help='Set list of upstream bridges')
+    upstream.add_argument('--bridges',
+                          help='List of upstream bridges to use')
+
+    subparsers.add_parser('restart', help='Restart Tor')
 
     return parser.parse_args()
 
@@ -121,6 +131,11 @@ def subcommand_configure(arguments):
     if arguments.service == 'disable':
         _disable()
 
+    restart = arguments.service is None and \
+              arguments.hidden_service is None and \
+              arguments.relay is None and arguments.bridge_relay is None
+    _use_upstream_bridges(arguments.use_upstream_bridges, restart=restart)
+
     restart = arguments.service is None and arguments.hidden_service is None
     _enable_relay(arguments.relay, arguments.bridge_relay, restart=restart)
 
@@ -139,13 +154,48 @@ def subcommand_configure(arguments):
         _disable_apt_transport_tor()
 
 
+def subcommand_set_upstream_bridges(arguments):
+    """Set list of upstream bridges."""
+    aug = augeas_load()
+
+    aug.remove(TOR_CONFIG + '/Bridge')
+    if arguments.bridges:
+        bridges = arguments.bridges.split('\n')
+        for bridge in bridges:
+            if bridge.strip():
+                aug.set(TOR_CONFIG + '/Bridge[last() + 1]', bridge.strip())
+
+    aug.save()
+
+
+def subcommand_restart(_):
+    """Restart Tor."""
+    if is_enabled() and is_running():
+        action_utils.service_restart('tor')
+
+
 def get_status():
     """Return dict with Tor status."""
     aug = augeas_load()
-    return {'relay_enabled': _is_relay_enabled(aug),
+    return {'use_upstream_bridges': _are_upstream_bridges_enabled(aug),
+            'upstream_bridges': _get_upstream_bridges(aug),
+            'relay_enabled': _is_relay_enabled(aug),
             'bridge_relay_enabled': _is_bridge_relay_enabled(aug),
             'ports': _get_ports(),
             'hidden_service': _get_hidden_service(aug)}
+
+
+def _are_upstream_bridges_enabled(aug):
+    """Return whether upstream bridges are being used."""
+    use_bridges = aug.get(TOR_CONFIG + '/UseBridges')
+    return use_bridges == '1'
+
+
+def _get_upstream_bridges(aug):
+    """Return upstream bridges separated by newlines."""
+    matches = aug.match(TOR_CONFIG + '/Bridge')
+    bridges = [aug.get(match) for match in matches]
+    return '\n'.join(bridges)
 
 
 def _is_relay_enabled(aug):
@@ -244,6 +294,26 @@ def _disable():
     """Disable and stop the service."""
     _disable_apt_transport_tor()
     action_utils.service_disable('tor')
+
+
+def _use_upstream_bridges(use_upstream_bridges=None, restart=True, aug=None):
+    """Enable use of upstream bridges."""
+    if use_upstream_bridges is None:
+        return
+
+    if not aug:
+        aug = augeas_load()
+
+    if use_upstream_bridges == 'enable':
+        aug.set(TOR_CONFIG + '/UseBridges', '1')
+    elif use_upstream_bridges == 'disable':
+        aug.set(TOR_CONFIG + '/UseBridges', '0')
+
+    aug.save()
+
+    if restart:
+        if is_enabled() and is_running():
+            action_utils.service_restart('tor')
 
 
 def _enable_relay(relay=None, bridge=None, restart=True, aug=None):

--- a/actions/tor
+++ b/actions/tor
@@ -128,22 +128,26 @@ def subcommand_get_status(_):
 
 def subcommand_configure(arguments):
     """Configure Tor."""
+    aug = augeas_load()
+
     if arguments.service == 'disable':
         _disable()
 
     restart = arguments.service is None and \
               arguments.hidden_service is None and \
               arguments.relay is None and arguments.bridge_relay is None
-    _use_upstream_bridges(arguments.use_upstream_bridges, restart=restart)
+    _use_upstream_bridges(arguments.use_upstream_bridges, restart=restart,
+                          aug=aug)
 
     restart = arguments.service is None and arguments.hidden_service is None
-    _enable_relay(arguments.relay, arguments.bridge_relay, restart=restart)
+    _enable_relay(arguments.relay, arguments.bridge_relay, restart=restart,
+                  aug=aug)
 
     restart = arguments.service is None
     if arguments.hidden_service == 'enable':
-        _enable_hs(restart=restart)
+        _enable_hs(restart=restart, aug=aug)
     elif arguments.hidden_service == 'disable':
-        _disable_hs(restart=restart)
+        _disable_hs(restart=restart, aug=aug)
 
     if arguments.service == 'enable':
         _enable()
@@ -346,9 +350,10 @@ def _enable_relay(relay=None, bridge=None, restart=True, aug=None):
             action_utils.service_restart('tor')
 
 
-def _enable_hs(restart=True):
+def _enable_hs(restart=True, aug=None):
     """Enable Tor hidden service"""
-    aug = augeas_load()
+    if not aug:
+        aug = augeas_load()
 
     if _get_hidden_service(aug)['enabled']:
         return
@@ -377,9 +382,10 @@ def _enable_hs(restart=True):
                 time.sleep(10)
 
 
-def _disable_hs(restart=True):
+def _disable_hs(restart=True, aug=None):
     """Disable Tor hidden service"""
-    aug = augeas_load()
+    if not aug:
+        aug = augeas_load()
 
     if not _get_hidden_service(aug)['enabled']:
         return

--- a/actions/tor
+++ b/actions/tor
@@ -85,7 +85,7 @@ def subcommand_setup(_):
     aug.set(TOR_CONFIG + '/SocksPort[1]', '[::]:9050')
     aug.set(TOR_CONFIG + '/SocksPort[2]', '0.0.0.0:9050')
     aug.set(TOR_CONFIG + '/ControlPort', '9051')
-    _enable_relay(relay='enable', bridge='enable', restart=False, aug=aug)
+    _enable_relay(relay='enable', bridge='enable', aug=aug)
     aug.set(TOR_CONFIG + '/ExitPolicy[1]', 'reject *:*')
     aug.set(TOR_CONFIG + '/ExitPolicy[2]', 'reject6 *:*')
 
@@ -133,21 +133,14 @@ def subcommand_configure(arguments):
     if arguments.service == 'disable':
         _disable()
 
-    restart = arguments.service is None and \
-              arguments.hidden_service is None and \
-              arguments.relay is None and arguments.bridge_relay is None
-    _use_upstream_bridges(arguments.use_upstream_bridges, restart=restart,
-                          aug=aug)
+    _use_upstream_bridges(arguments.use_upstream_bridges, aug=aug)
 
-    restart = arguments.service is None and arguments.hidden_service is None
-    _enable_relay(arguments.relay, arguments.bridge_relay, restart=restart,
-                  aug=aug)
+    _enable_relay(arguments.relay, arguments.bridge_relay, aug=aug)
 
-    restart = arguments.service is None
     if arguments.hidden_service == 'enable':
-        _enable_hs(restart=restart, aug=aug)
+        _enable_hs(aug=aug)
     elif arguments.hidden_service == 'disable':
-        _disable_hs(restart=restart, aug=aug)
+        _disable_hs(aug=aug)
 
     if arguments.service == 'enable':
         _enable()
@@ -176,6 +169,16 @@ def subcommand_restart(_):
     """Restart Tor."""
     if is_enabled() and is_running():
         action_utils.service_restart('tor')
+
+        aug = augeas_load()
+        if aug.get(TOR_CONFIG + '/HiddenServiceDir'):
+            # wait until hidden service information is available
+            tries = 0
+            while not _get_hidden_service()['enabled']:
+                tries += 1
+                if tries >= 12:
+                    return
+                time.sleep(10)
 
 
 def get_status():
@@ -300,7 +303,7 @@ def _disable():
     action_utils.service_disable('tor')
 
 
-def _use_upstream_bridges(use_upstream_bridges=None, restart=True, aug=None):
+def _use_upstream_bridges(use_upstream_bridges=None, aug=None):
     """Enable use of upstream bridges."""
     if use_upstream_bridges is None:
         return
@@ -315,12 +318,8 @@ def _use_upstream_bridges(use_upstream_bridges=None, restart=True, aug=None):
 
     aug.save()
 
-    if restart:
-        if is_enabled() and is_running():
-            action_utils.service_restart('tor')
 
-
-def _enable_relay(relay=None, bridge=None, restart=True, aug=None):
+def _enable_relay(relay=None, bridge=None, aug=None):
     """Enable Tor bridge relay."""
     if relay is None and bridge is None:
         return
@@ -345,12 +344,8 @@ def _enable_relay(relay=None, bridge=None, restart=True, aug=None):
 
     aug.save()
 
-    if restart:
-        if is_enabled() and is_running():
-            action_utils.service_restart('tor')
 
-
-def _enable_hs(restart=True, aug=None):
+def _enable_hs(aug=None):
     """Enable Tor hidden service"""
     if not aug:
         aug = augeas_load()
@@ -368,21 +363,8 @@ def _enable_hs(restart=True, aug=None):
             '443 127.0.0.1:443')
     aug.save()
 
-    if restart:
-        if is_enabled() and is_running():
-            action_utils.service_restart('tor')
 
-            # wait until hidden service information is available
-            tries = 0
-            while not _get_hidden_service()['enabled']:
-                tries += 1
-                if tries >= 12:
-                    return
-
-                time.sleep(10)
-
-
-def _disable_hs(restart=True, aug=None):
+def _disable_hs(aug=None):
     """Disable Tor hidden service"""
     if not aug:
         aug = augeas_load()
@@ -393,10 +375,6 @@ def _disable_hs(restart=True, aug=None):
     aug.remove(TOR_CONFIG + '/HiddenServiceDir')
     aug.remove(TOR_CONFIG + '/HiddenServicePort')
     aug.save()
-
-    if restart:
-        if is_enabled() and is_running():
-            action_utils.service_restart('tor')
 
 
 def _enable_apt_transport_tor():

--- a/actions/tor
+++ b/actions/tor
@@ -165,6 +165,9 @@ def subcommand_set_upstream_bridges(arguments):
             if bridge.strip():
                 aug.set(TOR_CONFIG + '/Bridge[last() + 1]', bridge.strip())
 
+    aug.set(TOR_CONFIG + '/ClientTransportPlugin',
+            'obfs4 exec /usr/bin/obfs4proxy')
+
     aug.save()
 
 

--- a/data/usr/share/augeas/lenses/tests/test_tor.aug
+++ b/data/usr/share/augeas/lenses/tests/test_tor.aug
@@ -9,3 +9,4 @@ test Tor.lns get "ExitPolicy reject *:*\n" = { "ExitPolicy" = "reject *:*" }
 test Tor.lns get "VirtualAddrNetworkIPv4 10.192.0.0/10\n" = { "VirtualAddrNetworkIPv4" = "10.192.0.0/10" }
 test Tor.lns get "ServerTransportPlugin obfs3,obfs4 exec /usr/bin/obfs4proxy\n" = { "ServerTransportPlugin" = "obfs3,obfs4 exec /usr/bin/obfs4proxy" }
 test Tor.lns get "HiddenServiceDir /var/lib/tor/hidden_service/\n" = { "HiddenServiceDir" = "/var/lib/tor/hidden_service/" }
+test Tor.lns get "Bridge obfs4 10.1.1.1:30000 0123456789ABCDEF0123456789ABCDEF01234567 cert=A/b+1 iat-mode=0\n" = { "Bridge" = "obfs4 10.1.1.1:30000 0123456789ABCDEF0123456789ABCDEF01234567 cert=A/b+1 iat-mode=0" }

--- a/data/usr/share/augeas/lenses/tor.aug
+++ b/data/usr/share/augeas/lenses/tor.aug
@@ -22,13 +22,17 @@ autoload xfm
 let eol = Util.eol
 
 let ws = /[ \t]/
-let kc = /[A-Za-z0-9_.,:*]/
-let vc = /[A-Za-z0-9_.,:*\/ ]/
-let keyname = kc+
-let val = /[[\/]*/ . kc . (vc* . /[]]*/ . vc* . kc . /[\/]*/)?
+let k = /[A-Za-z0-9_.,:*]+/
+let val = /[A-Za-z0-9_.,:*+-=\/]+/
 
-let entry = [ key keyname . del ws+ " " . store val . eol ]
+let bracket_val = "[" . val* . "]" . val*
+let multi_val = val . (" " . val)+
 
+let simple_entry = [ key k . del ws+ " " . store val . eol ]
+let bracket_entry = [ key k . del ws+ " " . store bracket_val . eol ]
+let multi_entry = [ key k . del ws+ " " . store multi_val . eol ]
+
+let entry = simple_entry|bracket_entry|multi_entry
 let lns = (entry|Util.comment|Util.empty_dos)*
 
 let filter = (incl "/etc/tor/torrc")

--- a/plinth/modules/tor/forms.py
+++ b/plinth/modules/tor/forms.py
@@ -20,6 +20,7 @@ Forms for configuring Tor.
 """
 
 from django import forms
+from django.forms import widgets
 from django.utils.translation import ugettext_lazy as _
 
 from plinth import cfg
@@ -62,3 +63,18 @@ class TorForm(forms.Form):  # pylint: disable=W0232
                     'network for installations and upgrades. This adds a '
                     'degree of privacy and security during software '
                     'downloads.'))
+    use_upstream_bridges = forms.BooleanField(
+        label=_('Use upstream bridges to connect to Tor network'),
+        required=False,
+        help_text=_('When enabled, the bridges configured below will be used '
+                    'to connect to the Tor network. This will disable relay '
+                    'modes. Use this option only if you cannot connect to '
+                    'the Tor network directly.'))
+    upstream_bridges = forms.CharField(
+        widget=widgets.Textarea,
+        label=_('Upstream bridges'),
+        required=False,
+        help_text=_('If you need to use a bridge to connect to Tor network, '
+                    'you can get some bridges from '
+                    'https://bridges.torproject.org/ and paste the bridge '
+                    'information here.'))

--- a/plinth/modules/tor/forms.py
+++ b/plinth/modules/tor/forms.py
@@ -80,6 +80,22 @@ class TorForm(forms.Form):  # pylint: disable=W0232
     enabled = forms.BooleanField(
         label=_('Enable Tor'),
         required=False)
+    use_upstream_bridges = forms.BooleanField(
+        label=_('Use upstream bridges to connect to Tor network'),
+        required=False,
+        help_text=_('When enabled, the bridges configured below will be used '
+                    'to connect to the Tor network. This will disable relay '
+                    'modes. Only use this option if you cannot connect to '
+                    'the Tor network directly.'))
+    upstream_bridges = TrimmedCharField(
+        widget=widgets.Textarea,
+        label=_('Upstream bridges'),
+        required=False,
+        help_text=_('If you need to use a bridge to connect to Tor network, '
+                    'you can get some bridges from '
+                    'https://bridges.torproject.org/ and paste the bridge '
+                    'information here.'),
+        validators=[bridges_validator])
     relay_enabled = forms.BooleanField(
         label=_('Enable Tor relay'),
         required=False,
@@ -111,19 +127,3 @@ class TorForm(forms.Form):  # pylint: disable=W0232
                     'network for installations and upgrades. This adds a '
                     'degree of privacy and security during software '
                     'downloads.'))
-    use_upstream_bridges = forms.BooleanField(
-        label=_('Use upstream bridges to connect to Tor network'),
-        required=False,
-        help_text=_('When enabled, the bridges configured below will be used '
-                    'to connect to the Tor network. This will disable relay '
-                    'modes. Use this option only if you cannot connect to '
-                    'the Tor network directly.'))
-    upstream_bridges = TrimmedCharField(
-        widget=widgets.Textarea,
-        label=_('Upstream bridges'),
-        required=False,
-        help_text=_('If you need to use a bridge to connect to Tor network, '
-                    'you can get some bridges from '
-                    'https://bridges.torproject.org/ and paste the bridge '
-                    'information here.'),
-        validators=[bridges_validator])

--- a/plinth/modules/tor/forms.py
+++ b/plinth/modules/tor/forms.py
@@ -49,7 +49,8 @@ def bridges_validator(bridges):
         parts = bridge.split()
 
         # IP:ORPort is required, transport and fingerprint are optional.
-        if len(parts) < 1 or len(parts) > 3:
+        # Transports may have additional options after the fingerprint.
+        if len(parts) < 1:
             raise ValidationError(
                 BRIDGE_VALIDATION_ERROR_MESSAGE, code='invalid')
 
@@ -94,7 +95,8 @@ class TorForm(forms.Form):  # pylint: disable=W0232
         help_text=_('If you need to use a bridge to connect to Tor network, '
                     'you can get some bridges from '
                     'https://bridges.torproject.org/ and paste the bridge '
-                    'information here.'),
+                    'information here. Note: If you need to use a pluggable '
+                    'transport, only obfs4 is supported currently.'),
         validators=[bridges_validator])
     relay_enabled = forms.BooleanField(
         label=_('Enable Tor relay'),

--- a/plinth/modules/tor/forms.py
+++ b/plinth/modules/tor/forms.py
@@ -62,7 +62,7 @@ def bridges_validator(bridges):
             try:
                 ip_info = parts[1].split(':')
                 validate_ipv46_address(ip_info[0])
-            except ValidationError:
+            except (ValidationError, IndexError):
                 raise ValidationError(
                     BRIDGE_VALIDATION_ERROR_MESSAGE, code='invalid')
 

--- a/plinth/modules/tor/templates/tor.html
+++ b/plinth/modules/tor/templates/tor.html
@@ -150,6 +150,20 @@
                 $('#id_tor-bridge_relay_enabled').prop('checked', false);
             }
         }).change();
+
+        $('#id_tor-use_upstream_bridges').change(function() {
+            if ($('#id_tor-use_upstream_bridges').prop('checked')) {
+                $('#id_tor-upstream_bridges').show('slow');
+                $('label[for="id_tor-upstream_bridges"]').show('slow');
+                $('label[for="id_tor-upstream_bridges"]').parent().show('slow');
+                $('#id_tor-relay_enabled').prop('checked', false);
+                $('#id_tor-bridge_relay_enabled').prop('checked', false);
+            } else {
+                $('#id_tor-upstream_bridges').hide('slow');
+                $('label[for="id_tor-upstream_bridges"]').hide('slow');
+                $('label[for="id_tor-upstream_bridges"]').parent().hide('slow');
+            }
+        }).change();
     })(jQuery);
   </script>
 

--- a/plinth/modules/tor/templates/tor.html
+++ b/plinth/modules/tor/templates/tor.html
@@ -158,10 +158,14 @@
                 $('label[for="id_tor-upstream_bridges"]').parent().show('slow');
                 $('#id_tor-relay_enabled').prop('checked', false);
                 $('#id_tor-bridge_relay_enabled').prop('checked', false);
+                $('#id_tor-relay_enabled').parent().parent().parent().parent().hide('slow');
+                $('#id_tor-bridge_relay_enabled').parent().parent().parent().parent().hide('slow');
             } else {
                 $('#id_tor-upstream_bridges').hide('slow');
                 $('label[for="id_tor-upstream_bridges"]').hide('slow');
                 $('label[for="id_tor-upstream_bridges"]').parent().hide('slow');
+                $('#id_tor-relay_enabled').parent().parent().parent().parent().show('slow');
+                $('#id_tor-bridge_relay_enabled').parent().parent().parent().parent().show('slow');
             }
         }).change();
     })(jQuery);

--- a/plinth/modules/tor/utils.py
+++ b/plinth/modules/tor/utils.py
@@ -64,6 +64,8 @@ def get_status():
 
     return {'enabled': is_enabled(),
             'is_running': is_running(),
+            'use_upstream_bridges': status['use_upstream_bridges'],
+            'upstream_bridges': status['upstream_bridges'],
             'relay_enabled': status['relay_enabled'],
             'bridge_relay_enabled': status['bridge_relay_enabled'],
             'ports': ports,


### PR DESCRIPTION
This adds a checkbox to the Tor page to enable upstream bridges. When checked, a textarea input is shown for upstream bridge entries, and the relay / bridge relay options are hidden. Upstream bridges may be regular bridges or obfs4. Fixes #512.

Also includes some refactoring of the augeas lens and tor restart logic.
