### PR TITLE
ejabberd: remove redundant button Client Apps

### DIFF
--- a/plinth/modules/ejabberd/templates/ejabberd.html
+++ b/plinth/modules/ejabberd/templates/ejabberd.html
@@ -51,8 +51,6 @@
 
 {% block configuration %}
 
-  {% include "clients.html" with clients=clients %}
-
   <h3>{% trans "Configuration" %}</h3>
 
   <form class="form" method="post">


### PR DESCRIPTION
This PR fixes issue #1167, removing the redundant `Client Apps` button.
I've tested both before and after installing ejabberd.