### PR TITLE
repro:  Add ability to open ports for RTP communication

### DIFF
--- a/actions/repro
+++ b/actions/repro
@@ -58,6 +58,10 @@ def subcommand_setup(_):
     action_utils.service_restart('repro')
     action_utils.webserver_enable('repro-plinth')
 
+    # We have introduced new firewalld service files and wish to use
+    # them.
+    action_utils.service_reload('firewalld')
+
 
 def main():
     """Parse arguments and perform all duties."""

--- a/data/usr/lib/firewalld/services/rtp-plinth.xml
+++ b/data/usr/lib/firewalld/services/rtp-plinth.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Real-time Transport Protocol</short>
+  <description>RTP is a protocol for delivering real-time data such as audio and video. Enable this if you run an internet telephony server using XMPP, SIP or H.323 and wish to enable audio and video communications.</description>
+  <port protocol="udp" port="1024-65535"/>
+</service>

--- a/data/usr/lib/firewalld/services/sip-plinth.xml
+++ b/data/usr/lib/firewalld/services/sip-plinth.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<service>
-  <short>SIP</short>
-  <description>The Session Initiaion Protocol (SIP) is commonly used in Internet telephony for audio/video calls and instant messaging.  Enable this if you are running a SIP proxy, registrar, redirector or gateway server over an unencrypted channel.</description>
-  <port protocol="udp" port="5060"/>
-  <port protocol="tcp" port="5060"/>
-</service>

--- a/data/usr/lib/firewalld/services/sip-tls-plinth.xml
+++ b/data/usr/lib/firewalld/services/sip-tls-plinth.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<service>
-  <short>SIP over TLS/DTLS</short>
-  <description>The Session Initiaion Protocol (SIP) is commonly used in Internet telephony for audio/video calls and instant messaging.  Enable this if you are running a SIP proxy, registrar, redirector or gateway server over a channel encrypted using TLS or DTLS.</description>
-  <port protocol="udp" port="5061"/>
-  <port protocol="tcp" port="5061"/>
-</service>

--- a/plinth/modules/repro/__init__.py
+++ b/plinth/modules/repro/__init__.py
@@ -69,7 +69,7 @@ def init():
 
     global service
     service = service_module.Service(
-        managed_services[0], title, ports=['sip-plinth', 'sip-tls-plinth'],
+        managed_services[0], title, ports=['sip', 'sips'],
         is_external=True, enable=enable, disable=disable)
 
     if service.is_enabled():

--- a/plinth/modules/repro/__init__.py
+++ b/plinth/modules/repro/__init__.py
@@ -28,7 +28,7 @@ from plinth import frontpage
 from plinth import service as service_module
 from plinth.views import ServiceView
 
-version = 1
+version = 2
 
 depends = ['apps']
 
@@ -69,7 +69,7 @@ def init():
 
     global service
     service = service_module.Service(
-        managed_services[0], title, ports=['sip', 'sips'],
+        managed_services[0], title, ports=['sip', 'sips', 'rtp-plinth'],
         is_external=True, enable=enable, disable=disable)
 
     if service.is_enabled():


### PR DESCRIPTION
Currently, when using audio/video calls with FreedomBox/repro, we are having to manually open UDP ports for RTP communication.  This patch proposes to enable RTP ports when repro is enabled.