### PR TITLE
Handle both admin and non-admin user names in update user template

### DIFF
--- a/plinth/templates/base.html
+++ b/plinth/templates/base.html
@@ -131,7 +131,7 @@
                    class="dropdown-toggle" data-toggle="dropdown"
                    role="button" aria-expanded="false">
                   <i class="glyphicon glyphicon-user nav-icon"></i>
-                  {{ user.username }}
+                  {{ request.user.username }}
                   <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu" role="menu">


### PR DESCRIPTION
When an admin user goes to the UpdateUser view of a different user, the template
gets only one username which is of the user being updated. This causes the admin
user's name being overwritten in the header section thus making it appear that
the user is modifying themselves and not the admin. This can cause confusion to
the admin user.

Explicitly getting the name of the user that made the request ensures that we
always get the correct username.

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>