### PR TITLE
groups: Display application user groups in the forms in users module

### DIFF
--- a/actions/users
+++ b/actions/users
@@ -73,6 +73,9 @@ def parse_arguments():
         'username', help='LDAP user to retrieve the groups for')
 
     subparser = subparsers.add_parser(
+        'get-all-groups', help='Get a list of all the LDAP groups in the system')
+
+    subparser = subparsers.add_parser(
         'add-user-to-group', help='Add an LDAP user to an LDAP group')
     subparser.add_argument('username', help='LDAP user to add to group')
     subparser.add_argument('groupname', help='LDAP group to add the user to')
@@ -341,6 +344,17 @@ def subcommand_remove_user_from_group(arguments):
     """Remove an LDAP user from an LDAP group."""
     remove_user_from_group(arguments.username, arguments.groupname)
     flush_cache()
+
+
+def subcommand_get_all_groups(_):
+    """Get all user groups"""
+    get_groups = "getent group".split()
+    cut_names = "cut -d: -f1".split()
+    groups = subprocess.Popen(get_groups, stdout=subprocess.PIPE, shell=False)
+    trimmed_groups = subprocess.Popen(cut_names, stdin=groups.stdout,
+                                      stdout=subprocess.PIPE, shell=False)
+    groups.stdout.close()
+    print(trimmed_groups.communicate()[0].decode())
 
 
 def flush_cache():

--- a/actions/users
+++ b/actions/users
@@ -346,17 +346,6 @@ def subcommand_remove_user_from_group(arguments):
     flush_cache()
 
 
-def subcommand_get_all_groups(_):
-    """Get all user groups"""
-    get_groups = "getent group".split()
-    cut_names = "cut -d: -f1".split()
-    groups = subprocess.Popen(get_groups, stdout=subprocess.PIPE, shell=False)
-    trimmed_groups = subprocess.Popen(cut_names, stdin=groups.stdout,
-                                      stdout=subprocess.PIPE, shell=False)
-    groups.stdout.close()
-    print(trimmed_groups.communicate()[0].decode())
-
-
 def flush_cache():
     """Flush nscd cache."""
     _run(['nscd', '--invalidate=passwd'])

