### PR TITLE
Capture and log all Python warnings

### DIFF
--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -26,6 +26,7 @@ import logging
 import os
 import stat
 import sys
+import warnings
 
 import cherrypy
 
@@ -81,6 +82,15 @@ def setup_logging():
 
     cherrypy.log.error_file = cfg.status_log_file
     cherrypy.log.access_file = cfg.access_log_file
+
+    # Capture all Python warnings such as deprecation warnings
+    logging.captureWarnings(True)
+
+    # Log all deprecation warnings when in debug mode
+    if cfg.debug:
+        warnings.filterwarnings('default', '', DeprecationWarning)
+        warnings.filterwarnings('default', '', PendingDeprecationWarning)
+        warnings.filterwarnings('default', '', ImportWarning)
 
 
 def setup_server():


### PR DESCRIPTION
- Capture all Python warnings so that they can shown as part of logging system
  on console and in log file.

- Also capture deprecation warnings into logging system if debug mode is
  enabled. Current versions of Python disable deprecation warnings by default.
  Django 1.11 also follows this approach now.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>