### PR TITLE
vagrant: Avoid debconf prompts while provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(2) do |config|
     cd /vagrant/
     ./setup.py install
     apt update
-    apt install -y $(plinth --list-dependencies)
+    DEBIAN_FRONTEND=noninteractive apt install -y $(plinth --list-dependencies)
     systemctl daemon-reload
     systemctl restart plinth
   SHELL


### PR DESCRIPTION
"vagrant provision" can get stuck at a debconf prompt while trying to install dependencies. Set non-interactive front end to avoid this.