### PR TITLE
Move Avahi files from freedombox-setup

### DIFF
--- a/data/etc/avahi/services/domain.service
+++ b/data/etc/avahi/services/domain.service
@@ -1,0 +1,12 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+
+  <name replace-wildcards="yes">%h</name>
+
+  <service>
+    <type>_domain._udp</type>
+    <port>53</port>
+  </service>
+
+</service-group>

--- a/data/etc/avahi/services/sftp-ssh.service
+++ b/data/etc/avahi/services/sftp-ssh.service
@@ -1,0 +1,14 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+
+  <name replace-wildcards="yes">%h</name>
+
+  <service>
+    <type>_sftp-ssh._tcp</type>
+    <port>22</port>
+    <txt-record>path=/home/fbx</txt-record>
+    <txt-record>u=fbx</txt-record>
+  </service>
+
+</service-group>

--- a/data/etc/avahi/services/ssh.service
+++ b/data/etc/avahi/services/ssh.service
@@ -1,0 +1,12 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+
+  <name replace-wildcards="yes">%h</name>
+
+  <service>
+    <type>_ssh._tcp</type>
+    <port>22</port>
+  </service>
+
+</service-group>

--- a/data/etc/avahi/services/xmpp-server.service
+++ b/data/etc/avahi/services/xmpp-server.service
@@ -1,0 +1,12 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+
+  <name replace-wildcards="yes">%h</name>
+
+  <service>
+    <type>_xmpp-server._tcp</type>
+    <port>5269</port>
+  </service>
+
+</service-group>

--- a/plinth/modules/avahi/__init__.py
+++ b/plinth/modules/avahi/__init__.py
@@ -21,6 +21,7 @@ Plinth module for service discovery.
 
 from django.utils.translation import ugettext_lazy as _
 
+from plinth import actions
 from plinth import cfg
 from plinth import service as service_module
 from plinth.menu import main_menu
@@ -35,7 +36,7 @@ is_essential = True
 
 managed_services = ['avahi-daemon']
 
-managed_packages = ['avahi-daemon']
+managed_packages = ['avahi-daemon', 'avahi-utils']
 
 name = _('Service Discovery')
 
@@ -66,6 +67,11 @@ def init():
 def setup(helper, old_version=False):
     """Install and configure the module."""
     helper.install(managed_packages)
+    # Reload avahi-daemon now that first-run does not reboot. After performing
+    # Plinth package installation, new Avahi files will be available and
+    # require restart.
+    helper.call('post', actions.superuser_run, 'service',
+                ['reload', 'avahi-daemon'])
 
 
 class AvahiServiceView(ServiceView):

--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,8 @@ setuptools.setup(
                  glob.glob('data/etc/apache2/sites-available/*.conf')),
                 ('/etc/apache2/includes',
                  glob.glob('data/etc/apache2/includes/*.conf')),
+                ('/etc/avahi/services/',
+                 glob.glob('data/etc/avahi/services/*.service')),
                 ('/etc/ikiwiki',
                  glob.glob('data/etc/ikiwiki/*.setup')),
                 ('/etc/NetworkManager/dispatcher.d/',


### PR DESCRIPTION
Avahi daemon is being managed in Plinth, so it makes sense for Plinth to be
providing the service files. Service files can be managed so that when service
is not available, it is not advertised using Avahi.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>
Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>

Currently not tested. Should be applied after #1028. 