### PR TITLE
password: add django password validators

### DIFF
--- a/plinth/__main__.py
+++ b/plinth/__main__.py
@@ -218,6 +218,23 @@ def configure_django():
 
     django.conf.settings.configure(
         ALLOWED_HOSTS=['*'],
+        AUTH_PASSWORD_VALIDATORS = [
+            {
+                'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+                'OPTIONS': {
+                    'min_length': 8,
+                }
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+            },
+        ],
         CACHES={'default':
                 {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}},
         DATABASES={'default':


### PR DESCRIPTION
Added all default django password validators.

Not enforcing special characters.
https://blog.codinghorror.com/password-rules-are-bullshit/

Signed-off-by: Joseph Nuthalpati <njoseph@thoughtworks.com>