### PR TITLE
Ensure url is a str for commonprefix

### DIFF
--- a/plinth/templatetags/plinth_extras.py
+++ b/plinth/templatetags/plinth_extras.py
@@ -42,7 +42,7 @@ def mark_active_menuitem(menu, path):
         if not path.startswith(str(urlitem['url'])):
             continue
 
-        match = os.path.commonprefix([urlitem['url'], path])
+        match = os.path.commonprefix([str(urlitem['url']), path])
         if len(match) > len(best_match):
             best_match = match
             best_match_item = urlitem


### PR DESCRIPTION
Fixes #1064. I'm still not sure why this is necessary, but it fixed the issue for me on Users and Networks pages.