### PR TITLE
dynamicdns: Allow reading status as non-root

### DIFF
--- a/plinth/modules/dynamicdns/dynamicdns.py
+++ b/plinth/modules/dynamicdns/dynamicdns.py
@@ -215,12 +215,12 @@ def configure(request):
 
 def statuspage(request):
     """Serve the status page."""
-    check_nat = actions.run('dynamicdns', ['get-nat'])
-    last_update = actions.run('dynamicdns', ['get-last-success'])
+    check_nat = _run(['get-nat'])
+    last_update = _run(['get-last-success'])
 
     no_nat = check_nat.strip() == 'no'
     nat_unchecked = check_nat.strip() == 'unknown'
-    timer = actions.run('dynamicdns', ['get-timer'])
+    timer = _run(['get-timer'])
 
     if no_nat:
         logger.info('Not behind a NAT')
@@ -241,7 +241,7 @@ def get_status():
     """Return the current status."""
     # TODO: use key/value instead of hard coded value list
     status = {}
-    output = actions.run('dynamicdns', ['status'])
+    output = _run(['status'])
     details = output.split()
     status['enabled'] = (output.split()[0] == 'enabled')
 


### PR DESCRIPTION
Recently dynamic DNS module was fixed to use root ownership and limited
permissions for configuration and status files to avoid other users
reading dynamic DNS account details.  This caused a regression when
Plinth is being run as non-root user.  This patch runs the commands to
read the current configuration as root user.