### PR TITLE
Prevent anonymous users from accessing setup pages

### DIFF
--- a/plinth/middleware.py
+++ b/plinth/middleware.py
@@ -21,6 +21,7 @@ Django middleware to show pre-setup message and setup progress.
 
 from django import urls
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.utils.translation import ugettext_lazy as _
 import logging
 
@@ -75,5 +76,6 @@ class SetupMiddleware(object):
         if module.setup_helper.get_state() == 'up-to-date':
             return
 
-        view = views.SetupView.as_view()
+        # Only allow logged-in users to access any setup page
+        view = login_required(views.SetupView.as_view())
         return view(request, setup_helper=module.setup_helper)

--- a/plinth/tests/data/django_test_settings.py
+++ b/plinth/tests/data/django_test_settings.py
@@ -31,6 +31,8 @@ DATABASES = {
 }
 
 INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
     'plinth',
 )
 


### PR DESCRIPTION
Anonymous users were able to access pages that used the 'public' decorator of stronghold. If such a page showed the installation routine of the setup module because of missing packages they were able to access and use it, in other words:
Anonymous users were able to install software.

Example url: `<your-server>/plinth/apps/xmpp/jsxc/`, in case you do not have xmpp installed you will see this screen, and the installation will work:
![screenshot_2016-12-25_19-08-09](https://cloud.githubusercontent.com/assets/1867309/21472489/83c5ba7a-cadd-11e6-8ced-c2c94cc4b083.png)

Ideas to make this more generic or implement it on a higher level are very much appreciated.