### PR TITLE
navbar: moved logout to user drop-down and added a new power drop-down

### DIFF
--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -132,19 +132,50 @@
                    role="button" aria-expanded="false">
                   <i class="glyphicon glyphicon-user nav-icon"></i>
                   {{ user.username }}
-                  <span class="caret"></span></a>
+                  <span class="caret"></span>
+                </a>
                 <ul class="dropdown-menu" role="menu">
-                  <li><a href="{% url 'users:edit' user.username %}"
-                         title="{% trans "Edit"%}">{% trans "Edit" %}</a></li>
-                  <li><a href="{% url 'users:change_password' user.username %}"
-                         title="{% trans "Change password" %}">
-                    {% trans "Change password" %}</a></li>
+                  <li>
+                    <a href="{% url 'users:edit' user.username %}"
+                       title="{% trans "Edit"%}">
+                      {% trans "Edit" %}
+                    </a>
+                  </li>
+                  <li>
+                    <a href="{% url 'users:change_password' user.username %}"
+                       title="{% trans "Change password" %}">
+                      {% trans "Change password" %}
+                    </a>
+                  </li>
+                  <li>
+                    <a href="{% url 'users:logout' %}"
+                       title="{% trans "Log out" %}">
+                      {% trans "Log out" %}
+                    </a>
+                  </li>
                 </ul>
               </li>
-              <li>
-                <a href="{% url 'users:logout' %}" title="{% trans "Log out" %}">
-                  <span class="glyphicon glyphicon-off nav-icon"></span>
+              <li class="dropdown">
+                <a href="{% url 'power:index' %}"
+                   class="dropdown-toggle" data-toggle="dropdown"
+                   role="button" aria-expanded="false">
+                  <i class="glyphicon glyphicon-off nav-icon"></i>
+                  <span class="caret"></span>
                 </a>
+                <ul class="dropdown-menu" role="menu">
+                  <li>
+                    <a href="{% url 'power:restart' %}"
+                       title="{% trans "Restart"%}">
+                      {% trans "Restart" %}
+                    </a>
+                  </li>
+                  <li>
+                    <a href="{% url 'power:shutdown' %}"
+                       title="{% trans "Shut down" %}">
+                      {% trans "Shut down" %}
+                    </a>
+                  </li>
+                </ul>
               </li>
             {% else %}
               <li>


### PR DESCRIPTION
This should fix issue #834.
The on/off symbol would get a drop-down menu for restart/shutdown, and the previous logout function can be found in the user drop-down menu (screenshots below).
Without JavaScript, the power button links to the existing power page, offering the same choice between restart and shutdown (and the already existing logout-button still appears for easy logout).

(Note I've also cleaned up some of the code style, to match with the style in the same file, above.)

Screenshots of PR, with JS enabled:
![new_userdropdown](https://cloud.githubusercontent.com/assets/8722846/26797480/4e538866-4a2d-11e7-8492-e0d52fa4bbc0.png)
![new_powerdropdown](https://cloud.githubusercontent.com/assets/8722846/26797500/59c838c2-4a2d-11e7-9c08-59832f3a2a44.png)

