### PR TITLE
Install dependency packages during install/provisioning

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -26,6 +26,13 @@ The entire setup is automatic and requires about 4.5 GB of disk space.
 
    $ vagrant provision
 
+## Installing Dependencies
+
+Apart from dependencies listing in INSTALL file, Plinth may have additional
+dependencies required by modules of Plinth.  To install these, run:
+
+    $ sudo apt install -y $(plinth --list-dependencies)
+
 ## Manually Setting Up for Development
 
 It is recommended that you use Vagrant to setup your development

--- a/INSTALL
+++ b/INSTALL
@@ -41,6 +41,7 @@
     program and run:
 
     $ sudo python3 setup.py install
+    $ sudo apt install -y $(plinth --list-dependencies)
 
 3. Run Plinth:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,8 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     cd /vagrant/
     ./setup.py install
+    apt update
+    apt install -y $(plinth --list-dependencies)
     systemctl daemon-reload
     systemctl restart plinth
   SHELL


### PR DESCRIPTION
This will not install all the dependencies of Plinth but will install the
dependencies required for essential modules to setup properly.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>