### PR TITLE
users: Restart nscd after setup

### DIFF
--- a/actions/users
+++ b/actions/users
@@ -63,6 +63,7 @@ def configure_slapd():
                                             'ldap-sasl-mech': 'EXTERNAL'})
     action_utils.dpkg_reconfigure('libnss-ldapd',
                                   {'nsswitch': 'group, passwd, shadow'})
+    action_utils.service_restart('nscd')
 
 
 def configure_ldap_structure():


### PR DESCRIPTION
The changes made for system login will not be effective until a restart. This
includes SSH login, console login, getent answers, etc.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>
Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>

Tested by running the fixed code again with `/usr/share/plinth/actions/users setup`.