### PR TITLE
ejabberd: Fix LDAP server entry in config file during setup.

### DIFF
--- a/actions/ejabberd
+++ b/actions/ejabberd
@@ -121,7 +121,8 @@ def subcommand_setup(_):
             listen_port['tls'] = False
 
     conf['auth_method'] = 'ldap'
-    conf['ldap_servers'] = ['localhost']
+    conf['ldap_servers'] = [ruamel.yaml.scalarstring.DoubleQuotedScalarString(
+        'localhost')]
     conf['ldap_base'] = ruamel.yaml.scalarstring.DoubleQuotedScalarString(
         'ou=users,dc=thisbox')
 


### PR DESCRIPTION
During ejabberd setup, plinth adds the config line `ldap_servers` in `/etc/ejabberd/ejabberd.yml`, but it is malformed because of missing double-quote around string `localhost`. This PR fixes that (although everything seems to work fine even with the malformed line.)
See also https://docs.ejabberd.im/admin/configuration/#ldap-connection.

The error messages in `/var/log/ejabberd/error.log` are:
```
2017-10-28 15:58:55.359 [error] <0.65.0>@ejabberd_config:validate_opts:1016 ignoring option 'ldap_servers' with invalid value: localhost
```