### PR TITLE
letsencrypt: More info on cert validity, and a delete button

### DIFF
--- a/actions/letsencrypt
+++ b/actions/letsencrypt
@@ -25,6 +25,7 @@ import json
 import os
 import subprocess
 import sys
+import re
 
 from plinth import action_utils
 
@@ -98,6 +99,22 @@ def get_certificate_expiry(domain):
     return output.decode().strip().split('=')[1]
 
 
+def get_validity_status(domain):
+    """Return validity status of a certificate, e.g. valid, revoked, expired."""
+    output = subprocess.check_output(['certbot', 'certificates', '-d', domain])
+    output = output.decode(sys.stdout.encoding)
+
+    match = re.search('INVALID: (.*)\)', output)
+    if match is not None:
+        validity = match.group(1).lower()
+    elif re.search('VALID', output) is not None:
+        validity = 'valid'
+    else:
+        validity = 'unknown'
+
+    return validity
+
+
 def subcommand_get_status(_):
     """Return a JSON dictionary of currently configured domains."""
     try:
@@ -114,7 +131,8 @@ def subcommand_get_status(_):
             'certificate_available': True,
             'expiry_date': get_certificate_expiry(domain),
             'web_enabled':
-            action_utils.webserver_is_enabled(domain, kind='site')
+            action_utils.webserver_is_enabled(domain, kind='site'),
+            'validity': get_validity_status(domain)
         }
 
     print(json.dumps({'domains': domain_status}))

--- a/actions/letsencrypt
+++ b/actions/letsencrypt
@@ -79,13 +79,17 @@ def parse_arguments():
     subparsers.add_parser(
         'get-status', help='Return the status of configured domains.')
     revoke_parser = subparsers.add_parser(
-        'revoke', help='Disable and domain and revoke its certificate.')
-    revoke_parser.add_argument(
-        '--domain', help='Domain name to revoke certificate for')
+        'revoke', help='Revoke certificate of a domain and disable website.')
+    revoke_parser.add_argument('--domain', required=True,
+                               help='Domain name to revoke certificate for')
     obtain_parser = subparsers.add_parser(
         'obtain', help='Obtain certificate for a domain and setup website.')
-    obtain_parser.add_argument(
-        '--domain', help='Domain name to obtain certificate for')
+    obtain_parser.add_argument('--domain', required=True,
+                               help='Domain name to obtain certificate for')
+    delete_parser = subparsers.add_parser(
+        'delete', help='Delete certificate for a domain and disable website.')
+    delete_parser.add_argument('--domain', required=True,
+                               help='Domain name to delete certificate of')
 
     subparsers.required = True
     return parser.parse_args()
@@ -179,6 +183,20 @@ def subcommand_obtain(arguments):
     setup_webserver_config(domain)
 
     action_utils.webserver_enable(domain, kind='site')
