### PR TITLE
Attempt at fixing #795, bug in get_disks() for Raspberry Pi 2 image.

### DIFF
--- a/plinth/modules/disks/__init__.py
+++ b/plinth/modules/disks/__init__.py
@@ -71,6 +71,7 @@ def get_disks():
 
     return disks
 
+
 def get_disks_new():
     """Return the list of disks and free space available."""
     command = ['lsblk', '--json', '--bytes', '--output-all']
@@ -78,7 +79,7 @@ def get_disks_new():
         process = subprocess.run(command, stdout=subprocess.PIPE, check=True)
     except subprocess.CalledProcessError as exception:
         logger.exception('Error getting disk information: %s', exception)
-        return []  # TODO: or raise an "Failed Action exception"?
+        return []
 
     output = process.stdout.decode()
     out_dict = json.loads(output)
@@ -90,8 +91,9 @@ def get_disks_new():
     dev_list = []
     dev_list.extend(_subdict_to_list(dev_dict) for dev_dict in dev_dicts)
     # TODO: test if really needed in case of just one entry in dev_list:
-    dev_list = [item for sublist in dev_list for item in sublist]  # flatten list
+    dev_list = [item for sublist in dev_list for item in sublist]  # flatten
     return dev_list
+
 
 def _subdict_to_list(dev_dict):
     # walk into device dict hierarchy, to append potential children to list
@@ -107,6 +109,7 @@ def _subdict_to_list(dev_dict):
         out_list.extend(_subdict_to_list(sub_dict) for sub_dict in children)
         return out_list
 
+
 def get_root_device(disks):
     """Return the root partition's device from list of partitions."""
     devices = [disk['device'] for disk in disks if disk['mount_point'] == '/']
@@ -114,6 +117,7 @@ def get_root_device(disks):
         return devices[0]
     except IndexError:
         return None
+
 
 def get_root_device2(disks):
     """Return the root partition's device from list of partitions."""

--- a/plinth/modules/disks/__init__.py
+++ b/plinth/modules/disks/__init__.py
@@ -71,6 +71,24 @@ def get_disks():
 
     return disks
 
+def get_disks_new():
+    command = ['lsblk', '--json', '--bytes', '--output-all']
+    try:
+        process = subprocess.run(command, stdout=subprocess.PIPE, check=True)
+    except subprocess.CalledProcessError as exception:
+        logger.exception('Error getting disk information: %s', exception)
+        return []  # TODO: or raise an "Failed Action exception"?
+
+    output = process.stdout.decode()
+    outputDict = json.loads(output)
+    for devdict in outputDict['blockdevices']:
+        disks = devdict['name']
+    #print(type(disks))
+    #disks = output
+    return disks
+
+def recurseIntoBlockDevices():
+    pass
 
 def get_root_device(disks):
     """Return the root partition's device from list of partitions."""
@@ -98,3 +116,10 @@ def is_expandable(device):
 def expand_partition(device):
     """Expand a partition."""
     actions.superuser_run('disks', ['expand-partition', device])
+
+
+if __name__ == '__main__':
+    print("Old output of get_disks():")
+    print(get_disks())
+    print("\nNew output of get_disks():")
+    print(get_disks_new())

--- a/plinth/modules/disks/__init__.py
+++ b/plinth/modules/disks/__init__.py
@@ -48,12 +48,11 @@ def init():
 
 
 def get_disks():
-    """ FIXME """
+    """Returns list of disks by combining information from df and lsblk."""
     infos_df = _get_diskinfo_df()
     infos_lsblk = _get_diskinfo_lsblk()
-    # Combine both sources of info-dicts into one dict, based on mount point;
-    # note that this also discards disks without a (current) mount point,
-    # which includes the parent devices returned by lsblk.
+    # Combine both sources of info dicts into one dict, based on mount point;
+    # note this discards disks without a (current) mount point.
     combined_list = []
     for info_df in infos_df:
         for info_lsblk in infos_lsblk:
@@ -104,17 +103,8 @@ def _get_diskinfo_lsblk():
 
 def get_root_device(disks):
     """Return the root partition's device from list of partitions."""
-    devices = [disk['device'] for disk in disks if disk['mount_point'] == '/']
-    try:
-        return devices[0]
-    except IndexError:
-        return None
-
-
-def get_root_device2(disks):
-    """Return the root partition's device from list of partitions."""
     devices = ['/dev/{0}'.format(disk['kname']) for disk in disks
-               if disk['mountpoint'] == '/']
+               if disk['mountpoint'] == '/' and disk['type'] == 'part']
     try:
         return devices[0]
     except IndexError:
