### PR TITLE
Plinth external login

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -27,6 +27,7 @@
     python3-configobj \
     python3-coverage \
     python3-django \
+    python3-django-captcha \
     python3-django-stronghold \
     python3-gi \
     python3-psutil \

--- a/data/etc/apache2/sites-available/plinth.conf
+++ b/data/etc/apache2/sites-available/plinth.conf
@@ -11,31 +11,4 @@
     ## Send the scheme from user's request to enable Plinth to redirect
     ## URLs, set cookies, set absolute URLs (if any) properly.
     RequestHeader    set X-Forwarded-Proto 'https' env=HTTPS
-
-    ## Allow traffic only from private networks
-    <RequireAny>
-        ## IPv4 local addresses
-        Require ip 127.0.0.0/8
-
-        ## IPv4 link local addresses
-        Require ip 169.254.0.0/16
-
-        ## IPv4 class A private addresses
-        Require ip 10.0.0.0/8
-
-        ## IPv4 class B private addresses
-        Require ip 172.16.0.0/12
-
-        ## IPv4 class C private addresses
-        Require ip 192.168.0.0/16
-
-        ## IPv6 local address
-        Require ip ::1
-
-        ## IPv6 link local addresses
-        Require ip fe80::/10
-
-        ## IPv6 private addresses
-        Require ip fc00::/7
-    </RequireAny>
 </Location>

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -240,6 +240,7 @@ def configure_django():
                 {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}},
         CAPTCHA_FONT_PATH=['/usr/share/fonts/truetype/ttf-bitstream-vera/Vera.ttf'],
         CAPTCHA_LENGTH=6,
+        CAPTCHA_FLITE_PATH='/usr/bin/flite',
         DATABASES={'default':
                    {'ENGINE': 'django.db.backends.sqlite3',
                     'NAME': cfg.store_file}},

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -204,6 +204,7 @@ def configure_django():
     ]
 
     applications = ['bootstrapform',
+                    'captcha',
                     'django.contrib.auth',
                     'django.contrib.contenttypes',
                     'django.contrib.messages',
@@ -237,6 +238,7 @@ def configure_django():
         ],
         CACHES={'default':
                 {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}},
+        CAPTCHA_FONT_PATH=['/usr/share/fonts/truetype/ttf-bitstream-vera/Vera.ttf'],
         DATABASES={'default':
                    {'ENGINE': 'django.db.backends.sqlite3',
                     'NAME': cfg.store_file}},
@@ -265,6 +267,9 @@ def configure_django():
         SESSION_ENGINE='django.contrib.sessions.backends.file',
         SESSION_FILE_PATH=sessions_directory,
         STATIC_URL='/'.join([cfg.server_dir, 'static/']).replace('//', '/'),
+        # STRONGHOLD_PUBLIC_URLS=(r'^captcha/', ),
+        STRONGHOLD_PUBLIC_NAMED_URLS=('captcha-image', 'captcha-image-2x',
+                                      'captcha-audio', 'captcha-refresh', ),
         TEMPLATES=templates,
         USE_L10N=True,
         USE_X_FORWARDED_HOST=cfg.use_x_forwarded_host)

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -239,6 +239,7 @@ def configure_django():
         CACHES={'default':
                 {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}},
         CAPTCHA_FONT_PATH=['/usr/share/fonts/truetype/ttf-bitstream-vera/Vera.ttf'],
+        CAPTCHA_LENGTH=6,
         DATABASES={'default':
                    {'ENGINE': 'django.db.backends.sqlite3',
                     'NAME': cfg.store_file}},

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -156,7 +156,7 @@ def setup_server():
 
 
 def configure_django():
-    """Setup Django configuration in the absense of .settings file"""
+    """Setup Django configuration in the absence of .settings file"""
     logging_configuration = {
         'version': 1,
         'disable_existing_loggers': False,
@@ -203,14 +203,16 @@ def configure_django():
         },
     ]
 
-    applications = ['bootstrapform',
-                    'captcha',
-                    'django.contrib.auth',
-                    'django.contrib.contenttypes',
-                    'django.contrib.messages',
-                    'stronghold',
-                    'plinth',
-                    'axes']
+    applications = [
+        'axes',
+        'captcha',
+        'bootstrapform',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.messages',
+        'stronghold',
+        'plinth',
+    ]
     applications += module_loader.get_modules_to_load()
     sessions_directory = os.path.join(cfg.data_dir, 'sessions')
 

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -209,7 +209,8 @@ def configure_django():
                     'django.contrib.contenttypes',
                     'django.contrib.messages',
                     'stronghold',
