### PR TITLE
travis: Fix build errors due to change to non-system python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 
 # Command to install dependencies
 install:
-  - virtualenv --python=python3 --system-site-packages _venv
+  - virtualenv --python=/usr/bin/python3 --system-site-packages _venv
   - source _venv/bin/activate
   - pip install Django$DJANGO_VERSION
   - pip install coverage==3.7


### PR DESCRIPTION
When virtualenv creates an environment with --python=python3, it was earlier
picking Python 3 from system at /usr/bin/python3. Due to recent changes in
Travis, now it picks up Python 3.6.1 from /opt. This new Python does not
take into account system packages which are being installed via apt.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>