### PR TITLE
users: Move part of LDAP setup to first-run

### DIFF
--- a/actions/users
+++ b/actions/users
@@ -37,6 +37,8 @@ def parse_arguments():
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
     subparsers.add_parser('setup', help='Setup LDAP')
+    subparsers.add_parser('first-run',
+                          help='Additional setup performed after reboot')
 
     return parser.parse_args()
 
@@ -51,8 +53,13 @@ def subcommand_setup(_):
     configure_slapd()
 
 
+def subcommand_first_run(_):
+    """Additional setup performed after reboot."""
+    configure_ldap_structure()
+
+
 def configure_slapd():
-    """Configure LDAP authentication and basic structure."""
+    """Configure LDAP authentication."""
     action_utils.dpkg_reconfigure('slapd', {'domain': 'thisbox'})
     action_utils.dpkg_reconfigure('nslcd', {'ldap-uris': 'ldapi:///',
                                             'ldap-base': 'dc=thisbox',
@@ -61,6 +68,9 @@ def configure_slapd():
     action_utils.dpkg_reconfigure('libnss-ldapd',
                                   {'nsswitch': 'group, passwd, shadow'})
 
+
+def configure_ldap_structure():
+    """Configure LDAP basic structure."""
     was_running = action_utils.service_is_running('slapd')
     if not was_running:
         action_utils.service_start('slapd')

--- a/data/usr/lib/freedombox/first-run.d/50_ldap
+++ b/data/usr/lib/freedombox/first-run.d/50_ldap
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Exit with an error code on any failure
+set -e
+
+# Enable tracing to see the commands in
+# /var/log/freedombox-first-run.log
+set -x
+
+# Setup LDAP structure
+/usr/share/plinth/actions/users first-run


### PR DESCRIPTION
LDAP admin and basic structure setup requires running slapd. Move this to first-run so we don't have to start slapd during setup. This should avoid issues when running setup in a chroot.

This should fix the setup errors I saw in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851504. If this change looks ok then I'd like to make a quick release including it.