-                    'plinth']
+                    'plinth',
+                    'axes']
     applications += module_loader.get_modules_to_load()
     sessions_directory = os.path.join(cfg.data_dir, 'sessions')
 

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -237,6 +237,7 @@ def configure_django():
                 'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
             },
         ],
+        AXES_LOCKOUT_URL='locked',
         CACHES={'default':
                 {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}},
         CAPTCHA_FONT_PATH=['/usr/share/fonts/truetype/ttf-bitstream-vera/Vera.ttf'],

--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -238,6 +238,7 @@ def configure_django():
             },
         ],
         AXES_LOCKOUT_URL='locked',
+        AXES_BEHIND_REVERSE_PROXY=True,
         CACHES={'default':
                 {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}},
         CAPTCHA_FONT_PATH=['/usr/share/fonts/truetype/ttf-bitstream-vera/Vera.ttf'],

--- a/plinth/module_loader.py
+++ b/plinth/module_loader.py
@@ -27,7 +27,6 @@ import os
 import re
 
 from plinth import cfg
-from plinth import urls
 from plinth import setup
 from plinth.signals import pre_module_loading, post_module_loading
 
@@ -114,6 +113,7 @@ def _insert_modules(module_name, module, remaining_modules, ordered_modules):
 
 def _include_module_urls(module_import_path, module_name):
     """Include the module's URLs in global project URLs list"""
