### PR TITLE
disks: restrict precision of reported available space on root partition

### DIFF
--- a/plinth/modules/disks/views.py
+++ b/plinth/modules/disks/views.py
@@ -74,19 +74,19 @@ def _format_bytes(size):
         return size
 
     if size < 1024:
-        return _('{disk_size} bytes').format(disk_size=size)
+        return _('{disk_size:.1f} bytes').format(disk_size=size)
 
     if size < 1024 ** 2:
         size /= 1024
-        return _('{disk_size} KiB').format(disk_size=size)
+        return _('{disk_size:.1f} KiB').format(disk_size=size)
 
     if size < 1024 ** 3:
         size /= 1024 ** 2
-        return _('{disk_size} MiB').format(disk_size=size)
+        return _('{disk_size:.1f} MiB').format(disk_size=size)
 
     if size < 1024 ** 4:
         size /= 1024 ** 3
-        return _('{disk_size} GiB').format(disk_size=size)
+        return _('{disk_size:.1f} GiB').format(disk_size=size)
 
     size /= 1024 ** 4
-    return _('{disk_size} TiB').format(disk_size=size)
+    return _('{disk_size:.1f} TiB').format(disk_size=size)


### PR DESCRIPTION
It bugs me that available space of the root partition is reported to silly precision :-).
This PR restricts it to one decimal; that's no problem since the unit changes (from Bytes to TiB).

![fixprecision](https://cloud.githubusercontent.com/assets/8722846/26456752/540fb620-416e-11e7-88cd-518e712f9e69.png)
