### PR TITLE
WIP?: ejabberd, jsxc, apache: Renaming out-dated "http-bind" to "bosh"

### DIFF
--- a/data/etc/apache2/conf-available/jwchat-plinth.conf
+++ b/data/etc/apache2/conf-available/jwchat-plinth.conf
@@ -1,6 +1,6 @@
 # Proxy for BOSH server
-ProxyPass /http-bind/ http://localhost:5280/http-bind/
-ProxyPassReverse /http-bind/ http://localhost:5280/http-bind/
-<Proxy http://localhost:5280/http-bind/*>
+ProxyPass /bosh/ http://localhost:5280/bosh/
+ProxyPassReverse /bosh/ http://localhost:5280/bosh/
+<Proxy http://localhost:5280/bosh/*>
     Require all granted
 </Proxy>

--- a/plinth/modules/ejabberd/__init__.py
+++ b/plinth/modules/ejabberd/__init__.py
@@ -190,6 +190,6 @@ def diagnose():
     results.append(action_utils.diagnose_port_listening(5280, 'tcp4'))
     results.append(action_utils.diagnose_port_listening(5280, 'tcp6'))
     results.extend(
-        action_utils.diagnose_url_on_all('http://{host}/http-bind/'))
+        action_utils.diagnose_url_on_all('http://{host}/bosh/'))
 
     return results

--- a/plinth/modules/jsxc/static/jsxc-plinth.js
+++ b/plinth/modules/jsxc/static/jsxc-plinth.js
@@ -44,7 +44,7 @@
 
 $(function() {
     var settings = {
-        url: '/http-bind/',
+        url: '/bosh/',
         domain: plinth_settings.domainname
     };
 


### PR DESCRIPTION
This PR addresses issue #1090, and works for me on the current vagrant image (0.15.3).
However, maybe more changes are necessary to upgrade from previous versions?