### PR TITLE
users: Use own copy of ldapscripts config

### DIFF
--- a/actions/users
+++ b/actions/users
@@ -39,6 +39,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='subcommand', help='Sub command')
 
+    subparsers.add_parser('first-setup', help='Perform initial setup of LDAP')
     subparsers.add_parser('setup', help='Setup LDAP')
 
     subparser = subparsers.add_parser(
@@ -90,6 +91,13 @@ def parse_arguments():
     return parser.parse_args()
 
 
+def subcommand_first_setup(_):
+    """Perform initial setup of LDAP."""
+    # Avoid reconfiguration of slapd during module upgrades, because
+    # this will move the existing database.
+    action_utils.dpkg_reconfigure('slapd', {'domain': 'thisbox'})
+
+
 def subcommand_setup(_):
     """Setup LDAP."""
     # Update pam configs for access and mkhomedir.
@@ -97,14 +105,13 @@ def subcommand_setup(_):
 
     configure_ldapscripts()
 
-    configure_slapd()
+    configure_ldap_authentication()
 
     configure_ldap_structure()
 
 
-def configure_slapd():
+def configure_ldap_authentication():
     """Configure LDAP authentication."""
-    action_utils.dpkg_reconfigure('slapd', {'domain': 'thisbox'})
     action_utils.dpkg_reconfigure('nslcd', {
         'ldap-uris': 'ldapi:///',
         'ldap-base': 'dc=thisbox',

--- a/actions/users
+++ b/actions/users
@@ -22,14 +22,16 @@ Configuration helper for the LDAP user directory
 
 import argparse
 import augeas
+import os
 import re
+import shutil
 import subprocess
 import sys
 
 from plinth import action_utils
 
 ACCESS_CONF = '/etc/security/access.conf'
-LDAPSCRIPTS_CONF = '/etc/ldapscripts/ldapscripts.conf'
+LDAPSCRIPTS_CONF = '/etc/ldapscripts/freedombox-ldapscripts.conf'
 
 
 def parse_arguments():
@@ -192,6 +194,9 @@ olcRootDN: gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth
 
 def configure_ldapscripts():
     """Set the configuration used by ldapscripts for later user management."""
+    # modify a copy of the config file
+    shutil.copy('/etc/ldapscripts/ldapscripts.conf', LDAPSCRIPTS_CONF)
+
     aug = augeas.Augeas(
         flags=augeas.Augeas.NO_LOAD + augeas.Augeas.NO_MODL_AUTOLOAD)
     aug.set('/augeas/load/Shellvars/lens', 'Shellvars.lns')
@@ -345,10 +350,11 @@ def flush_cache():
 
 def _run(arguments, **kwargs):
     """Run a command. Check return code and suppress output by default."""
+    env = dict(os.environ, LDAPSCRIPTS_CONF=LDAPSCRIPTS_CONF)
     kwargs['stdout'] = kwargs.get('stdout', subprocess.DEVNULL)
     kwargs['stderr'] = kwargs.get('stderr', subprocess.DEVNULL)
     kwargs['check'] = kwargs.get('check', True)
-    return subprocess.run(arguments, **kwargs)
+    return subprocess.run(arguments, env=env, **kwargs)
 
 
 def main():

--- a/plinth/modules/users/__init__.py
+++ b/plinth/modules/users/__init__.py
@@ -27,7 +27,7 @@ from plinth import actions
 from plinth.menu import main_menu
 
 
-version = 1
+version = 2
 
 is_essential = True
 
@@ -54,6 +54,8 @@ def init():
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
+    if old_version is None:
+        helper.call('post', actions.superuser_run, 'users', ['first-setup'])
     helper.call('post', actions.superuser_run, 'users', ['setup'])
 
 


### PR DESCRIPTION
Avoid modifying the conffile shipped with ldapscripts.

I tested this change in 2 steps:
1. Running "users setup" action placed the modified file in /etc/ldapscripts/plinth-ldapscripts.conf. However, this also re-ran the slapd setup, which led to ldap being unusable.
2. Starting with a fresh vagrant box, manually placed the file in /etc/ldapscripts/plinth-ldapscripts.conf. I also reverted /etc/ldapscripts/ldapscripts.conf to the original using ```sudo apt-get --reinstall -o Dpkg::Options::="--force-confask" install ldapscripts```. Then I tested user add/modify/delete functions through Plinth.