### PR TITLE
power: warn if a package manager is running before shutdown/restart

### DIFF
--- a/plinth/modules/power/templates/power.html
+++ b/plinth/modules/power/templates/power.html
@@ -24,7 +24,7 @@
 {% block configuration %}
 
   {% if pkg_manager_is_busy %}
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-danger">
     {% blocktrans trimmed %}
       Currently an installation or upgrade is running.
       Consider waiting until it's finished before shutting down or restarting.

--- a/plinth/modules/power/templates/power.html
+++ b/plinth/modules/power/templates/power.html
@@ -23,6 +23,15 @@
 
 {% block configuration %}
 
+  {% if pkg_manager_is_busy %}
+    <div class="alert alert-warning" role="alert">
+    {% blocktrans trimmed %}
+      Currently an installation or upgrade is running.
+      Consider waiting until it's finished before shutting down or restarting.
+    {% endblocktrans %}
+    </div>
+  {% endif %}
+
   <p>
     <a class="btn btn-default btn-md" href="{% url 'power:restart' %}">
       {% trans "Restart &raquo;" %}</a>

--- a/plinth/modules/power/templates/power_restart.html
+++ b/plinth/modules/power/templates/power_restart.html
@@ -33,6 +33,15 @@
     {% endblocktrans %}
   </p>
 
+  {% if pkg_manager_is_busy %}
+    <div class="alert alert-warning" role="alert">
+    {% blocktrans trimmed %}
+      Currently an installation or upgrade is running.
+      Consider waiting until it's finished before restarting.
+    {% endblocktrans %}
+    </div>
+  {% endif %}
+
   <form class="form" method="post">
     {% csrf_token %}
 

--- a/plinth/modules/power/templates/power_restart.html
+++ b/plinth/modules/power/templates/power_restart.html
@@ -34,7 +34,7 @@
   </p>
 
   {% if pkg_manager_is_busy %}
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-danger">
     {% blocktrans trimmed %}
       Currently an installation or upgrade is running.
       Consider waiting until it's finished before restarting.

--- a/plinth/modules/power/templates/power_restart.html
+++ b/plinth/modules/power/templates/power_restart.html
@@ -47,8 +47,14 @@
 
     {{ form|bootstrap }}
 
-    <input type="submit" class="btn btn-primary"
-           value="{% trans "Restart Now" %}"/>
+    {% if pkg_manager_is_busy %}
+      <input type="submit" class="btn btn-danger"
+             value="{% trans "Restart Now" %}"/>
+    {% else %}
+      <input type="submit" class="btn btn-primary"
+             value="{% trans "Restart Now" %}"/>
+    {% endif %}
+
   </form>
 
 {% endblock %}

--- a/plinth/modules/power/templates/power_shutdown.html
+++ b/plinth/modules/power/templates/power_shutdown.html
@@ -46,8 +46,14 @@
 
     {{ form|bootstrap }}
 
-    <input type="submit" class="btn btn-primary"
-           value="{% trans "Shut Down Now" %}"/>
+    {% if pkg_manager_is_busy %}
+      <input type="submit" class="btn btn-danger"
+             value="{% trans "Shut Down Now" %}"/>
+    {% else %}
+      <input type="submit" class="btn btn-primary"
+             value="{% trans "Shut Down Now" %}"/>
+    {% endif %}
+
   </form>
 
 

--- a/plinth/modules/power/templates/power_shutdown.html
+++ b/plinth/modules/power/templates/power_shutdown.html
@@ -33,7 +33,7 @@
   </p>
 
   {% if pkg_manager_is_busy %}
-    <div class="alert alert-warning" role="alert">
+    <div class="alert alert-danger">
     {% blocktrans trimmed %}
       Currently an installation or upgrade is running.
       Consider waiting until it's finished before shutting down.

--- a/plinth/modules/power/templates/power_shutdown.html
+++ b/plinth/modules/power/templates/power_shutdown.html
@@ -32,6 +32,15 @@
     {% endblocktrans %}
   </p>
 
+  {% if pkg_manager_is_busy %}
+    <div class="alert alert-warning" role="alert">
+    {% blocktrans trimmed %}
+      Currently an installation or upgrade is running.
+      Consider waiting until it's finished before shutting down.
+    {% endblocktrans %}
+    </div>
+  {% endif %}
+
   <form class="form" method="post">
     {% csrf_token %}
 

--- a/plinth/modules/power/views.py
+++ b/plinth/modules/power/views.py
@@ -33,7 +33,8 @@ def index(request):
     """Serve power controls page."""
     return TemplateResponse(request, 'power.html',
                             {'title': power.title,
-                             'description': power.description})
+                             'description': power.description,
+                             'pkg_manager_is_busy': _is_pkg_manager_busy()})
 
 
 def restart(request):
@@ -48,7 +49,8 @@ def restart(request):
 
     return TemplateResponse(request, 'power_restart.html',
                             {'title': _('Power'),
-                             'form': form})
+                             'form': form,
+                             'pkg_manager_is_busy': _is_pkg_manager_busy()})
 
 
 def shutdown(request):
@@ -63,4 +65,14 @@ def shutdown(request):
 
     return TemplateResponse(request, 'power_shutdown.html',
                             {'title': _('Power'),
-                             'form': form})
+                             'form': form,
+                             'pkg_manager_is_busy': _is_pkg_manager_busy()})
+
+
+def _is_pkg_manager_busy():
+    """Return whether a package manager is running."""
+    try:
+        actions.superuser_run('packages', ['is-package-manager-busy'])
+        return True
+    except actions.ActionError:
+        return False


### PR DESCRIPTION
This addresses issue #746. Warnings are shown before shutdown or restart.
Here an (edit: outdated) screenshot before shutdown:
![power_warning](https://user-images.githubusercontent.com/8722846/27998223-36a572cc-650a-11e7-8947-dae8b0a661e8.png)
