### PR TITLE
repro: Safety check to make sure pubtkt module is enabled

### DIFF
--- a/data/etc/apache2/conf-available/repro-plinth.conf
+++ b/data/etc/apache2/conf-available/repro-plinth.conf
@@ -5,5 +5,7 @@
 <Location /repro>
     ProxyPass http://localhost:5080
     Include includes/freedombox-single-sign-on.conf
-    TKTAuthToken "admin"
+    <IfModule mod_auth_pubtkt.c>
+        TKTAuthToken "admin"
+    </IfModule>
 </Location>


### PR DESCRIPTION
If pubtkt module is not enabled (rare) and if repro is enabled, Apache fails to
start. Make sure this effects only repro module. The single-sign-on
configuration already ensures that access is denied if pubtkt module is not
enabled, preventing unauthorized access.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>