### PR TITLE
first-run: Skip installation of essential modules from Plinth

### DIFF
--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -338,9 +338,8 @@ def main():
 
     module_loader.load_modules()
 
-    # Run setup steps for essential modules
-    # Installation is not necessary as they are dependencies of Plinth
-    run_setup(None, allow_install=False)
+    if arguments.setup is not False:
+        run_setup_and_exit(arguments.setup, allow_install=True)
 
     if arguments.setup_no_install is not False:
         run_setup_and_exit(arguments.setup_no_install, allow_install=False)
@@ -353,6 +352,10 @@ def main():
 
     if arguments.diagnose:
         run_diagnostics_and_exit()
+
+    # Run setup steps for essential modules
+    # Installation is not necessary as they are dependencies of Plinth
+    run_setup(None, allow_install=False)
 
     setup_server()
 

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -338,7 +338,9 @@ def main():
 
     module_loader.load_modules()
 
-    run_setup(arguments.setup)
+    # Run setup steps for essential modules
+    # Installation is not necessary as they are dependencies of Plinth
+    run_setup(None, allow_install=False)
 
     if arguments.setup_no_install is not False:
         run_setup_and_exit(arguments.setup_no_install, allow_install=False)


### PR DESCRIPTION
Essential modules would be installed by apt as they are already
dependencies of plinth.
Plinth trying to trigger an installation is unnecessary.
Plinth installing deb packages might also cause problems with plinth startup
if automatic upgrades are running.

Signed-off-by: Joseph Nuthalpati <njoseph@thoughtworks.com>