### PR TITLE
networks: activate connection properly and idempotancy for setup

### DIFF
--- a/actions/networks
+++ b/actions/networks
@@ -14,6 +14,11 @@ function get-interfaces {
     NO_OF_WIRELESS_IFACES=$(echo $WIRELESS_IFACES | wc -w)
 }
 
+function activate-connection {
+    connection_name="$1"
+    nohup nmcli con up "$connection_name" &>/dev/null &
+}
+
 function configure-regular-interface {
     local interface="$1"
     local zone="$2"
@@ -23,6 +28,7 @@ function configure-regular-interface {
     nmcli con add con-name "$connection_name" ifname "$interface" type ethernet
     nmcli con modify "$connection_name" connection.autoconnect TRUE
     nmcli con modify "$connection_name" connection.zone "$zone"
+    activate-connection "$connection_name"
 
     echo "Configured interface '$interface' for '$zone' use as '$connection_name'."
 }
@@ -44,6 +50,8 @@ function configure-shared-interface {
     #  - Add firewall rules for NATing from this interface
     nmcli con modify "$connection_name" ipv4.method shared
 
+    activate-connection "$connection_name"
+
     echo "Configured interface '$interface' for shared use as '$connection_name'."
 }
 
@@ -60,6 +68,7 @@ function configure-wireless-interface {
     nmcli con modify "$connection_name" wifi.mode ap
     nmcli con modify "$connection_name" wifi-sec.key-mgmt wpa-psk
     nmcli con modify "$connection_name" wifi-sec.psk "$secret"
+    activate-connection "$connection_name"
 
     echo "Configured interface '$interface' for shared use as '$connection_name'."
 }
@@ -132,10 +141,6 @@ function setup {
 if [ -f "/var/lib/freedombox/is-freedombox-disk-image" ]
 then
     setup
-    # Restart network-manager so that the connections created will be activated.
-    # On a fresh disk image, this means the default network manager connections
-    # will be ignored and newly created connections will be activated.
-    systemctl restart network-manager
 else
     echo "Not a FreedomBox disk image. Skipping network configuration."
 fi

--- a/actions/networks
+++ b/actions/networks
@@ -14,6 +14,21 @@ function get-interfaces {
     NO_OF_WIRELESS_IFACES=$(echo $WIRELESS_IFACES | wc -w)
 }
 
+function add-connection {
+    local connection_name="$1"
+    shift
+    local interface="$1"
+    shift
+    local remaining_arguments="$@"
+
+    already_exists=$(nmcli --terse --fields name,device con show | grep "$connection_name:$interface" || true)
+    if [ -n "$already_exists" ]; then
+        echo "Connection '$connection_name' already exists for device '$interface', not adding."
+    else
+        nmcli con add con-name "$connection_name" ifname "$interface" $remaining_arguments
+    fi
+}
+
 function activate-connection {
     connection_name="$1"
     nohup nmcli con up "$connection_name" &>/dev/null &
@@ -25,7 +40,7 @@ function configure-regular-interface {
     local connection_name="FreedomBox WAN"
 
     # Create n-m connection for a regular interface
-    nmcli con add con-name "$connection_name" ifname "$interface" type ethernet
+    add-connection "$connection_name" "$interface" type ethernet
     nmcli con modify "$connection_name" connection.autoconnect TRUE
     nmcli con modify "$connection_name" connection.zone "$zone"
     activate-connection "$connection_name"
@@ -38,7 +53,7 @@ function configure-shared-interface {
     local connection_name="FreedomBox LAN $interface"
 
     # Create n-m connection for eth1
-    nmcli con add con-name "$connection_name" ifname "$interface" type ethernet
+    add-connection "$connection_name" "$interface" type ethernet
     nmcli con modify "$connection_name" connection.autoconnect TRUE
     nmcli con modify "$connection_name" connection.zone internal
 
@@ -61,7 +76,7 @@ function configure-wireless-interface {
     local ssid="FreedomBox$interface"
     local secret="freedombox123"
 
-    nmcli con add con-name "$connection_name" ifname "$interface" type wifi ssid "$ssid"
+    add-connection "$connection_name" "$interface" type wifi ssid "$ssid"
     nmcli con modify "$connection_name" connection.autoconnect TRUE
     nmcli con modify "$connection_name" connection.zone internal
     nmcli con modify "$connection_name" ipv4.method shared


### PR DESCRIPTION
When network-manager restarts, it leaves the existing connections intact. So, active the newly created connection to make them work.

Only add a connection for a device if a connection with that name is not already
associated with that device.

Closes #1045.

Minimal testing was done to ensure the results are better than what we have now.  May check again later with full disk image but I think the patch can be merged.