### PR TITLE
Power: Remove power button from application header

### DIFF
--- a/plinth/modules/power/__init__.py
+++ b/plinth/modules/power/__init__.py
@@ -21,6 +21,8 @@ Plinth module for power controls.
 
 from django.utils.translation import ugettext_lazy as _
 
+from plinth.menu import main_menu
+
 version = 1
 
 is_essential = True
@@ -33,5 +35,5 @@ description = [
 
 
 def init():
-    """Initialize the power module."""
-    pass  # not in menu, see issue #834
+    menu = main_menu.get('system')
+    menu.add_urlname(name, 'glyphicon-off', 'power:index')

--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -155,29 +155,7 @@
                   </li>
                 </ul>
               </li>
-              <li class="dropdown">
-                <a href="{% url 'power:index' %}"
-                   class="dropdown-toggle" data-toggle="dropdown"
-                   role="button" aria-expanded="false">
-                  <i class="glyphicon glyphicon-off nav-icon"></i>
-                  <span class="caret"></span>
-                </a>
-                <ul class="dropdown-menu" role="menu">
-                  <li>
-                    <a href="{% url 'power:restart' %}"
-                       title="{% trans "Restart"%}">
-                      {% trans "Restart" %}
-                    </a>
-                  </li>
-                  <li>
-                    <a href="{% url 'power:shutdown' %}"
-                       title="{% trans "Shut down" %}">
-                      {% trans "Shut down" %}
-                    </a>
-                  </li>
-                </ul>
-              </li>
-            {% else %}
+              {% else %}
               <li>
                   <a href="{% url 'users:login' %}" title="{% trans "Log in" %}">
                     <i class="glyphicon glyphicon-user nav-icon"></i>


### PR DESCRIPTION
- Remove power buttons from their prominent position in the header
- Restore power to its original position in the Configure page

Closes #1074

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>