### PR TITLE
transmission: fix sso not being enabled

### DIFF
--- a/plinth/action_utils.py
+++ b/plinth/action_utils.py
@@ -156,7 +156,7 @@ def webserver_enable(name, kind='config', apply_changes=True):
     is required.  If changes have been applied, then performed action
     is returned.
     """
-    if webserver_is_enabled(name, kind):
+    if webserver_is_enabled(name, kind) and kind == 'module':
         return
 
     command_map = {

--- a/plinth/modules/transmission/__init__.py
+++ b/plinth/modules/transmission/__init__.py
@@ -18,18 +18,17 @@
 Plinth module to configure Transmission server
 """
 
-from django.utils.translation import ugettext_lazy as _
 import json
 
-from plinth import actions
-from plinth import action_utils
-from plinth import frontpage
+from django.utils.translation import ugettext_lazy as _
+
 from plinth import service as service_module
-from plinth.menu import main_menu
+from plinth import action_utils, actions, frontpage
 from plinth.client import web_client
+from plinth.menu import main_menu
 from plinth.modules.users import add_group
 
-version = 1
+version = 2
 
 managed_services = ['transmission-daemon']
 


### PR DESCRIPTION
- Transmission version wasn't updated, so the new configuration didn't take
  effect.
- The new configuration disabled Transmission's own auth and an apache reload is
  required for SSO auth to be enabled for Transmission. This was not happening
  because webserver_enable command finds that webserver is already enabled for
  Transmission. It cannot detect upgrades. Hence disabled that check for
  reloads. We're still avoiding restarts if there's no config change, just like
  before.

Fixes #1139

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>