### PR TITLE
Diaspora: Disable for release 0.15.2

### DIFF
--- a/data/etc/plinth/modules-enabled/diaspora
+++ b/data/etc/plinth/modules-enabled/diaspora
@@ -1,2 +1,0 @@
-plinth.modules.diaspora
-

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,10 @@ ENABLED_APPS_PATH = "/etc/plinth/modules-enabled/"
 
 DISABLED_APPS_TO_REMOVE = [
     'apps',
+    'diaspora',
+    'owncloud',
     'system',
     'xmpp',
-    'owncloud'
 ]
 
 LOCALE_PATHS = [


### PR DESCRIPTION
diaspora* is no longer installable from Debian
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872305

Signed-off-by: Joseph Nuthalpati <njoseph@thoughtworks.com>