### PR TITLE
[WIP] networks: Move initial connection setup to Plinth

### DIFF
--- a/actions/networks
+++ b/actions/networks
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+set -e
+
+# Configure networking for all wired and wireless devices.
+#
+# Creates network-manager connections.
+
+function get-interfaces {
+    # XXX: Sorting of interfaces is non-numeric
+    WIRED_IFACES=$(nmcli --terse --fields type,device device | grep "^ethernet:" | cut -d: -f2 | sort)
+    NO_OF_WIRED_IFACES=$(echo $WIRED_IFACES | wc -w)
+
+    WIRELESS_IFACES=$(nmcli --terse --fields type,device device | grep "^wifi:" | cut -d: -f2 | sort)
+    NO_OF_WIRELESS_IFACES=$(echo $WIRELESS_IFACES | wc -w)
+}
+
+function configure-regular-interface {
+    local interface="$1"
+    local zone="$2"
+    local connection_name="FreedomBox WAN"
+
+    # Create n-m connection for a regular interface
+    nmcli con add con-name "$connection_name" ifname "$interface" type ethernet
+    nmcli con modify "$connection_name" connection.autoconnect TRUE
+    nmcli con modify "$connection_name" connection.zone "$zone"
+
+    echo "Configured interface '$interface' for '$zone' use as '$connection_name'."
+}
+
+function configure-shared-interface {
+    local interface="$1"
+    local connection_name="FreedomBox LAN $interface"
+
+    # Create n-m connection for eth1
+    nmcli con add con-name "$connection_name" ifname "$interface" type ethernet
+    nmcli con modify "$connection_name" connection.autoconnect TRUE
+    nmcli con modify "$connection_name" connection.zone internal
+
+    # Configure this interface to be shared with other computers.
+    #  - Self-assign an address and network
+    #  - Start and manage DNS server (dnsmasq)
+    #  - Start and manage DHCP server (dnsmasq)
+    #  - Register address with mDNS
+    #  - Add firewall rules for NATing from this interface
+    nmcli con modify "$connection_name" ipv4.method shared
+
+    echo "Configured interface '$interface' for shared use as '$connection_name'."
+}
+
+function configure-wireless-interface {
+    local interface="$1"
+    local connection_name="FreedomBox $interface"
+    local ssid="FreedomBox$interface"
+    local secret="freedombox123"
+
+    nmcli con add con-name "$connection_name" ifname "$interface" type wifi ssid "$ssid"
+    nmcli con modify "$connection_name" connection.autoconnect TRUE
+    nmcli con modify "$connection_name" connection.zone internal
+    nmcli con modify "$connection_name" ipv4.method shared
+    nmcli con modify "$connection_name" wifi.mode ap
+    nmcli con modify "$connection_name" wifi-sec.key-mgmt wpa-psk
+    nmcli con modify "$connection_name" wifi-sec.psk "$secret"
+
+    echo "Configured interface '$interface' for shared use as '$connection_name'."
+}
+
+function multi-wired-setup {
+    local first_interface="$1"
+    shift
+    local remaining_interfaces="$@"
+
+    configure-regular-interface "$first_interface" external
+
+    for interface in $remaining_interfaces
+    do
+        configure-shared-interface "$interface"
+    done
+}
+
+function one-wired-setup {
+    local interface="$1"
+
+    case $NO_OF_WIRELESS_IFACES in
+        "0")
+            configure-regular-interface "$interface" internal
+            ;;
+        *)
+            configure-regular-interface "$interface" external
+            ;;
+    esac
+}
+
+function wireless-setup {
+    local interfaces="$@"
+
+    for interface in $interfaces
+    do
+        configure-wireless-interface "$interface"
+    done
+}
+
+function setup {
+    echo "Setting up network configuration..."
+    get-interfaces
+
+    case $NO_OF_WIRED_IFACES in
+        "0")
+            echo "No wired interfaces detected."
+            ;;
+        "1")
+            one-wired-setup $WIRED_IFACES
+            ;;
+        *)
+            multi-wired-setup $WIRED_IFACES
+    esac
+
+    wireless-setup $WIRELESS_IFACES
+
+    echo "Done setting up network configuration."
+}
+
+#
+# For a user who installed using freedombox-setup Debian package, when Plinth is
+# run for the first time, don't run network setup. This is ensured by checking
+# for the file /var/lib/freedombox/is-freedombox-disk-image which will not
+# exist.
+#
+# For a user who installed using FreedomBox disk image, when Plinth runs for the
+# first time, setup process executes and triggers the script due networks module
+# being an essential module.
+#
+if [ -f "/var/lib/freedombox/is-freedombox-disk-image" ]
+then
+    setup
+    # Restart network-manager so that the connections created will be activated.
+    # On a fresh disk image, this means the default network manager connections
+    # will be ignored and newly created connections will be activated.
+    systemctl restart network-manager
+fi

--- a/actions/networks
+++ b/actions/networks
@@ -7,11 +7,10 @@ set -e
 # Creates network-manager connections.
 
 function get-interfaces {
-    # XXX: Sorting of interfaces is non-numeric
-    WIRED_IFACES=$(nmcli --terse --fields type,device device | grep "^ethernet:" | cut -d: -f2 | sort)
+    WIRED_IFACES=$(nmcli --terse --fields type,device device | grep "^ethernet:" | cut -d: -f2 | sort -V)
     NO_OF_WIRED_IFACES=$(echo $WIRED_IFACES | wc -w)
 
-    WIRELESS_IFACES=$(nmcli --terse --fields type,device device | grep "^wifi:" | cut -d: -f2 | sort)
+    WIRELESS_IFACES=$(nmcli --terse --fields type,device device | grep "^wifi:" | cut -d: -f2 | sort -V)
     NO_OF_WIRELESS_IFACES=$(echo $WIRELESS_IFACES | wc -w)
 }
 

--- a/plinth/modules/networks/__init__.py
+++ b/plinth/modules/networks/__init__.py
@@ -23,6 +23,7 @@ from django.utils.translation import ugettext_lazy as _
 from logging import Logger
 import subprocess
 
+from plinth import actions
 from plinth import action_utils
 from plinth import network
 from plinth.menu import main_menu
@@ -48,6 +49,7 @@ def init():
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
+    actions.superuser_run('networks')
 
 
 def diagnose():


### PR DESCRIPTION
Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>

This is the last piece required after #1002, that will let us eliminate freedombox-setup's first-run and the reboot after it.  Since the networks module's version is not incremented, users upgrading from earlier version of Plinth will never run the setup code.  However, images built with the change will end up running the setup code.

Work remaining here is to test.