### PR TITLE
[WIP] disks: Warning about insufficient space on root partition 

### DIFF
--- a/plinth/modules/disks/views.py
+++ b/plinth/modules/disks/views.py
@@ -26,7 +26,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from plinth.modules import disks as disks_module
-from plinth.utils import format_lazy
+from plinth.utils import format_lazy, is_user_admin
 
 
 logger = logging.getLogger(__name__)
@@ -76,6 +76,9 @@ def expand_partition(request, device):
 
 def warn_about_low_disk_space(request):
     """Warn about insufficient space on root partition."""
+    if not is_user_admin(request, cached=False):
+        return
+
     disks = disks_module.get_disks()
     list_root = [disk for disk in disks if disk['mountpoint'] == '/']
     perc_used = list_root[0]['percentage_used'] if list_root else -1

--- a/plinth/urls.py
+++ b/plinth/urls.py
@@ -29,6 +29,5 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^apps/$', TemplateView.as_view(template_name='apps.html'),
         name='apps'),
-    url(r'^sys/$', TemplateView.as_view(template_name='system.html'),
-        name='system'),
+    url(r'^sys/$', views.system_index, name='system'),
 ]

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -31,6 +31,7 @@ import time
 from . import forms, frontpage
 import plinth
 from plinth import actions
+from plinth.modules.disks import views as disk_views
 
 
 @public
@@ -44,6 +45,8 @@ def index(request):
         details = frontpage.shortcuts[selection]['details']
         details_label = frontpage.shortcuts[selection]['label']
         configure_url = frontpage.shortcuts[selection]['configure_url']
+
+    disk_views.warn_about_insufficient_root_space(request)
 
     return TemplateResponse(request, 'index.html',
                             {'title': _('FreedomBox'),

--- a/plinth/views.py
+++ b/plinth/views.py
@@ -46,7 +46,7 @@ def index(request):
         details_label = frontpage.shortcuts[selection]['label']
         configure_url = frontpage.shortcuts[selection]['configure_url']
 
-    disk_views.warn_about_insufficient_root_space(request)
+    disk_views.warn_about_low_disk_space(request)
 
     return TemplateResponse(request, 'index.html',
                             {'title': _('FreedomBox'),
@@ -55,6 +55,12 @@ def index(request):
                              'details': details,
                              'details_label': details_label,
                              'configure_url': configure_url})
+
+
+def system_index(request):
+    """Serve the system index page."""
+    disk_views.warn_about_low_disk_space(request)
+    return TemplateResponse(request, 'system.html')
 
 
 class ServiceView(FormView):


### PR DESCRIPTION
This PR addresses issue #985, showing messages to warn about insufficient space on the root partition. I consider this a workaround until a proper, general notification system is implemented, see #867.

In the current implementation, warnings are shown if the remaining used space is either <10%  or <1GiB free space (severe, in red), and if either <25% or 2GiB (less severe, in yellow). The percentage thresholds match the ones used for coloring on the Disks page. The warnings are shown on the main index page, on the System Configuration, and on Disks itself.

One simple way to test it is by generating a big data file, to trigger the warning, e.g. `fallocate -l 1G nullbytes`.

Here two screenshots:
![spacewarning1](https://user-images.githubusercontent.com/8722846/29846579-0853bbe8-8d07-11e7-8584-4c604ce4350b.png)

And from the main page (looks a bit odd, as messages don't take up all space...):
![spacewarning2](https://user-images.githubusercontent.com/8722846/29846702-6b498002-8d07-11e7-8af3-f9b6c0562792.png)
