### PR TITLE
diaspora: Don't enable service until domain name is set

### DIFF
--- a/actions/diaspora
+++ b/actions/diaspora
@@ -86,8 +86,8 @@ def set_domain_name(domain_name):
             'http://{}:3000'.format(domain_name))
     aug.save()
 
-    diaspora.generate_apache_configuration('/etc/apache2/conf-available/diaspora-plinth.conf',
-                                           domain_name)
+    diaspora.generate_apache_configuration(
+        '/etc/apache2/conf-available/diaspora-plinth.conf', domain_name)
 
     action_utils.service_start('diaspora')
 

--- a/plinth/modules/diaspora/__init__.py
+++ b/plinth/modules/diaspora/__init__.py
@@ -97,7 +97,11 @@ def setup(helper, old_version=None):
     helper.install(managed_packages)
     helper.call('custom_config', actions.superuser_run, 'diaspora',
                 ['disable-ssl'])
-    helper.call('post', actions.superuser_run, 'diaspora', ['enable'])
+
+
+def setup_domain_name(domain_name):
+    actions.superuser_run('diaspora',
+                          ['setup', '--domain-name', domain_name])
     global service
     if service is None:
         service = service_module.Service(
@@ -108,8 +112,8 @@ def setup(helper, old_version=None):
             is_enabled=is_enabled,
             enable=enable,
             disable=disable)
-    helper.call('post', service.notify_enabled, None, True)
-    helper.call('post', add_shortcut)
+    service.notify_enabled(None, True)
+    add_shortcut()
 
 
 def add_shortcut():

--- a/plinth/modules/diaspora/views.py
+++ b/plinth/modules/diaspora/views.py
@@ -24,7 +24,6 @@ from django.urls import reverse_lazy
 from django.utils.translation import ugettext as _
 from django.views.generic import FormView
 
-from plinth import actions
 from plinth.forms import DomainSelectionForm
 from plinth.modules import diaspora
 from plinth.utils import get_domain_names
@@ -43,9 +42,7 @@ class DiasporaSetupView(FormView):
 
     def form_valid(self, form):
         domain_name = form.cleaned_data['domain_name']
-        actions.superuser_run('diaspora',
-                              ['setup', '--domain-name', domain_name])
-        diaspora.add_shortcut()
+        diaspora.setup_domain_name(domain_name)
 
         return super().form_valid(form)
 


### PR DESCRIPTION
This avoids an issue where it would try to enable the apache conf possibly before it is generated.