### PR TITLE
make subcommands mandatory, fixes calls without arguments

### DIFF
--- a/actions/bind
+++ b/actions/bind
@@ -67,6 +67,7 @@ def parse_arguments():
     dns = subparsers.add_parser('dns', help='Set DNS forwarders')
     dns.add_argument('--set', help='List of IP addresses, separated by space')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/deluge
+++ b/actions/deluge
@@ -58,6 +58,7 @@ def parse_arguments():
     subparsers.add_parser('enable', help='Enable deluge-web site')
     subparsers.add_parser('disable', help='Disable deluge-web site')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/disks
+++ b/actions/disks
@@ -43,6 +43,7 @@ def parse_arguments():
     subparser.add_argument(
         'device', help='Partition which needs to be resized')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/ejabberd
+++ b/actions/ejabberd
@@ -78,6 +78,7 @@ def parse_arguments():
         help='Update ejabberd with new domainname')
     domainname_change.add_argument('--domainname', help='New domainname')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/firewall
+++ b/actions/firewall
@@ -57,6 +57,7 @@ def parse_arguments():
         '--zone', help='Zone from which service is to be removed',
         required=True)
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/ikiwiki
+++ b/actions/ikiwiki
@@ -66,6 +66,7 @@ def parse_arguments():
     delete = subparsers.add_parser('delete', help='Delete a wiki or blog.')
     delete.add_argument('--name', help='Name of wiki or blog to delete.')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/infinoted
+++ b/actions/infinoted
@@ -109,6 +109,7 @@ def parse_arguments():
 
     subparsers.add_parser('setup', help='Configure infinoted after install')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/letsencrypt
+++ b/actions/letsencrypt
@@ -86,6 +86,7 @@ def parse_arguments():
     obtain_parser.add_argument(
         '--domain', help='Domain name to obtain certificate for')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/matrixsynapse
+++ b/actions/matrixsynapse
@@ -40,6 +40,7 @@ def parse_arguments():
         '--domain-name',
         help='The domain name that will be used by Matrix Synapse')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/minetest
+++ b/actions/minetest
@@ -46,6 +46,7 @@ def parse_arguments():
     configure.add_argument('--enable_damage', choices=['true', 'false'],
                            help='Set damage true/false')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/monkeysphere
+++ b/actions/monkeysphere
@@ -56,6 +56,7 @@ def parse_arguments():
         'host-cancel-publish', help='Cancel a running publish operation')
     host_cancel_publish.add_argument('pid', help='PID of the publish process')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/openvpn
+++ b/actions/openvpn
@@ -106,6 +106,7 @@ def parse_arguments():
     get_profile.add_argument('remote_server',
                              help='The server name for the user to connect')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/packages
+++ b/actions/packages
@@ -42,6 +42,7 @@ def parse_arguments():
     subparser.add_argument(
         'packages', nargs='+', help='list of packages to install')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/pagekite
+++ b/actions/pagekite
@@ -80,6 +80,7 @@ def parse_arguments():
                                            help='Remove a pagekite service')
     remove_service.add_argument('--service', help='json service dictionary')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/power
+++ b/actions/power
@@ -32,6 +32,7 @@ def parse_arguments():
     subparsers.add_parser('restart', help='Restart the system')
     subparsers.add_parser('shutdown', help='Shut down the system')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/privoxy
+++ b/actions/privoxy
@@ -34,6 +34,7 @@ def parse_arguments():
         'pre-install',
         help='Preseed debconf values before packages are installed')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/radicale
+++ b/actions/radicale
@@ -42,6 +42,7 @@ def parse_arguments():
     configure.add_argument('--rights_type',
                            help='Set the rights type for radicale')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/repro
+++ b/actions/repro
@@ -34,6 +34,7 @@ def parse_arguments():
 
     subparsers.add_parser('setup', help='Configure repro')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/roundcube
+++ b/actions/roundcube
@@ -43,6 +43,7 @@ def parse_arguments():
     subparsers.add_parser('enable', help='Enable Roundcube')
     subparsers.add_parser('disable', help='Disable Roundcube')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/security
+++ b/actions/security
@@ -40,6 +40,7 @@ def parse_arguments():
         'disable-restricted-access',
         help='Don\'t restrict console login to users in admin or sudo group')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/shaarli
+++ b/actions/shaarli
@@ -34,6 +34,7 @@ def parse_arguments():
     subparsers.add_parser('enable', help='Enable Shaarli site')
     subparsers.add_parser('disable', help='Disable Shaarli site')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/snapshot
+++ b/actions/snapshot
@@ -45,6 +45,7 @@ def parse_arguments():
     subparser = subparsers.add_parser('rollback', help='Rollback to snapshot')
     subparser.add_argument('number', help='Number of snapshot to rollback to')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/ssh
+++ b/actions/ssh
@@ -43,6 +43,7 @@ def parse_arguments():
     set_keys.add_argument('--username')
     set_keys.add_argument('--keys')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/syncthing
+++ b/actions/syncthing
@@ -38,6 +38,7 @@ def parse_arguments():
     subparsers.add_parser('enable', help='Enable Syncthing')
     subparsers.add_parser('disable', help='Disable Syncthing')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/tor
+++ b/actions/tor
@@ -71,6 +71,7 @@ def parse_arguments():
 
     subparsers.add_parser('restart', help='Restart Tor')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/transmission
+++ b/actions/transmission
@@ -45,6 +45,7 @@ def parse_arguments():
         'merge-configuration',
         help='Merge JSON configuration from stdin with existing')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/ttrss
+++ b/actions/ttrss
@@ -41,6 +41,7 @@ def parse_arguments():
     subparsers.add_parser('enable', help='Enable Tiny Tiny RSS site')
     subparsers.add_parser('disable', help='Disable Tiny Tiny RSS site')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/upgrades
+++ b/actions/upgrades
@@ -46,6 +46,7 @@ def parse_arguments():
                           help='Return whether package manager is busy')
     subparsers.add_parser('get-log', help='Print the automatic upgrades log')
 
+    subparsers.required = True
     return parser.parse_args()
 
 

--- a/actions/users
+++ b/actions/users
@@ -40,6 +40,7 @@ def parse_arguments():
     subparsers.add_parser('first-run',
                           help='Additional setup performed after reboot')
 
+    subparsers.required = True
     return parser.parse_args()
 
 


### PR DESCRIPTION
For all these actions, calling without any argument lead to the same AttributeError:
```
subcommand = arguments.subcommand.replace('-', '_')
AttributeError: 'NoneType' object has no attribute 'replace'
```
Switching `subparsers.required = True` demands for the subcommands that are set up, so when now calling without arguments, the usage prompt is printed.
Something to consider: Should the script also end with an error code?