@@ -138,20 +128,3 @@ def is_expandable(device):
 def expand_partition(device):
     """Expand a partition."""
     actions.superuser_run('disks', ['expand-partition', device])
-
-
-if __name__ == '__main__':
-    disksOld = _get_diskinfo_df()
-    print("Output of (old) _get_diskinfo_df():")
-    print(disksOld)
-    print("\nOLD output of get_root_device():")
-    print(get_root_device(disksOld))
-    print("\n----------------------------------")
-    disksNew = _get_diskinfo_lsblk()
-    print("\nOutput of (new) _get_diskinfo_lsblk():")
-    print(disksNew)
-    print("\nNEW output of get_root_device2():")
-    print(get_root_device2(disksNew))
-    print('\n----------------------------------')
-    print('New, combined output of get_disks():')
-    print(get_disks())

--- a/plinth/modules/disks/__init__.py
+++ b/plinth/modules/disks/__init__.py
@@ -48,6 +48,7 @@ def init():
 
 
 def get_disks():
+    """ FIXME """
     infos_df = _get_diskinfo_df()
     infos_lsblk = _get_diskinfo_lsblk()
     # Combine both sources of info-dicts into one dict, based on mount point;
@@ -59,7 +60,7 @@ def get_disks():
             if info_df['mount_point'] == info_lsblk['mountpoint']:
                 info_df.update(info_lsblk)
                 combined_list.append(info_df)
-        return combined_list
+    return combined_list
 
 
 def _get_diskinfo_df():
@@ -141,17 +142,16 @@ def expand_partition(device):
 
 if __name__ == '__main__':
     disksOld = _get_diskinfo_df()
-    print("OLD output of get_disks():")
+    print("Output of (old) _get_diskinfo_df():")
     print(disksOld)
     print("\nOLD output of get_root_device():")
     print(get_root_device(disksOld))
     print("\n----------------------------------")
     disksNew = _get_diskinfo_lsblk()
-    print("\nNEW output of get_disks_new():")
+    print("\nOutput of (new) _get_diskinfo_lsblk():")
     print(disksNew)
     print("\nNEW output of get_root_device2():")
     print(get_root_device2(disksNew))
-
-    print('----------------')
-    print('combined output of get_disks():')
+    print('\n----------------------------------')
+    print('New, combined output of get_disks():')
     print(get_disks())

--- a/plinth/modules/disks/__init__.py
+++ b/plinth/modules/disks/__init__.py
@@ -87,24 +87,23 @@ def get_disks_new():
     # This hierarchy is flattened into a list (without sub-lists),
     # containing parent devices p1, p2, ..., and their children ...
     # TODO: more description
-    
-    # FIXME: Why/how does commenting in the next 2 lines impact the 3rd??
-#    dev_list = []
-#    dev_list.extend(_subdict_to_list(dev_dict) for dev_dict in dev_dicts)
-    dev_list = _subdict_to_list(dev_dicts[0])  # FIXME: fix above line
+    dev_list = []
+    dev_list.extend(_subdict_to_list(dev_dict) for dev_dict in dev_dicts)
+    # TODO: test if really needed in case of just one entry in dev_list:
+    dev_list = [item for sublist in dev_list for item in sublist]  # flatten list
     return dev_list
 
-def _subdict_to_list(dev_json):
-    # do depth-first walk into device dict hierarchy, append children to list
-    if 'children' not in dev_json.keys():
+def _subdict_to_list(dev_dict):
+    # walk into device dict hierarchy, to append potential children to list
+    if 'children' not in dev_dict.keys():
         children = None
     else:
-        children = dev_json.pop('children')
+        children = dev_dict.pop('children')
     if children is None:
-        return dev_json
+        return dev_dict
     else:  # recursively accumulate sub-dicts
         out_list = []
-        out_list.append(dev_json)  # add parent, then follow children
+        out_list.append(dev_dict)  # add parent, then follow children
         out_list.extend(_subdict_to_list(sub_dict) for sub_dict in children)
         return out_list
 
@@ -150,7 +149,7 @@ if __name__ == '__main__':
     print(disksOld)
     print("\nOLD output of get_root_device():")
     print(get_root_device(disksOld))
