### PR TITLE
SSO: Add check to see if auth_pubtkt module is available

### DIFF
--- a/data/etc/apache2/includes/freedombox-single-sign-on.conf
+++ b/data/etc/apache2/includes/freedombox-single-sign-on.conf
@@ -1,9 +1,15 @@
-TKTAuthPublicKey /etc/apache2/auth-pubtkt-keys/pubkey.pem
-TKTAuthLoginURL /plinth/accounts/sso/login/
-TKTAuthBackArgName next
-TKTAuthDigest SHA1
-TKTAuthRefreshURL /plinth/accounts/sso/refresh/
-TKTAuthUnauthURL /plinth
-AuthType mod_auth_pubtkt
-AuthName "FreedomBox Single Sign On"
-Require valid-user
+<IfModule mod_auth_pubtkt.c>
+    TKTAuthPublicKey /etc/apache2/auth-pubtkt-keys/pubkey.pem
+    TKTAuthLoginURL /plinth/accounts/sso/login/
+    TKTAuthBackArgName next
+    TKTAuthDigest SHA1
+    TKTAuthRefreshURL /plinth/accounts/sso/refresh/
+    TKTAuthUnauthURL /plinth
+    AuthType mod_auth_pubtkt
+    AuthName "FreedomBox Single Sign On"
+    Require valid-user
+</IfModule>
+
+<IfModule !mod_auth_pubtkt.c>
+    Deny from all
+</IfModule>


### PR DESCRIPTION
- Solves bug #890
- Since Apache might be started before Plinth setup is ever run, we
have to handle the case where the auth_pubtkt module may not be available.