### PR TITLE
i18n: don't use backslash-newline for wrapping long lines in _()

### DIFF
--- a/plinth/modules/datetime/forms.py
+++ b/plinth/modules/datetime/forms.py
@@ -34,8 +34,8 @@ class DateTimeForm(ServiceForm):
     """Date/time configuration form."""
     time_zone = forms.ChoiceField(
         label=_('Time Zone'),
-        help_text=_('Set your time zone to get accurate timestamps. \
-This will set the system-wide time zone.'))
+        help_text=_('Set your time zone to get accurate timestamps. '
+                    'This will set the system-wide time zone.'))
 
     def __init__(self, *args, **kwargs):
         """Initialize the date/time form."""

--- a/plinth/modules/minetest/forms.py
+++ b/plinth/modules/minetest/forms.py
@@ -32,24 +32,24 @@ class MinetestForm(ServiceForm):
         required=True,
         min_value=1,
         max_value=100,
-        help_text=_('You can change the maximum number of players playing \
-                     minetest at a single instance of time'))
+        help_text=_('You can change the maximum number of players playing '
+                    'minetest at a single instance of time.'))
 
     creative_mode = forms.BooleanField(
         label=_('Enable creative mode'),
         required=False,
-        help_text=_('Creative mode changes the rules of the game to make it \
-                     more suitable for creative gameplay, rather than \
-                     challenging "survival" gameplay.'))
+        help_text=_('Creative mode changes the rules of the game to make it '
+                    'more suitable for creative gameplay, rather than '
+                    'challenging "survival" gameplay.'))
 
     enable_pvp = forms.BooleanField(
         label=_('Enable PVP'),
         required=False,
-        help_text=_('Enabling Player Vs Player will allow players to damage \
-                    other players'))
+        help_text=_('Enabling Player Vs Player will allow players to damage '
+                    'other players.'))
 
     enable_damage = forms.BooleanField(
         label=_('Enable damage'),
         required=False,
-        help_text=_('When disabled, players cannot die or receive damage of \
-                    any kind'))
+        help_text=_('When disabled, players cannot die or receive damage of '
+                    'any kind.'))

--- a/plinth/modules/networks/forms.py
+++ b/plinth/modules/networks/forms.py
@@ -43,8 +43,9 @@ class ConnectionForm(forms.Form):
                     'to.'))
     zone = forms.ChoiceField(
         label=_('Firewall Zone'),
-        help_text=_('The firewall zone will control which services are \
-available over this interfaces. Select Internal only for trusted networks.'),
+        help_text=_('The firewall zone will control which services are '
+                    'available over this interfaces. Select Internal only '
+                    'for trusted networks.'),
         choices=[('external', _('External')),
                  ('internal', _('Internal'))])
     ipv4_method = forms.ChoiceField(

--- a/plinth/modules/transmission/forms.py
+++ b/plinth/modules/transmission/forms.py
@@ -29,9 +29,9 @@ class TransmissionForm(ServiceForm):  # pylint: disable=W0232
     """Transmission configuration form"""
     download_dir = forms.CharField(
         label=_('Download directory'),
-        help_text=_('Directory where downloads are saved.  If you change the \
-default directory, ensure that the new directory exists and is writable by \
-"debian-transmission" user.'))
+        help_text=_('Directory where downloads are saved.  If you change the '
+                    'default directory, ensure that the new directory exists '
+                    'and is writable by "debian-transmission" user.'))
 
     rpc_username = forms.CharField(
         label=_('Username'),
@@ -39,6 +39,6 @@ default directory, ensure that the new directory exists and is writable by \
 
     rpc_password = forms.CharField(
         label=_('Password'),
-        help_text=_('Password to login to the web interface.  Current \
-password is shown in a hashed format.  To set a new password, enter the \
-password in plain text.'))
+        help_text=_('Password to login to the web interface.  Current '
+                    'password is shown in a hashed format.  To set a new '
+                    'password, enter the password in plain text.'))


### PR DESCRIPTION
Hi, this should fix #872. I've rgrep'd through all *.py files, so this should be all.

Edit: Oh, found one more, sorry for the 2nd commit. Please squash them before signing off.