### PR TITLE
help: Add Debian release to about page.

### DIFF
--- a/plinth/modules/help/help.py
+++ b/plinth/modules/help/help.py
@@ -57,7 +57,8 @@ def about(request):
     context = {
         'title': _('About {box_name}').format(box_name=_(cfg.box_name)),
         'version': __version__,
-        'new_version': not plinth.candidate.is_installed
+        'new_version': not plinth.candidate.is_installed,
+        'os_release': get_os_release()
     }
     return TemplateResponse(request, 'help_about.html', context)
 
@@ -90,3 +91,15 @@ def status_log(request):
         'data': data
     }
     return TemplateResponse(request, 'statuslog.html', context)
+
+
+def get_os_release():
+    """Returns the Debian release number and name"""
+    output = 'Error: Cannot read PRETTY_NAME in /etc/os-release.'
+    with open('/etc/os-release', 'r') as release_file:
+        for line in release_file:
+            if 'PRETTY_NAME=' in line:
+                line = line.replace('"', '').strip()
+                line = line.split('=')
+                output = line[1]
+    return output

--- a/plinth/modules/help/templates/help_about.html
+++ b/plinth/modules/help/templates/help_about.html
@@ -83,7 +83,7 @@
       {% endblocktrans %}
     {% else %}
       {% blocktrans trimmed %}
-        Your Plinth version is up-to-date.
+        Plinth is up to date.
       {% endblocktrans %}
     {% endif %}
   </p>

--- a/plinth/modules/help/templates/help_about.html
+++ b/plinth/modules/help/templates/help_about.html
@@ -74,12 +74,16 @@
 
   <p style='margin-top:30px'>
     {% blocktrans trimmed %}
-      You are running Plinth version {{ version }}.
+      You are running {{ os_release }} and Plinth version {{ version }}.
     {% endblocktrans %}
 
     {% if new_version %}
       {% blocktrans trimmed %}
-        There is a new version available.
+        There is a new Plinth version available.
+      {% endblocktrans %}
+    {% else %}
+      {% blocktrans trimmed %}
+        Your Plinth version is up-to-date.
       {% endblocktrans %}
     {% endif %}
   </p>


### PR DESCRIPTION
This adds the Debian version to Plinth's help - about page, and explicitly tells the user whether Plinth is up to date.
Fixes #831 which reports about doubts around these versions.

(Edit: outdated!) Screenshot from vagrant image:
![addeddebrelease](https://cloud.githubusercontent.com/assets/8722846/26473253/ba212ebc-41aa-11e7-98a7-1b9fadb9c30e.png)