-    
+    print("\n----------------------------------")
     disksNew = get_disks_new()
     print("\nNEW output of get_disks_new():")
     print(disksNew)

--- a/plinth/modules/disks/__init__.py
+++ b/plinth/modules/disks/__init__.py
@@ -98,12 +98,14 @@ def _get_diskinfo_lsblk():
 
     output = process.stdout.decode()
     dev_dicts = json.loads(output)['blockdevices']
+    for ddict in dev_dicts:
+        ddict['dev_kname'] = '/dev/{0}'.format(ddict['kname'])
     return dev_dicts
 
 
 def get_root_device(disks):
     """Return the root partition's device from list of partitions."""
-    devices = ['/dev/{0}'.format(disk['kname']) for disk in disks
+    devices = [disk['dev_kname'] for disk in disks
                if disk['mountpoint'] == '/' and disk['type'] == 'part']
     try:
         return devices[0]

--- a/plinth/modules/disks/templates/disks.html
+++ b/plinth/modules/disks/templates/disks.html
@@ -47,7 +47,7 @@
         <tbody>
           {% for disk in disks %}
             <tr>
-              <td>{{ disk.device }}</td>
+              <td>{{ disk.dev_kname }}</td>
               <td>{{ disk.mount_point }}</td>
               <td>{{ disk.file_system_type }}</td>
               <td>


### PR DESCRIPTION
Hi, this should fix #795, see there for context.

I've tried to be minimally invasive, and had to make a few compromises.
Most importantly, I think lsblk and df deliver complimentary info, so I combined their output, based on the reported mount points.
I'm curious what you think.

In case it's interesting, here's a debugging print running on my Pi2 (see also screenshot below):
Note that in the first line, `_get_diskinfo_df()` is just a renamed function `get_disks()`, just to compare the old and the new versions.
The main fix is that `get_root_device()` now returns `/dev/mmcblk0p2` instead of `/dev/root` (which by the way isn't even visible in the file system).

```
Output of (old) _get_diskinfo_df():
[{'mount_point': '/', 'size': '7.2G', 'used': '3.8G', 'percentage_used': 56, 'file_system_type': 'ext4', 'device': '/dev/root'}, {'mount_point': '/boot', 'size': '117M', 'used': '20M', 'percentage_used': 18, 'file_system_type': 'vfat', 'device': '/dev/mmcblk0p1'}, {'mount_point': '/mnt/usb16G', 'size': '15G', 'used': '4.0G', 'percentage_used': 30, 'file_system_type': 'ext4', 'device': '/dev/sda1'}]

OLD output of get_root_device():
/dev/root

----------------------------------

Output of (new) _get_diskinfo_lsblk():
[{'pkname': None, 'kname': 'sda', 'type': 'disk', 'mountpoint': None}, {'pkname': 'sda', 'kname': 'sda1', 'type': 'part', 'mountpoint': '/mnt/usb16G'}, {'pkname': None, 'kname': 'mmcblk0', 'type': 'disk', 'mountpoint': None}, {'pkname': 'mmcblk0', 'kname': 'mmcblk0p1', 'type': 'part', 'mountpoint': '/boot'}, {'pkname': 'mmcblk0', 'kname': 'mmcblk0p2', 'type': 'part', 'mountpoint': '/'}]

NEW output of get_root_device2():
/dev/mmcblk0p2

----------------------------------
New, combined output of get_disks():
[{'mountpoint': '/', 'pkname': 'mmcblk0', 'mount_point': '/', 'size': '7.2G', 'kname': 'mmcblk0p2', 'used': '3.8G', 'percentage_used': 56, 'type': 'part', 'file_system_type': 'ext4', 'device': '/dev/root'}, {'mountpoint': '/boot', 'pkname': 'mmcblk0', 'mount_point': '/boot', 'size': '117M', 'kname': 'mmcblk0p1', 'used': '20M', 'percentage_used': 18, 'type': 'part', 'file_system_type': 'vfat', 'device': '/dev/mmcblk0p1'}, {'mountpoint': '/mnt/usb16G', 'pkname': 'sda', 'mount_point': '/mnt/usb16G', 'size': '15G', 'kname': 'sda1', 'used': '4.0G', 'percentage_used': 30, 'type': 'part', 'file_system_type': 'ext4', 'device': '/dev/sda1'}]
```