### PR TITLE
Fixes #781, Cache checked for admin in context processor

### DIFF
--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -169,7 +169,7 @@ def configure_django():
         'root': {
             'handlers': ['console', 'file'],
             'level': 'DEBUG' if cfg.debug else 'INFO'
-            }
+            }            
         }
 
     templates = [

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -169,12 +169,7 @@ def configure_django():
         'root': {
             'handlers': ['console', 'file'],
             'level': 'DEBUG' if cfg.debug else 'INFO'
-            },
-        'loggers': {
-            'django.db.backends': {
-                'level': 'DEBUG'
-                }
-            }                
+            }
         }
 
     templates = [

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -169,7 +169,12 @@ def configure_django():
         'root': {
             'handlers': ['console', 'file'],
             'level': 'DEBUG' if cfg.debug else 'INFO'
-            }            
+            },
+        'loggers': {
+            'django.db.backends': {
+                'level': 'DEBUG'
+                }
+            }                
         }
 
     templates = [

--- a/plinth/context_processors.py
+++ b/plinth/context_processors.py
@@ -43,5 +43,5 @@ def common(request):
         'submenu': cfg.main_menu.active_item(request),
         'active_menu_urls': active_menu_urls,
         'box_name': _(cfg.box_name),
-        'user_is_admin': is_user_admin(request.user)
+        'user_is_admin': is_user_admin(request, True)
     }

--- a/plinth/middleware.py
+++ b/plinth/middleware.py
@@ -102,5 +102,5 @@ class AdminRequiredMiddleware(object):
            hasattr(view_func, 'IS_NON_ADMIN'):
             return
 
-        if not is_user_admin(request.user):
+        if not is_user_admin(request):
             raise PermissionDenied

--- a/plinth/modules/users/forms.py
+++ b/plinth/modules/users/forms.py
@@ -171,7 +171,7 @@ class UserUpdateForm(ValidNewUsernameCheckMixin, forms.ModelForm):
 
         super(UserUpdateForm, self).__init__(*args, **kwargs)
 
-        if not is_user_admin(request.user):
+        if not is_user_admin(request):
             self.fields['is_active'].widget = forms.HiddenInput()
             self.fields['groups'].disabled = True
 

--- a/plinth/modules/users/views.py
+++ b/plinth/modules/users/views.py
@@ -85,7 +85,7 @@ class UserUpdate(ContextMixin, SuccessMessageMixin, UpdateView):
     def dispatch(self, request, *args, **kwargs):
         """Handle a request and return a HTTP response."""
         if self.request.user.get_username() != self.kwargs['slug'] \
-           and not is_user_admin(self.request.user):
+           and not is_user_admin(self.request):
             raise PermissionDenied
 
         return super().dispatch(request, *args, **kwargs)
@@ -156,7 +156,7 @@ class UserChangePassword(ContextMixin, SuccessMessageMixin, FormView):
     def dispatch(self, request, *args, **kwargs):
         """Handle a request and return a HTTP response."""
         if self.request.user.get_username() != self.kwargs['slug'] \
-           and not is_user_admin(self.request.user):
+           and not is_user_admin(self.request):
             raise PermissionDenied
 
         return super().dispatch(request, *args, **kwargs)

--- a/plinth/utils.py
+++ b/plinth/utils.py
@@ -54,8 +54,9 @@ def non_admin_view(func):
 
 def is_user_admin(request, cached=False):
     """Return whether user is an administrator."""
-    if cached and request.session['cache_user_is_admin']:
+    if cached and request.session['cache_user_is_admin'] is not None:
         return request.session['cache_user_is_admin']
+
     user_is_admin = request.user.groups.filter(name='admin').exists()
     request.session['cache_user_is_admin'] = user_is_admin
     return user_is_admin

--- a/plinth/utils.py
+++ b/plinth/utils.py
@@ -54,7 +54,10 @@ def non_admin_view(func):
 
 def is_user_admin(request, cached=False):
     """Return whether user is an administrator."""
-    if cached and request.session['cache_user_is_admin'] is not None:
+    if not request.user.is_authenticated():
+        return False
+
+    if 'cache_user_is_admin' in request.session and cached:
         return request.session['cache_user_is_admin']
 
     user_is_admin = request.user.groups.filter(name='admin').exists()

--- a/plinth/utils.py
+++ b/plinth/utils.py
@@ -52,6 +52,10 @@ def non_admin_view(func):
     return func
 
 
-def is_user_admin(user):
+def is_user_admin(request, cached=False):
     """Return whether user is an administrator."""
-    return user.groups.filter(name='admin').exists()
+    if cached and request.session['cache_user_is_admin']:
+        return request.session['cache_user_is_admin']
+    user_is_admin = request.user.groups.filter(name='admin').exists()
+    request.session['cache_user_is_admin'] = user_is_admin
+    return user_is_admin


### PR DESCRIPTION
Fixes #781, Cache is checked for user admin details. Changes the definition of is_user_admin in `plinth/utils.py`