--- a/actions/users
+++ b/actions/users
@@ -21,11 +21,11 @@ Configuration helper for the LDAP user directory
 """
 
 import argparse
-import augeas
 import re
 import subprocess
 import sys
 
+import augeas
 from plinth import action_utils
 
 ACCESS_CONF = '/etc/security/access.conf'
@@ -39,44 +39,41 @@ def parse_arguments():
 
     subparsers.add_parser('setup', help='Setup LDAP')
 
-    subparser = subparsers.add_parser(
-        'create-user', help='Create an LDAP user')
+    subparser = subparsers.add_parser('create-user',
+                                      help='Create an LDAP user')
     subparser.add_argument('username', help='Name of the LDAP user to create')
 
-    subparser = subparsers.add_parser(
-        'remove-user', help='Delete an LDAP user')
+    subparser = subparsers.add_parser('remove-user',
+                                      help='Delete an LDAP user')
     subparser.add_argument('username', help='Name of the LDAP user to delete')
 
-    subparser = subparsers.add_parser(
-        'rename-user', help='Rename an LDAP user')
+    subparser = subparsers.add_parser('rename-user',
+                                      help='Rename an LDAP user')
     subparser.add_argument('oldusername', help='Old name of the LDAP user')
     subparser.add_argument('newusername', help='New name of the LDAP user')
 
-    subparser = subparsers.add_parser(
-        'set-user-password', help='Set the password of an LDAP user')
+    subparser = subparsers.add_parser('set-user-password',
+                                      help='Set the password of an LDAP user')
     subparser.add_argument(
         'username', help='Name of the LDAP user to set the password for')
 
-    subparser = subparsers.add_parser(
-        'create-group', help='Create an LDAP group')
-    subparser.add_argument(
-        'groupname', help='Name of the LDAP group to create')
+    subparser = subparsers.add_parser('create-group',
+                                      help='Create an LDAP group')
+    subparser.add_argument('groupname',
+                           help='Name of the LDAP group to create')
 
-    subparser = subparsers.add_parser(
-        'remove-group', help='Delete an LDAP group')
-    subparser.add_argument(
-        'groupname', help='Name of the LDAP group to delete')
+    subparser = subparsers.add_parser('remove-group',
+                                      help='Delete an LDAP group')
+    subparser.add_argument('groupname',
+                           help='Name of the LDAP group to delete')
 
     subparser = subparsers.add_parser(
         'get-user-groups', help='Get all the LDAP groups for an LDAP user')
-    subparser.add_argument(
-        'username', help='LDAP user to retrieve the groups for')
+    subparser.add_argument('username',
+                           help='LDAP user to retrieve the groups for')
 
-    subparser = subparsers.add_parser(
-        'get-all-groups', help='Get a list of all the LDAP groups in the system')
-
-    subparser = subparsers.add_parser(
-        'add-user-to-group', help='Add an LDAP user to an LDAP group')
+    subparser = subparsers.add_parser('add-user-to-group',
+                                      help='Add an LDAP user to an LDAP group')
     subparser.add_argument('username', help='LDAP user to add to group')
     subparser.add_argument('groupname', help='LDAP group to add the user to')
 
@@ -84,8 +81,8 @@ def parse_arguments():
         'remove-user-from-group',
         help='Remove an LDAP user from an LDAP group')
     subparser.add_argument('username', help='LDAP user to remove from group')
-    subparser.add_argument(
-        'groupname', help='LDAP group to remove the user from')
+    subparser.add_argument('groupname',
+                           help='LDAP group to remove the user from')
 
     subparsers.required = True
     return parser.parse_args()
@@ -138,13 +135,10 @@ def create_organizational_unit(unit):
     """Create an organizational unit in LDAP."""
     distinguished_name = 'ou={unit},dc=thisbox'.format(unit=unit)
     try:
-        subprocess.run(
-            [
-                'ldapsearch', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///', '-s',
-                'base', '-b', distinguished_name, '(objectclass=*)'
-            ],
-            stdout=subprocess.DEVNULL,
-            check=True)
+        subprocess.run([
+            'ldapsearch', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///', '-s',
+            'base', '-b', distinguished_name, '(objectclass=*)'
+        ], stdout=subprocess.DEVNULL, check=True)
         return  # Already exists
     except subprocess.CalledProcessError:
         input = '''
@@ -152,23 +146,18 @@ dn: ou={unit},dc=thisbox
 objectClass: top
 objectClass: organizationalUnit
 ou: {unit}'''.format(unit=unit)
-        subprocess.run(
-            ['ldapadd', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///'],
-            input=input.encode(),
-            stdout=subprocess.DEVNULL,
-            check=True)
+        subprocess.run(['ldapadd', '-Q', '-Y', 'EXTERNAL', '-H',
+                        'ldapi:///'], input=input.encode(),
+                       stdout=subprocess.DEVNULL, check=True)
 
 
 def setup_admin():
     """Remove LDAP admin password and Allow root to modify the users."""
-    process = subprocess.run(
-        [
-            'ldapsearch', '-Q', '-L', '-L', '-L', '-Y', 'EXTERNAL', '-H',
-            'ldapi:///', '-s', 'base', '-b', 'olcDatabase={1}mdb,cn=config',
-            '(objectclass=*)', 'olcRootDN', 'olcRootPW'
-        ],
-        check=True,
-        stdout=subprocess.PIPE)
+    process = subprocess.run([
+        'ldapsearch', '-Q', '-L', '-L', '-L', '-Y', 'EXTERNAL', '-H',
+        'ldapi:///', '-s', 'base', '-b', 'olcDatabase={1}mdb,cn=config',
+        '(objectclass=*)', 'olcRootDN', 'olcRootPW'
+    ], check=True, stdout=subprocess.PIPE)
     ldap_object = {}
     for line in process.stdout.decode().splitlines():
         if line:
@@ -177,10 +166,8 @@ def setup_admin():
 
     if 'olcRootPW' in ldap_object:
         subprocess.run(
-            ['ldapmodify', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///'],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            input=b'''
+            ['ldapmodify', '-Q', '-Y', 'EXTERNAL', '-H',
+             'ldapi:///'], check=True, stdout=subprocess.DEVNULL, input=b'''
 dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 delete: olcRootPW''')
@@ -188,10 +175,8 @@ delete: olcRootPW''')
     root_dn = 'gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth'
     if ldap_object['olcRootDN'] != root_dn:
         subprocess.run(
-            ['ldapmodify', '-Q', '-Y', 'EXTERNAL', '-H', 'ldapi:///'],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            input=b'''
+            ['ldapmodify', '-Q', '-Y', 'EXTERNAL', '-H',
+             'ldapi:///'], check=True, stdout=subprocess.DEVNULL, input=b'''
 dn: olcDatabase={1}mdb,cn=config
 changetype: modify
 replace: olcRootDN
@@ -261,8 +246,7 @@ def subcommand_rename_user(arguments):
 
 def set_user_password(username, password):
     """Set a user's password."""
