### PR TITLE
disks: delete existing test file, if necessary

### DIFF
--- a/plinth/modules/disks/tests/test_disks.py
+++ b/plinth/modules/disks/tests/test_disks.py
@@ -53,11 +53,7 @@ class Disk():
         directory = os.path.dirname(os.path.realpath(__file__))
         disk_file = os.path.join(directory, 'temp_disk.img')
 
-        try:
-            os.stat(disk_file)
-        except FileNotFoundError:
-            pass
-        else:
+        if os.path.isfile(disk_file):
             os.remove(disk_file)
 
         command = 'dd if=/dev/zero of={file} bs=1M count={size}' \

--- a/plinth/modules/disks/tests/test_disks.py
+++ b/plinth/modules/disks/tests/test_disks.py
@@ -53,6 +53,13 @@ class Disk():
         directory = os.path.dirname(os.path.realpath(__file__))
         disk_file = os.path.join(directory, 'temp_disk.img')
 
+        try:
+            os.stat(disk_file)
+        except FileNotFoundError:
+            pass
+        else:
+            os.remove(disk_file)
+
         command = 'dd if=/dev/zero of={file} bs=1M count={size}' \
                   .format(size=self.size, file=disk_file)
         subprocess.run(command.split(), stderr=subprocess.DEVNULL, check=True)


### PR DESCRIPTION
This is an attempt to fix issue #780.
At least on the vagrant image (not checked elsewhere), this allows the disk test to pass even if they are interrupted for some reason. (I've simulated this by commenting out the cleanup methods in the [\_\_exit\_\_ method]( https://github.com/freedombox/Plinth/blob/master/plinth/modules/disks/tests/test_disks.py#L114)).
In issue #780, it was proposed to create a new disk file name for every test. However, this PR circumvents the creation of multiple files by simply checking if the disk file exists already, and deleting it if it does.
Due to repeated `losetup`s, there are however many loopback devices accumulating in `/dev/loop*` after multiple tests, which seems fine.

Edit: More explanation, simplified the file-check.