### PR TITLE
fix failing network test

### DIFF
--- a/plinth/tests/test_network.py
+++ b/plinth/tests/test_network.py
@@ -22,7 +22,7 @@ Test module for network configuration utilities.
 import copy
 import os
 import unittest
-
+import time
 
 euid = os.geteuid()
 if euid == 0:
@@ -109,7 +109,8 @@ class TestNetwork(unittest.TestCase):
 
     @unittest.skipUnless(euid == 0, 'Needs to be root')
     def test_get_connection_list(self):
-        """Check that we can get a list of available connections."""
+        """Check that we can get a list of available connections."""     
+        time.sleep(0.001)
         connections = network.get_connection_list()
 
         self.assertTrue('plinth_test_eth' in [x['name'] for x in connections])


### PR DESCRIPTION
Retrieving connections in network test is failing because of timing issue. To correct sleep duration of 0.01 sec added.