### PR TITLE
SSO: Generate keys during plinth startup

### DIFF
--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -260,13 +260,13 @@ def run_setup(module_list, allow_install=True):
             setup.setup_modules(module_list, allow_install=allow_install)
     except Exception as exception:
         logger.error('Error running setup - %s', exception)
-        error_code = 1
+        return 1
+    return 0
 
 
 def run_setup_and_exit(module_list, allow_install=True):
     """Run setup on all essential modules and exit."""
-    error_code = 0
-    run_setup(module_list, allow_install)
+    error_code = run_setup(module_list, allow_install)
     sys.exit(error_code)
 
 

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -252,9 +252,7 @@ def configure_django():
     os.chmod(cfg.store_file, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
 
 
-def run_setup_and_exit(module_list, allow_install=True):
-    """Run setup on all essential modules and exit."""
-    error_code = 0
+def run_setup(module_list, allow_install=True):
     try:
         if not module_list:
             setup.setup_modules(essential=True, allow_install=allow_install)
@@ -264,6 +262,11 @@ def run_setup_and_exit(module_list, allow_install=True):
         logger.error('Error running setup - %s', exception)
         error_code = 1
 
+
+def run_setup_and_exit(module_list, allow_install=True):
+    """Run setup on all essential modules and exit."""
+    error_code = 0
+    run_setup(module_list, allow_install)
     sys.exit(error_code)
 
 
@@ -334,8 +337,8 @@ def main():
     menu.init()
 
     module_loader.load_modules()
-    if arguments.setup is not False:
-        run_setup_and_exit(arguments.setup)
+
+    run_setup(arguments.setup)
 
     if arguments.setup_no_install is not False:
         run_setup_and_exit(arguments.setup_no_install, allow_install=False)

--- a/plinth/modules/sso/__init__.py
+++ b/plinth/modules/sso/__init__.py
@@ -18,7 +18,7 @@
 Plinth module to configure Single Sign On services.
 """
 
-from plinth import actions, action_utils
+from plinth import actions
 from django.utils.translation import ugettext_lazy as _
 
 version = 1
@@ -31,15 +31,8 @@ title = _('Single Sign On')
 
 managed_packages = ['libapache2-mod-auth-pubtkt', 'openssl', 'python3-openssl']
 
-first_boot_steps = [
-    {
-        'id': 'sso_firstboot',
-        'url': 'sso:firstboot',
-        'order': 1
-    },
-]
-
 
 def setup(helper, old_version=None):
     """Install the required packages"""
     helper.install(managed_packages)
+    actions.superuser_run('auth-pubtkt', ['create-key-pair'])

--- a/plinth/modules/sso/urls.py
+++ b/plinth/modules/sso/urls.py
@@ -20,11 +20,10 @@ URLs for the Single Sign On module.
 
 from django.conf.urls import url
 
-from .views import login, refresh, FirstBootView
+from .views import login, refresh
 from stronghold.decorators import public
 
 urlpatterns = [
     url(r'^accounts/sso/login/$', public(login), name='sso-login'),
     url(r'^accounts/sso/refresh/$', refresh, name='sso-refresh'),
-    url(r'^accounts/sso/firstboot/$', public(FirstBootView.as_view()), name='firstboot'),
 ]

--- a/plinth/modules/sso/views.py
+++ b/plinth/modules/sso/views.py
@@ -22,11 +22,8 @@ import os
 import urllib
 
 from plinth import actions
-from plinth.modules import first_boot
 
-from django.urls import reverse
 from django.http import HttpResponseRedirect
-from django.views.generic.base import RedirectView
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import (login as auth_login, logout as
@@ -75,12 +72,3 @@ def refresh(request):
     response = HttpResponseRedirect(redirect_url)
     response.delete_cookie(SSO_COOKIE_NAME)
     return set_ticket_cookie(request.user, response)
-
-
-class FirstBootView(RedirectView):
-    """Create keys for Apache server during first boot"""
-
-    def get_redirect_url(self, *args, **kwargs):
-        actions.superuser_run('auth-pubtkt', ['create-key-pair'])
-        first_boot.mark_step_done('sso_firstboot')
-        return reverse(first_boot.next_step())

--- a/plinth/modules/users/__init__.py
+++ b/plinth/modules/users/__init__.py
@@ -38,7 +38,7 @@ first_boot_steps = [
     {
         'id': 'users_firstboot',
         'url': 'users:firstboot',
-        'order': 2
+        'order': 1
     },
 ]
 


### PR DESCRIPTION
- Removed key generation for mod_auth_pubtkt from first boot.
- Running setup every time plinth starts so that new essential modules
can be setup properly.

Partially fixes #875