### PR TITLE
Don't run Plinth setup as part of freedombox/setup

### DIFF
--- a/data/usr/lib/freedombox/setup.d/86_plinth
+++ b/data/usr/lib/freedombox/setup.d/86_plinth
@@ -34,12 +34,5 @@ a2ensite plinth-ssl.conf
 
 echo "Done configuring Apache for Plinth."
 
-echo "Running Plinth setup..."
-
-# Run plinth setup to configure various necessary program
-plinth --setup-no-install
-
 # Ensure that DB and log file permissions are correct
 chown -R plinth: /var/lib/plinth /var/log/plinth
-
-echo "Done running Plinth setup."


### PR DESCRIPTION
Instead run all of the setup process during the first boot. This enables us to
someday remove the reboot step entirely.

Tests: After building a new image with the changes, call the modules have shown
to be properly setup. Running the setup wizard, creating admin user and logging
works as expected.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>

This fixes #993.  When I merged #996, I actually tested the entire setup with this patch in place (due to an earlier patch that @JosephKiranBabu and I worked on). So, the testing I did by building full image and checking that all the modules have been properly setup applies to this patch.