### PR TITLE
ejabberd: Use dynamic reload after enabling/disabling MAM

### DIFF
--- a/actions/ejabberd
+++ b/actions/ejabberd
@@ -270,7 +270,7 @@ def subcommand_mam(argument):
         ruamel.yaml.round_trip_dump(conf, file_handle)
 
     if action_utils.service_is_running('ejabberd'):
-        action_utils.service_restart('ejabberd')
+        subprocess.call(['ejabberdctl', 'reload_config'])
 
 
 def subcommand_letsencrypt(arguments):


### PR DESCRIPTION
After a user enables/disables MAM, use ejabberd's reload_config instead
of restarting ejabberd.

Please let me know how this looks? Could reload_config also be of use
when adding/dropping a Let's Encrypt certificate?

Fixes #1010