### PR TITLE
disks: add missing import json

### DIFF
--- a/plinth/modules/disks/__init__.py
+++ b/plinth/modules/disks/__init__.py
@@ -22,6 +22,7 @@ Plinth module to manage disks.
 from django.utils.translation import ugettext_lazy as _
 import logging
 import subprocess
+import json
 
 from plinth import actions
 from plinth.menu import main_menu


### PR DESCRIPTION
Currently there's a missing `import json` in the disks module, leading to crash whenever it's visited in plinth. I guess it somehow got lost during rebasing of my commits in PR #823.
This PR fixes that.