### PR TITLE
Merge firstboot KVStore entries

### DIFF
--- a/plinth/kvstore.py
+++ b/plinth/kvstore.py
@@ -40,3 +40,8 @@ def set(key, value):  # pylint: disable-msg=W0622
     """Store the value of a key"""
     store = KVStore(key=key, value=value)
     store.save()
+
+
+def delete(key):
+    """Delete a key"""
+    return KVStore.objects.get(key=key).delete()

--- a/plinth/migrations/0003_merge_firstboot_completed_fields.py
+++ b/plinth/migrations/0003_merge_firstboot_completed_fields.py
@@ -1,0 +1,82 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Remove the deprecated KVStore entries 'setup_state' and 'firstboot_state',
+and only use the new entry 'firstboot_completed' instead.
+"""
+
+from __future__ import unicode_literals
+
+from django.db import migrations
+from plinth.models import KVStore
+
+
+def merge_firstboot_finished_fields(apps, schema_editor):
+    """
+    Merge 'setup_state' and 'firstboot_state' into 'firstboot_completed'.
+
+    'firstboot_completed' is the most accurate name for now, and by combining
+    the fields we do not have to deal with legacy states/fields anymore.
+    """
+    # Get and remove 'firstboot_state'
+    firstboot_state = 0
+    try:
+        _object = KVStore.objects.get(key='firstboot_state')
+    except KVStore.DoesNotExist:
+        pass
+    else:
+        firstboot_state = _object.value
+        _object.delete()
+
+    # Get and remove 'setup_state'
+    setup_state = 0
+    try:
+        _object = KVStore.objects.get(key='setup_state')
+    except KVStore.DoesNotExist:
+        pass
+    else:
+        setup_state = _object.value
+        _object.delete()
+
+    # Get current 'firstboot_completed'
+    firstboot_completed = False
+    try:
+        _object = KVStore.objects.get(key='firstboot_completed')
+    except KVStore.DoesNotExist:
+        pass
+    else:
+        firstboot_completed = _object.value
+
+    # Set new 'firstboot_completed' if needed
+    new_firstboot_completed = bool(firstboot_completed or setup_state or
+                                   firstboot_state)
+    if new_firstboot_completed and not firstboot_completed:
+        obj, created = KVStore.objects.get_or_create(key='firstboot_completed')
+        obj.value = 1
+        obj.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('plinth', '0002_modulestore'),
+    ]
+
+    operations = [
+        migrations.RunPython(merge_firstboot_finished_fields),
+    ]

--- a/plinth/modules/first_boot/__init__.py
+++ b/plinth/modules/first_boot/__init__.py
@@ -106,7 +106,7 @@ def mark_step_done(id):
 
     kvstore.set(id, 1)
     if not next_step_or_none():
-        kvstore.set('setup_state', 1)
+        set_completed()
 
 
 def is_completed():
@@ -115,9 +115,12 @@ def is_completed():
 
     global _is_completed
     if _is_completed is None:
+        # TODO
+        # Rename setup_state to 'firstboot_completed',
+        # taking care of the existing kvstore variable name.
         _is_completed = kvstore.get_default('setup_state', 0)
 
-    return _is_completed
+    return bool(_is_completed)
 
 
 def set_completed():

--- a/plinth/modules/first_boot/__init__.py
+++ b/plinth/modules/first_boot/__init__.py
@@ -115,10 +115,7 @@ def is_completed():
 
     global _is_completed
     if _is_completed is None:
-        # TODO
-        # Rename setup_state to 'firstboot_completed',
-        # taking care of the existing kvstore variable name.
-        _is_completed = kvstore.get_default('setup_state', 0)
+        _is_completed = kvstore.get_default('firstboot_completed', 0)
 
     return bool(_is_completed)
 
@@ -129,4 +126,4 @@ def set_completed():
 
     global _is_completed
     _is_completed = True
-    kvstore.set('setup_state', 1)
+    kvstore.set('firstboot_completed', 1)

--- a/plinth/modules/first_boot/middleware.py
+++ b/plinth/modules/first_boot/middleware.py
@@ -25,7 +25,6 @@ from django.urls import reverse
 from django.conf import settings
 import logging
 
-from plinth import kvstore
 from plinth.modules import first_boot
 
 LOGGER = logging.getLogger(__name__)
@@ -49,14 +48,6 @@ class FirstBootMiddleware(object):
             return
 
         firstboot_completed = first_boot.is_completed()
-
-        # Migrate from old settings variable
-        if not firstboot_completed:
-            old_state = kvstore.get_default('firstboot_state', 0)
-            if old_state == 10:
-                firstboot_completed = True
-                first_boot.set_completed()
-
         user_requests_firstboot = first_boot.is_firstboot_url(request.path)
 
         # Redirect to first boot if requesting normal page and first

--- a/plinth/modules/first_boot/middleware.py
+++ b/plinth/modules/first_boot/middleware.py
@@ -48,20 +48,20 @@ class FirstBootMiddleware(object):
         if user_requests_help:
             return
 
-        state = first_boot.is_completed()
+        firstboot_completed = first_boot.is_completed()
 
         # Migrate from old settings variable
-        if state == 0:
+        if not firstboot_completed:
             old_state = kvstore.get_default('firstboot_state', 0)
             if old_state == 10:
-                state = 1
+                firstboot_completed = True
                 first_boot.set_completed()
 
         user_requests_firstboot = first_boot.is_firstboot_url(request.path)
 
         # Redirect to first boot if requesting normal page and first
         # boot is not complete.
-        if state == 0 and not user_requests_firstboot:
+        if not firstboot_completed and not user_requests_firstboot:
             next_step = first_boot.next_step_or_none()
             if next_step:
                 return HttpResponseRedirect(reverse(next_step))
@@ -71,5 +71,5 @@ class FirstBootMiddleware(object):
 
         # Redirect to index page if request firstboot after it is
         # finished.
-        if state == 1 and user_requests_firstboot:
+        if firstboot_completed and user_requests_firstboot:
             return HttpResponseRedirect(reverse('index'))

--- a/plinth/modules/first_boot/templatetags/firstboot_extras.py
+++ b/plinth/modules/first_boot/templatetags/firstboot_extras.py
@@ -21,13 +21,13 @@ Template tags for first boot module.
 
 from django import template
 
+from plinth.modules import first_boot
 from plinth import kvstore
 
 register = template.Library()
 
 
 @register.simple_tag
-def firstboot_is_finished():
+def firstboot_is_completed():
     """Return whether firstboot process is completed."""
-    state = kvstore.get_default('setup_state', 0)
-    return state == 1
+    return first_boot.is_completed()

--- a/plinth/modules/first_boot/templatetags/firstboot_extras.py
+++ b/plinth/modules/first_boot/templatetags/firstboot_extras.py
@@ -22,7 +22,6 @@ Template tags for first boot module.
 from django import template
 
 from plinth.modules import first_boot
-from plinth import kvstore
 
 register = template.Library()
 

--- a/plinth/modules/help/templates/help_base.html
+++ b/plinth/modules/help/templates/help_base.html
@@ -26,8 +26,8 @@
 {# Adapt mainmenu-links during firstboot #}
 {% block mainmenu_left %}
 
-  {% firstboot_is_finished as firstboot_finished %}
-  {% if not firstboot_finished %}
+  {% firstboot_is_completed as firstboot_completed %}
+  {% if not firstboot_completed %}
 
     <span class="navbar-brand">
       <img src="{% static 'theme/img/freedombox-logo-32px.png' %}"
@@ -46,8 +46,8 @@
 
 {% block mainmenu_right %}
 
-  {% firstboot_is_finished as firstboot_finished %}
-  {% if not firstboot_finished %}
+  {% firstboot_is_completed as firstboot_completed %}
+  {% if not firstboot_completed %}
     {% include "firstboot_navbar.html" %}
   {% else %}
     {{ block.super }}


### PR DESCRIPTION
We had two kvstore entries for representing whether firstboot is completed: `setup_state` and the legacy `firstboot_state`. Both are booleans and the name is not accurate for what they are/were doing anymore.
- merge kvstore entries 'firstboot_state' and 'setup_state' into 'firstboot_completed' (a hopefully more accurate name). This is done via a migration so we don't have to deal with legacy fields in our code.
- make more use of functionality provided by `firstboot.__init__.py` instead of dealing with kvstore directly
- introduced kvstore.delete (needed by the migration script to clean old entries)