### PR TITLE
Include module static files in build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,7 @@ setuptools.setup(
     tests_require=['coverage >= 3.7'],
     include_package_data=True,
     package_data={'plinth': ['templates/*',
+                             'modules/*/static/*',
                              'modules/*/templates/*',
                              'locale/*/LC_MESSAGES/*.[pm]o']},
     data_files=[('/usr/lib/firewalld/services/',


### PR DESCRIPTION
"./setup.py install" already handles this correctly, but needs to be explicity listed for git-buildpackage to include the files in the debian package.