### PR TITLE
Fix some Django deprecations

### DIFF
--- a/plinth/module_loader.py
+++ b/plinth/module_loader.py
@@ -118,7 +118,7 @@ def _include_module_urls(module_import_path, module_name):
     try:
         urls.urlpatterns += [
             django.conf.urls.url(
-                r'', django.conf.urls.include(url_module, module_name))]
+                r'', django.conf.urls.include((url_module, module_name)))]
     except ImportError:
         logger.debug('No URLs for %s', module_name)
         if cfg.debug:

--- a/plinth/modules/pagekite/templatetags/pagekite_extras.py
+++ b/plinth/modules/pagekite/templatetags/pagekite_extras.py
@@ -21,7 +21,7 @@ from plinth.modules.pagekite import utils
 register = template.Library()
 
 
-@register.assignment_tag
+@register.simple_tag
 def create_pagekite_service_url(service, kite_name):
     """Create a URL out of a pagekite service
 

--- a/plinth/modules/snapshot/views.py
+++ b/plinth/modules/snapshot/views.py
@@ -20,9 +20,9 @@ Views for snapshot module.
 """
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 import json
 


### PR DESCRIPTION
- Use simple_tag() instead of assignment_tag().  Assignments with simple_tag()
  works just like before.

- When loading urls for application, specify application name during inclusion.

- Use the reverse() method from django.urls which as moved from
  django.core.urlresolvers.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>