-    process = _run(
-        ['slappasswd', '-s', password], stdout=subprocess.PIPE)
+    process = _run(['slappasswd', '-s', password], stdout=subprocess.PIPE)
     password = process.stdout.decode().strip()
     _run(['ldapsetpasswd', username, password])
 
@@ -276,14 +260,14 @@ def get_user_groups(username):
     """Returns only the supplementary groups of the given user.
 
     Exclude the 'users' primary group from the returned list."""
-    process = _run(
-        ['ldapid', username], stdout=subprocess.PIPE, check=False)
+    process = _run(['ldapid', username], stdout=subprocess.PIPE, check=False)
     output = process.stdout.decode().strip()
     if output:
         groups_part = output.split(' ')[2]
         groups = groups_part.split('=')[1]
-        group_names = [user.strip('()')
-                       for user in re.findall('\(.*?\)', groups)]
+        group_names = [
+            user.strip('()') for user in re.findall('\(.*?\)', groups)
+        ]
         group_names.remove('users')
         return group_names
 

--- a/data/etc/apache2/conf-available/tt-rss-plinth.conf
+++ b/data/etc/apache2/conf-available/tt-rss-plinth.conf
@@ -7,10 +7,13 @@ Alias /tt-rss-app /usr/share/tt-rss/www
 
 <Location /tt-rss>
     Include includes/freedombox-single-sign-on.conf
+    <IfModule mod_auth_pubtkt.c>
+        TKTAuthToken "newsfeed" "admin"
+    </IfModule>
 </Location>
 
 <Location /tt-rss-app>
     Include includes/freedombox-auth-ldap.conf
     Require valid-user
-    # TODO Restrict access to `news` group
+    # TODO Restrict access to `newsfeed` group
 </Location>

--- a/data/etc/apache2/conf-available/tt-rss-plinth.conf
+++ b/data/etc/apache2/conf-available/tt-rss-plinth.conf
@@ -8,12 +8,12 @@ Alias /tt-rss-app /usr/share/tt-rss/www
 <Location /tt-rss>
     Include includes/freedombox-single-sign-on.conf
     <IfModule mod_auth_pubtkt.c>
-        TKTAuthToken "newsfeed" "admin"
+        TKTAuthToken "feed-reader" "admin"
     </IfModule>
 </Location>
 
 <Location /tt-rss-app>
     Include includes/freedombox-auth-ldap.conf
     Require valid-user
-    # TODO Restrict access to `newsfeed` group
+    # TODO Restrict access to `feed-reader` group
 </Location>

--- a/plinth/modules/deluge/__init__.py
+++ b/plinth/modules/deluge/__init__.py
@@ -27,7 +27,7 @@ from plinth import frontpage
 from plinth import service as service_module
 from plinth.client import web_client
 from plinth.menu import main_menu
-from plinth.modules.users import add_group
+from plinth.modules.users import create_group, register_group
 
 
 version = 2
@@ -51,6 +51,8 @@ description = [
       'it immediately after enabling this service.')
 ]
 
+group = ('bit-torrent', _('Download files using BitTorrent applications'))
+
 reserved_usernames = ['debian-deluged']
 
 web_clients = [web_client(name='Deluge', url='/deluge')]
@@ -72,6 +74,7 @@ def init():
 
         if is_enabled():
             add_shortcut()
