### PR TITLE
tt-rss: Make tt-rss api accessible using Apache basic auth

### DIFF
--- a/data/etc/apache2/conf-available/tt-rss-plinth.conf
+++ b/data/etc/apache2/conf-available/tt-rss-plinth.conf
@@ -3,7 +3,14 @@
 ## Allow all valid LDAP users.
 ##
 Alias /tt-rss /usr/share/tt-rss/www
+Alias /tt-rss-api /usr/share/tt-rss/www
 
 <Location /tt-rss>
     Include includes/freedombox-single-sign-on.conf
+</Location>
+
+<Location /tt-rss-api>
+    Include includes/freedombox-auth-ldap.conf
+    Require valid-user
+    # TODO Restrict access to `news` group
 </Location>


### PR DESCRIPTION
Partially fixes #958

The user still has to enable API access from Preferences in the tt-rss app.
Ideally, this should be automated, but this setting wasn't trivial to find. Will
try to automate this in a future pull request.

Signed-off-by: Joseph Nuthalpati <njoseph@thoughtworks.com>
Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>
 