+    from plinth import urls
     url_module = module_import_path + '.urls'
     try:
         urls.urlpatterns += [

--- a/plinth/modules/sso/__init__.py
+++ b/plinth/modules/sso/__init__.py
@@ -29,7 +29,10 @@ depends = ['security', 'apache']
 
 name = _('Single Sign On')
 
-managed_packages = ['libapache2-mod-auth-pubtkt', 'openssl', 'python3-openssl', 'flite']
+managed_packages = [
+    'libapache2-mod-auth-pubtkt', 'openssl', 'python3-openssl', 'flite',
+    'ttf-bitstream-vera'
+]
 
 
 def setup(helper, old_version=None):

--- a/plinth/modules/sso/__init__.py
+++ b/plinth/modules/sso/__init__.py
@@ -29,7 +29,7 @@ depends = ['security', 'apache']
 
 name = _('Single Sign On')
 
-managed_packages = ['libapache2-mod-auth-pubtkt', 'openssl', 'python3-openssl']
+managed_packages = ['libapache2-mod-auth-pubtkt', 'openssl', 'python3-openssl', 'flite']
 
 
 def setup(helper, old_version=None):

--- a/plinth/modules/sso/forms.py
+++ b/plinth/modules/sso/forms.py
@@ -15,16 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 """
-URLs for the Single Sign On module.
+Forms for the Single Sign On module of Plinth
 """
 
-from django.conf.urls import url
+from django.contrib.auth.forms import AuthenticationForm as DjangoAuthenticationForm
+from captcha.fields import CaptchaField
 
 
-from .views import SSOLoginView, refresh
-from stronghold.decorators import public
-
-urlpatterns = [
-    url(r'^accounts/sso/login/$', public(SSOLoginView.as_view()), name='sso-login'),
-    url(r'^accounts/sso/refresh/$', refresh, name='sso-refresh'),
-]
+class AuthenticationForm(DjangoAuthenticationForm):
+    captcha = CaptchaField()

--- a/plinth/modules/sso/views.py
+++ b/plinth/modules/sso/views.py
@@ -62,7 +62,8 @@ class SSOLoginView(LoginView):
             if request.user.is_authenticated:
                 return set_ticket_cookie(request.user, response)
             else: # Redirect user to captcha page
-                return HttpResponseRedirect('captcha')
+                redirect = '' if request.path.rstrip('/').endswith('captcha') else 'captcha'
+                return HttpResponseRedirect(redirect)
         return response
 
 

--- a/plinth/modules/sso/views.py
+++ b/plinth/modules/sso/views.py
@@ -21,6 +21,8 @@ Views for the Single Sign On module of Plinth
 import os
 import urllib
 
+from .forms import AuthenticationForm
+
 from plinth import actions
 
 from django.http import HttpResponseRedirect
@@ -51,15 +53,21 @@ class SSOLoginView(LoginView):
     """View to login to Plinth and set a auth_pubtkt cookie which will be
     used to provide Single Sign On for some other applications
     """
-
     redirect_authenticated_user = True
     template_name = 'login.html'
 
     def dispatch(self, request, *args, **kwargs):
         response = super(SSOLoginView, self).dispatch(request, *args, **kwargs)
-        return set_ticket_cookie(
-            request.user,
-            response) if request.user.is_authenticated else response
+        if request.POST:
+            if request.user.is_authenticated:
+                return set_ticket_cookie(request.user, response)
+            else: # Redirect user to captcha page
+                return HttpResponseRedirect('captcha')
+        return response
+
+
+class CaptchaLoginView(SSOLoginView):
+    form_class = AuthenticationForm
 
 
 class SSOLogoutView(LogoutView):

--- a/plinth/modules/users/urls.py
+++ b/plinth/modules/users/urls.py
@@ -20,11 +20,13 @@ URLs for the Users module
 
 from django.conf.urls import url
 from django.urls import reverse_lazy
-from stronghold.decorators import public
 
+from stronghold.decorators import public
 from plinth.utils import non_admin_view
 from plinth.modules.sso.views import SSOLoginView, SSOLogoutView, CaptchaLoginView
 from . import views
+
+from axes.decorators import watch_login
 
 urlpatterns = [
     url(r'^sys/users/$', views.UserList.as_view(), name='index'),
@@ -38,8 +40,11 @@ urlpatterns = [
     url(r'^sys/users/(?P<slug>[\w.@+-]+)/change_password/$',
         non_admin_view(views.UserChangePassword.as_view()),
         name='change_password'),
-    # Add Django's login/logout urls
-    url(r'^accounts/login/$', public(SSOLoginView.as_view()), name='login'),
+
+    # Authnz is handled by SSO
+    url(r'^accounts/login/$',
+        public(watch_login(SSOLoginView.as_view())),
+        name='login'),
     url(r'^accounts/logout/$',
         non_admin_view(SSOLogoutView.as_view()),
         {'next_page': reverse_lazy('index')},

--- a/plinth/modules/users/urls.py
+++ b/plinth/modules/users/urls.py
@@ -23,7 +23,7 @@ from django.urls import reverse_lazy
 
 from stronghold.decorators import public
 from plinth.utils import non_admin_view
-from plinth.modules.sso.views import SSOLoginView, SSOLogoutView, CaptchaLoginView
+from plinth.modules.sso.views import SSOLoginView, SSOLogoutView
 from . import views
 
 from axes.decorators import watch_login
@@ -49,9 +49,6 @@ urlpatterns = [
         non_admin_view(SSOLogoutView.as_view()),
         {'next_page': reverse_lazy('index')},
         name='logout'),
-    url(r'^accounts/login/captcha/$',
-        public(CaptchaLoginView.as_view()),
-        name='captcha-login'),
     url(r'^users/firstboot/$',
         public(views.FirstBootView.as_view()),
         name='firstboot'),

--- a/plinth/modules/users/urls.py
+++ b/plinth/modules/users/urls.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 URLs for the Users module
 """
@@ -24,24 +23,31 @@ from django.urls import reverse_lazy
 from stronghold.decorators import public
 
 from plinth.utils import non_admin_view
-from plinth.modules.sso.views import SSOLoginView, SSOLogoutView
+from plinth.modules.sso.views import SSOLoginView, SSOLogoutView, CaptchaLoginView
 from . import views
-
 
 urlpatterns = [
     url(r'^sys/users/$', views.UserList.as_view(), name='index'),
     url(r'^sys/users/create/$', views.UserCreate.as_view(), name='create'),
     url(r'^sys/users/(?P<slug>[\w.@+-]+)/edit/$',
-        non_admin_view(views.UserUpdate.as_view()), name='edit'),
-    url(r'^sys/users/(?P<slug>[\w.@+-]+)/delete/$', views.UserDelete.as_view(),
+        non_admin_view(views.UserUpdate.as_view()),
+        name='edit'),
+    url(r'^sys/users/(?P<slug>[\w.@+-]+)/delete/$',
+        views.UserDelete.as_view(),
         name='delete'),
     url(r'^sys/users/(?P<slug>[\w.@+-]+)/change_password/$',
         non_admin_view(views.UserChangePassword.as_view()),
         name='change_password'),
     # Add Django's login/logout urls
     url(r'^accounts/login/$', public(SSOLoginView.as_view()), name='login'),
-    url(r'^accounts/logout/$', non_admin_view(SSOLogoutView.as_view()),
-        {'next_page': reverse_lazy('index')}, name='logout'),
-    url(r'^users/firstboot/$', public(views.FirstBootView.as_view()),
+    url(r'^accounts/logout/$',
+        non_admin_view(SSOLogoutView.as_view()),
+        {'next_page': reverse_lazy('index')},
+        name='logout'),
+    url(r'^accounts/login/captcha/$',
+        public(CaptchaLoginView.as_view()),
+        name='captcha-login'),
+    url(r'^users/firstboot/$',
+        public(views.FirstBootView.as_view()),
         name='firstboot'),
 ]

--- a/plinth/tests/data/django_test_settings.py
+++ b/plinth/tests/data/django_test_settings.py
@@ -30,11 +30,15 @@ DATABASES = {
     }
 }
 
-INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'plinth',
-)
+INSTALLED_APPS = [
+        'captcha',
+        'bootstrapform',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.messages',
+        'stronghold',
+        'plinth',
+    ]
 
 # These are included here solely to suppress Django warnings
 # during testing setup

--- a/plinth/tests/test_utils.py
+++ b/plinth/tests/test_utils.py
@@ -44,7 +44,7 @@ class TestIsAdminUser(TestCase):
         """Test anonymous user is reported as non-admin."""
         super(TestIsAdminUser, self).setUp()
         self.request.user = Mock()
-        self.request.user.is_authenticated.return_value = False
+        self.request.user.is_authenticated = False
         self.assertFalse(is_user_admin(self.request))
         self.assertFalse(is_user_admin(self.request, cached=True))
 

--- a/plinth/urls.py
+++ b/plinth/urls.py
@@ -14,20 +14,33 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 Django URLconf file containing all urls
 """
-
-from django.conf.urls import url
+from captcha import views as cviews
+from django.conf.urls import url, include
 from django.views.generic import TemplateView
+
+from stronghold.decorators import public
 
 from . import views
 
-
 urlpatterns = [
     url(r'^$', views.index, name='index'),
-    url(r'^apps/$', TemplateView.as_view(template_name='apps.html'),
+    url(r'^apps/$',
+        TemplateView.as_view(template_name='apps.html'),
         name='apps'),
     url(r'^sys/$', views.system_index, name='system'),
+
+    # captcha urls are public
+    url(r'image/(?P<key>\w+)/$',
+        public(cviews.captcha_image),
+        name='captcha-image',
+        kwargs={'scale': 1}),
+    url(r'image/(?P<key>\w+)@2/$',
+        public(cviews.captcha_image),
+        name='captcha-image-2x',
+        kwargs={'scale': 2}),
+    url(r'audio/(?P<key>\w+)/$', public(cviews.captcha_audio), name='captcha-audio'),
+    url(r'refresh/$', public(cviews.captcha_refresh), name='captcha-refresh'),
 ]

--- a/plinth/urls.py
+++ b/plinth/urls.py
@@ -18,9 +18,10 @@
 Django URLconf file containing all urls
 """
 from captcha import views as cviews
-from django.conf.urls import url, include
+from django.conf.urls import url
 from django.views.generic import TemplateView
 
+from plinth.modules.sso.views import CaptchaLoginView
 from stronghold.decorators import public
 
 from . import views
@@ -43,4 +44,5 @@ urlpatterns = [
         kwargs={'scale': 2}),
     url(r'audio/(?P<key>\w+)/$', public(cviews.captcha_audio), name='captcha-audio'),
     url(r'refresh/$', public(cviews.captcha_refresh), name='captcha-refresh'),
+    url(r'locked/$', public(CaptchaLoginView.as_view()), name='locked_out'),
 ]

--- a/plinth/utils.py
+++ b/plinth/utils.py
@@ -57,7 +57,7 @@ def non_admin_view(func):
 
 def is_user_admin(request, cached=False):
     """Return whether user is an administrator."""
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         return False
 
     if 'cache_user_is_admin' in request.session and cached:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cherrypy >= 3.0
 configobj
 coverage >= 3.7
 django >= 1.10.0
+django-axes
 django-bootstrap-form
 django-simple-captcha
 django-stronghold

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ configobj
 coverage >= 3.7
 django >= 1.10.0
 django-bootstrap-form
+django-simple-captcha
 django-stronghold
 psutil
 python-apt

--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,7 @@ setuptools.setup(
         'configobj',
         'django >= 1.10.0',
         'django-bootstrap-form',
+        'django-simple-captcha',
         'django-stronghold',
         'psutil',
         'python-apt',


### PR DESCRIPTION
- Enabled plinth login from external ip addresses #961
- Added `django-axes` which checks if login failed for 3 times and redirects to a captcha page from the next request onwards. Using `django-simple-captcha` for displaying captcha.
- Plinth depends on the Debian packages of the above two Python libraries. `django-axes` is not packaged yet.