+            register_group(group)
 
 
 def setup(helper, old_version=None):
@@ -86,7 +89,7 @@ def setup(helper, old_version=None):
             disable=disable)
     helper.call('post', service.notify_enabled, None, True)
     helper.call('post', add_shortcut)
-    add_group('bittorrent')
+    create_group(group[0])
 
 
 def add_shortcut():

--- a/plinth/modules/ikiwiki/__init__.py
+++ b/plinth/modules/ikiwiki/__init__.py
@@ -29,6 +29,7 @@ from plinth import frontpage
 from plinth import service as service_module
 from plinth.menu import main_menu
 from plinth.client import web_client
+from plinth.modules.users import create_group, register_group
 
 
 version = 1
@@ -60,6 +61,9 @@ description = [
 
 web_clients = [web_client(name='ikiwiki', url='/ikiwiki')]
 
+group = ('wiki', _('View and edit wiki applications'))
+
+
 def init():
     """Initialize the ikiwiki module."""
     menu = main_menu.get('apps')
@@ -74,6 +78,7 @@ def init():
 
         if is_enabled():
             add_shortcuts()
+            register_group(group)
 
 
 def setup(helper, old_version=None):
@@ -87,6 +92,7 @@ def setup(helper, old_version=None):
             is_enabled=is_enabled, enable=enable, disable=disable)
     helper.call('post', service.notify_enabled, None, True)
     helper.call('post', add_shortcuts)
+    create_group(group[0])
 
 
 def add_shortcuts():

--- a/plinth/modules/ttrss/__init__.py
+++ b/plinth/modules/ttrss/__init__.py
@@ -29,7 +29,7 @@ from plinth import frontpage
 from plinth import service as service_module
 from plinth.menu import main_menu
 from plinth.client import web_client, mobile_client
-
+from plinth.modules.users import add_group
 
 version = 2
 
@@ -101,6 +101,7 @@ def setup(helper, old_version=None):
             is_enabled=is_enabled, enable=enable, disable=disable)
     helper.call('post', service.notify_enabled, None, True)
     helper.call('post', add_shortcut)
+    add_group('newsfeed')
 
 
 def add_shortcut():

--- a/plinth/modules/ttrss/__init__.py
+++ b/plinth/modules/ttrss/__init__.py
@@ -29,7 +29,7 @@ from plinth import frontpage
 from plinth import service as service_module
 from plinth.menu import main_menu
 from plinth.client import web_client, mobile_client
-from plinth.modules.users import add_group
+from plinth.modules.users import create_group, register_group
 
 version = 2
 
@@ -67,6 +67,8 @@ mobile_clients = [
                                  '?id=org.ttrssreader',
                   fdroid_url='https://f-droid.org/packages/org.ttrssreader/')]
 
+group = ('feed-reader', _('Read and subscribe to news feeds'))
+
 service = None
 
 
@@ -86,6 +88,7 @@ def init():
 
         if is_enabled():
             add_shortcut()
+            register_group(group)
 
 
 def setup(helper, old_version=None):
@@ -101,7 +104,7 @@ def setup(helper, old_version=None):
             is_enabled=is_enabled, enable=enable, disable=disable)
     helper.call('post', service.notify_enabled, None, True)
     helper.call('post', add_shortcut)
-    add_group('newsfeed')
+    create_group(group[0])
 
 
 def add_shortcut():