+
+
+def subcommand_delete(arguments):
+    """Disable a domain and delete the certificate."""
+    domain = arguments.domain
+    command = ['certbot', 'delete', '--cert-name', domain]
+    process = subprocess.Popen(command, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    if process.returncode:
+        print(stderr.decode(), file=sys.stderr)
+        sys.exit(1)
+
+    action_utils.webserver_disable(domain, kind='site')
 
 
 def setup_webserver_config(domain):

--- a/plinth/modules/letsencrypt/templates/letsencrypt.html
+++ b/plinth/modules/letsencrypt/templates/letsencrypt.html
@@ -57,7 +57,7 @@
                         Valid, expires on {{ expiry_date }}
                       {% endblocktrans %}
                     </span>
-                  {% elif domain_status.certificate_available and domain_status.validity == "valid" %}
+                  {% elif domain_status.certificate_available and not domain_status.validity == "valid" %}
                     <span class="label label-warning">
                       {% if "revoked" in domain_status.validity %}
                         {% blocktrans trimmed %}

--- a/plinth/modules/letsencrypt/templates/letsencrypt.html
+++ b/plinth/modules/letsencrypt/templates/letsencrypt.html
@@ -51,11 +51,31 @@
               <tr>
                 <td>{{ domain }}</td>
                 <td>
-                  {% if domain_status.certificate_available %}
+                  {% if domain_status.certificate_available and domain_status.validity == "valid" %}
                     <span class="label label-success">
                       {% blocktrans trimmed with expiry_date=domain_status.expiry_date %}
-                        Expires on {{ expiry_date }}
+                        Valid, expires on {{ expiry_date }}
                       {% endblocktrans %}
+                    </span>
+                  {% elif domain_status.certificate_available and domain_status.validity == "valid" %}
+                    <span class="label label-warning">
+                      {% if "revoked" in domain_status.validity %}
+                        {% blocktrans trimmed %}
+                          Revoked
+                        {% endblocktrans %}
+                      {% elif "expired" in domain_status.validity %}
+                        {% blocktrans trimmed with expiry_date=domain_status.expiry_date %}
+                          Expired on {{ expiry_date }}
+                        {% endblocktrans %}
+                      {% elif "test" in domain_status.validity %}
+                        {% blocktrans trimmed %}
+                          Invalid test certificate
+                        {% endblocktrans %}
+                      {% else %}
+                        {% blocktrans trimmed with reason=domain_status.validity %}
+                          Invalid ({{ reason }})
+                        {% endblocktrans %}
+                      {% endif %}
                     </span>
                   {% else %}
                     <span class="label label-warning">
@@ -73,17 +93,19 @@
                 <td>
                   {% if domain_status.certificate_available %}
                     <form class="form form-inline" method="post"
-                          action="{% url 'letsencrypt:revoke' domain %}">
-                      {% csrf_token %}
-                      <button class="btn btn-sm btn-default" type="submit">
-                        {% trans "Revoke" %}</button>
-                    </form>
-                    <form class="form form-inline" method="post"
                           action="{% url 'letsencrypt:obtain' domain %}">
                       {% csrf_token %}
                       <button class="btn btn-sm btn-default" type="submit">
                         {% trans "Re-obtain" %}</button>
                     </form>
+                    {% if "revoked" not in domain_status.validity %}
+                      <form class="form form-inline" method="post"
+                            action="{% url 'letsencrypt:revoke' domain %}">
+                        {% csrf_token %}
+                        <button class="btn btn-sm btn-default" type="submit">
+                          {% trans "Revoke" %}</button>
+                      </form>
+                    {% endif %}
                   {% else %}
                     <form class="form form-inline" method="post"
                           action="{% url 'letsencrypt:obtain' domain %}">

--- a/plinth/modules/letsencrypt/templates/letsencrypt.html
+++ b/plinth/modules/letsencrypt/templates/letsencrypt.html
@@ -98,6 +98,12 @@
                       <button class="btn btn-sm btn-default" type="submit">
                         {% trans "Re-obtain" %}</button>
                     </form>
+                    <form class="form form-inline" method="post"
+                          action="{% url 'letsencrypt:delete' domain %}">
+                      {% csrf_token %}
+                      <button class="btn btn-sm btn-default" type="submit">
+                        {% trans "Delete" %}</button>
+                    </form>
                     {% if "revoked" not in domain_status.validity %}
                       <form class="form form-inline" method="post"
                             action="{% url 'letsencrypt:revoke' domain %}">

--- a/plinth/modules/letsencrypt/urls.py
+++ b/plinth/modules/letsencrypt/urls.py
@@ -20,7 +20,6 @@ URLs for the Let's Encrypt module.
 """
 
 from django.conf.urls import url
-
 from . import views
 
 
@@ -30,4 +29,6 @@ urlpatterns = [
         name='revoke'),
     url(r'^sys/letsencrypt/obtain/(?P<domain>[^/]+)/$', views.obtain,
         name='obtain'),
+    url(r'^sys/letsencrypt/delete/(?P<domain>[^/]+)/$', views.delete,
+        name='delete'),
 ]

--- a/plinth/modules/letsencrypt/views.py
+++ b/plinth/modules/letsencrypt/views.py
@@ -52,7 +52,8 @@ def revoke(request, domain):
     try:
         actions.superuser_run('letsencrypt', ['revoke', '--domain', domain])
         messages.success(
-            request, _('Certificate successfully revoked for domain {domain}')
+            request, _('Certificate successfully revoked for domain {domain}.'
+                       'This may take a few moments to take effect.')
             .format(domain=domain))
     except ActionError as exception:
         messages.error(

--- a/plinth/modules/letsencrypt/views.py
+++ b/plinth/modules/letsencrypt/views.py
@@ -81,6 +81,23 @@ def obtain(request, domain):
     return redirect(reverse_lazy('letsencrypt:index'))
 
 
+@require_POST
+def delete(request, domain):
+    """Delete a certificate for a given domain."""
+    try:
+        actions.superuser_run('letsencrypt', ['delete', '--domain', domain])
+        messages.success(
+            request, _('Certificate successfully deleted for domain {domain}')
+            .format(domain=domain))
+    except ActionError as exception:
+        messages.error(
+            request,
+            _('Failed to delete certificate for domain {domain}: {error}')
+            .format(domain=domain, error=exception.args[2]))
+
+    return redirect(reverse_lazy('letsencrypt:index'))
+
+
 def get_status():
     """Get the current settings."""
     status = actions.superuser_run('letsencrypt', ['get-status'])


### PR DESCRIPTION
Hi, this PR yields more visible information of LE certificate validity, e.g. whether a certificate is revoked (via OCSP), or expired, or invalid for other reasons (such as a test certificate). That info is extracted from `certbot`, [see here](https://github.com/certbot/certbot/blob/master/certbot/cert_manager.py#L182) for the parsed human-readable reasons.
In addition, a delete button is included, which functions independently of all other buttons. I briefly thought about revoking a certificate first before deleting it, but as it is, the user would have to do that.

Below, a comparison with/without this PR, with the *same* certificate status (only the order of rows in the table changes, unfortunately).

**Current master:** Note the missing information that the cert for "test2" subdomain is revoked; and the Revoke button is still shown.
![certstat_old](https://user-images.githubusercontent.com/8722846/27510478-6be41038-5911-11e7-96fc-feced9f46792.png)
**With this PR:** Note the information "Revoked" for the "test2" subdomain, and missing Revoke button. Similarly, there would be "Expired on {{ expiry_date }}" or "Invalid test certificate" as other possible reasons for an invalid certifiate. Also, any certificate may be deleted (and the button order is changed to make them line up across rows).
![certstat_new](https://user-images.githubusercontent.com/8722846/27510481-88fe1e16-5911-11e7-9fb3-effa31c2ef0c.png)
