### PR TITLE
Spelling: "fail2ban" → "Fail2ban"

### DIFF
--- a/plinth/modules/security/forms.py
+++ b/plinth/modules/security/forms.py
@@ -33,6 +33,6 @@ class SecurityForm(forms.Form):
                     'without further authorization.'))
     fail2ban_enabled = forms.BooleanField(
         label=_('Fail2ban (recommended)'), required=False,
-        help_text=_('When this option is enabled, fail2ban will limit brute force '
+        help_text=_('When this option is enabled, Fail2ban will limit brute force '
                     'break-in attempts to the SSH server and other password protected '
                     'internet-services which are enabled.'))

--- a/plinth/modules/security/forms.py
+++ b/plinth/modules/security/forms.py
@@ -32,7 +32,7 @@ class SecurityForm(forms.Form):
                     'Console users may be able to access some services '
                     'without further authorization.'))
     fail2ban_enabled = forms.BooleanField(
-        label=_('Fail2ban (recommended)'), required=False,
-        help_text=_('When this option is enabled, Fail2ban will limit brute force '
-                    'break-in attempts to the SSH server and other password protected '
-                    'internet-services which are enabled.'))
+        label=_('Fail2Ban (recommended)'), required=False,
+        help_text=_('When this option is enabled, Fail2Ban will limit brute force '
+                    'break-in attempts to the SSH server and other enabled '
+                    'password protected internet-services.'))


### PR DESCRIPTION
As per https://www.fail2ban.org/wiki/index.php/Main_Page