### PR TITLE
letsencrypt: Mark module as non-essential

### DIFF
--- a/plinth/modules/letsencrypt/__init__.py
+++ b/plinth/modules/letsencrypt/__init__.py
@@ -29,7 +29,7 @@ from plinth.utils import format_lazy
 
 version = 1
 
-is_essential = True
+is_essential = False
 
 depends = ['apps', 'names']
 


### PR DESCRIPTION
There is an on-going discussion regarding whether the certbot (letsencrypt) package should be in Debian stretch, due to instability of the API:
https://lists.debian.org/debian-devel/2016/11/msg00784.html

With this change, the certbot package won't be a dependency for plinth, and won't be installed automatically. Users can still visit the letsencrypt page to setup the module, which will install the certbot package (assuming the package is available).