### PR TITLE
UI: Make apps and configure pages responsive on small screens

### DIFF
--- a/plinth/templates/apps.html
+++ b/plinth/templates/apps.html
@@ -20,6 +20,14 @@
 
 {% load i18n %}
 
+{% block submenu %}
+  {% if submenu %}
+    <div class="sidebar">
+      {% include "submenu.html" with menu=submenu %}
+    </div>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 
   <h2>{% trans "Services and Applications" %}</h2>

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -205,7 +205,7 @@
         <div class="col-md-3">
           {% block submenu %}
             {% if submenu %}
-              <div class="sidebar">
+              <div class="sidebar visible-lg-block">
                 {% include "submenu.html" with menu=submenu %}
               </div><!--/.sidebar -->
             {% endif %}

--- a/plinth/templates/system.html
+++ b/plinth/templates/system.html
@@ -20,6 +20,14 @@
 
 {% load i18n %}
 
+{% block submenu %}
+  {% if submenu %}
+    <div class="sidebar">
+      {% include "submenu.html" with menu=submenu %}
+    </div>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 
   <h2>{% trans "System Configuration" %}</h2>


### PR DESCRIPTION
- Hide the listing of apps and configuration options on small screens, so that
  the user doesn't have to navigate to the bottom of the page.
- Closes #921