--- a/plinth/modules/users/__init__.py
+++ b/plinth/modules/users/__init__.py
@@ -14,26 +14,25 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 Plinth module to manage users
 """
 
-from django.utils.translation import ugettext_lazy as _
 import subprocess
 
-from plinth import action_utils
-from plinth import actions
-from plinth.errors import ActionError
-from plinth.menu import main_menu
+from django.utils.translation import ugettext_lazy as _
 
+from plinth import action_utils, actions
+from plinth.menu import main_menu
 
 version = 1
 
 is_essential = True
 
-managed_packages = ['ldapscripts', 'ldap-utils', 'libnss-ldapd',
-                    'libpam-ldapd', 'nslcd', 'slapd']
+managed_packages = [
+    'ldapscripts', 'ldap-utils', 'libnss-ldapd', 'libpam-ldapd', 'nslcd',
+    'slapd'
+]
 
 first_boot_steps = [
     {
@@ -80,33 +79,27 @@ def _diagnose_ldap_entry(search_item):
     result = 'failed'
 
     try:
-        subprocess.check_output(['ldapsearch', '-x', '-b', 'dc=thisbox',
-                                 search_item])
+        subprocess.check_output(
+            ['ldapsearch', '-x', '-b', 'dc=thisbox', search_item])
         result = 'passed'
     except subprocess.CalledProcessError:
         pass
 
-    return [_('Check LDAP entry "{search_item}"')
-            .format(search_item=search_item), result]
+    return [
+        _('Check LDAP entry "{search_item}"').format(search_item=search_item),
+        result
+    ]
 
 
 def create_group(group):
     """Add an LDAP group."""
     actions.superuser_run('users', options=['create-group', group])
+    register_group(group)
 
 
 def remove_group(group):
     """Remove an LDAP group."""
     actions.superuser_run('users', options=['remove-group', group])
-
-
-def get_all_groups():
-    """Retrieve the set of all LDAP groups in the system"""
-    try:
-        groups = actions.superuser_run('users', options=['get-all-groups'])
-        return set(groups.strip().split())
-    except ActionError:
-        return {}
 
 
 def register_group(group):

--- a/plinth/modules/users/__init__.py
+++ b/plinth/modules/users/__init__.py
@@ -24,6 +24,7 @@ import subprocess
 
 from plinth import action_utils
 from plinth import actions
+from plinth.errors import ActionError
 from plinth.menu import main_menu
 
 
@@ -94,3 +95,12 @@ def add_group(group):
 def remove_group(group):
     """Remove an LDAP group."""
     actions.superuser_run('users', options=['remove-group', group])
+
+
+def get_all_groups():
+    """Retrieve the set of all LDAP groups in the system"""
+    try:
+        groups = actions.superuser_run('users', options=['get-all-groups'])
+        return set(groups.strip().split())
+    except ActionError:
+        return {}

--- a/plinth/modules/users/__init__.py
+++ b/plinth/modules/users/__init__.py
@@ -45,6 +45,9 @@ first_boot_steps = [
 
 name = _('Users and Groups')
 
+# List of all Plinth user groups
+groups = set()
+
 
 def init():
     """Intialize the user module."""
@@ -87,7 +90,7 @@ def _diagnose_ldap_entry(search_item):
             .format(search_item=search_item), result]
 
 
-def add_group(group):
+def create_group(group):
     """Add an LDAP group."""
     actions.superuser_run('users', options=['create-group', group])
 
@@ -104,3 +107,7 @@ def get_all_groups():
         return set(groups.strip().split())
     except ActionError:
         return {}
+
+
+def register_group(group):
+    groups.add(group)

--- a/plinth/modules/users/forms.py
+++ b/plinth/modules/users/forms.py
@@ -29,13 +29,22 @@ from plinth import actions
 from plinth.errors import ActionError
 from plinth.modules import first_boot
 from plinth.modules.security import set_restricted_access
+from plinth.modules.users import get_all_groups
 from plinth.utils import is_user_admin
 from plinth import module_loader
 
-GROUP_CHOICES = (
-    ('admin', _('admin')),
-    ('wiki', _('wiki')),
-)
+PLINTH_APP_GROUPS = {
+    'admin',
+    'newsfeed',
+ }
+
+
+def get_group_choices():
+    groups = PLINTH_APP_GROUPS.intersection(get_all_groups())
+    return ((group, _(group)) for group in groups)
+
+
+GROUP_CHOICES = get_group_choices()
 
 
 class ValidNewUsernameCheckMixin(object):


### PR DESCRIPTION
- Whenever a Plinth app is installed, it creates a user group in LDAP for its
  category of applications (this is an idempotent operation).
- List all the user groups created by the applications in the create and update
  forms in the users module so that the administrator can have flexibility in
  giving permissions for accessing services on FreedomBox.

Closes #690
Prerequisite for #860

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>

This PR uses tt-rss as a reference implementation for framework-level support 
of adding user groups per application. 
The word `newsfeed` is chosen because a group called `news` already exists in 
the ldap database. I'm okay with changing it.