### PR TITLE
storage: hotfix issue with locales that don't use periods as decimal separator

### DIFF
--- a/plinth/modules/storage/views.py
+++ b/plinth/modules/storage/views.py
@@ -105,6 +105,7 @@ def warn_about_low_disk_space(request):
 def _interpret_size_string(size_str):
     """Convert size string to number of bytes."""
     size_str = size_str.replace(',', '.')  # some locales use commas
+    size_str = size_str.replace('٫', '.')  # arabic decimal separator
     if size_str[-1] in '0123456789':
         return float(size_str[:-1])
 

--- a/plinth/modules/storage/views.py
+++ b/plinth/modules/storage/views.py
@@ -104,6 +104,7 @@ def warn_about_low_disk_space(request):
 
 def _interpret_size_string(size_str):
     """Convert size string to number of bytes."""
+    size_str = size_str.replace(',', '.')  # some locales use commas
     if size_str[-1] in '0123456789':
         return float(size_str[:-1])
 


### PR DESCRIPTION
Fixes issue #1043 ; tested with German locale, where commas are used as decimal separator. (Which reproduced the issue.)