### PR TITLE
setup.py: Install all first-run scripts for freedombox-setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Fixed
 - setup: Fixed an infinite redirect in a rare case.
+- setup.py: Install all first-run scripts for freedombox-setup.
 
 ## [0.13.0] - 2017-01-18
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ setuptools.setup(
                 ('/usr/lib/freedombox/setup.d/',
                  ['data/usr/lib/freedombox/setup.d/86_plinth']),
                 ('/usr/lib/freedombox/first-run.d',
-                 ['data/usr/lib/freedombox/first-run.d/90_firewall']),
+                 glob.glob('data/usr/lib/freedombox/first-run.d/*')),
                 ('/etc/apache2/conf-available',
                  glob.glob('data/etc/apache2/conf-available/*.conf')),
                 ('/etc/apache2/sites-available',


### PR DESCRIPTION
Fixes #714.

I've tested this by running "vagrant provision" and checking that the 50_ldap script was installed in the correct location.