### PR TITLE
Use the common LDAP auth configuration in all modules

### DIFF
--- a/data/etc/apache2/conf-available/ikiwiki-plinth.conf
+++ b/data/etc/apache2/conf-available/ikiwiki-plinth.conf
@@ -9,12 +9,7 @@ AddHandler cgi-script .cgi
 <Location /ikiwiki-auth>
     Options +ExecCGI
 
-    AuthType basic
-    AuthName "FreedomBox Login"
-    AuthBasicProvider ldap
-    AuthLDAPUrl "ldap:///ou=users,dc=thisbox?uid"
-    AuthLDAPGroupAttribute memberUid
-    AuthLDAPGroupAttributeIsDN off
+    Include includes/freedombox-auth-ldap.conf
     Require ldap-group cn=admin,ou=groups,dc=thisbox
     Require ldap-group cn=wiki,ou=groups,dc=thisbox
 </Location>

--- a/data/etc/apache2/conf-available/radicale-plinth.conf
+++ b/data/etc/apache2/conf-available/radicale-plinth.conf
@@ -8,11 +8,6 @@ Redirect 301 /.well-known/caldav /radicale/.well-known/caldav
 <Location /radicale>
     ProxyPass http://localhost:5232
 
-    AuthType basic
-    AuthName "FreedomBox Login"
-    AuthBasicProvider ldap
-    AuthLDAPUrl "ldap:///ou=users,dc=thisbox?uid"
-    AuthLDAPGroupAttribute memberUid
-    AuthLDAPGroupAttributeIsDN off
+    Include includes/freedombox-auth-ldap.conf
     Require valid-user
 </Location>

--- a/data/etc/apache2/conf-available/repro-plinth.conf
+++ b/data/etc/apache2/conf-available/repro-plinth.conf
@@ -5,11 +5,6 @@
 <Location /repro>
     ProxyPass http://localhost:5080
 
-    AuthType basic
-    AuthName "FreedomBox Login"
-    AuthBasicProvider ldap
-    AuthLDAPUrl "ldap:///ou=users,dc=thisbox?uid"
-    AuthLDAPGroupAttribute memberUid
-    AuthLDAPGroupAttributeIsDN off
+    Include includes/freedombox-auth-ldap.conf
     Require ldap-group cn=admin,ou=groups,dc=thisbox
 </Location>

--- a/data/etc/apache2/conf-available/tt-rss-plinth.conf
+++ b/data/etc/apache2/conf-available/tt-rss-plinth.conf
@@ -5,11 +5,6 @@
 Alias /tt-rss /usr/share/tt-rss/www
 
 <Location /tt-rss>
-    AuthType basic
-    AuthName "FreedomBox Login"
-    AuthBasicProvider ldap
-    AuthLDAPUrl "ldap:///ou=users,dc=thisbox?uid"
-    AuthLDAPGroupAttribute memberUid
-    AuthLDAPGroupAttributeIsDN off
+    Include includes/freedombox-auth-ldap.conf
     Require valid-user
 </Location>


### PR DESCRIPTION
By maintaining a common LDAP auth configuration, it becomes easy for
us to change the configuration values in future for upgrades etc.