### PR TITLE
users: Make sure first run actually works

### DIFF
--- a/plinth/modules/users/__init__.py
+++ b/plinth/modules/users/__init__.py
@@ -57,7 +57,7 @@ def init():
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
-    if old_version is None:
+    if not old_version:
         helper.call('post', actions.superuser_run, 'users', ['first-setup'])
     helper.call('post', actions.superuser_run, 'users', ['setup'])
 


### PR DESCRIPTION
During the first setup, older_version is sent as 0 instead of None. Make sure
that is actually works by doing proper condition check.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>

This should fix #1169. I have not tested this fix by building a full image yet. However, running `actions/users first-setup` on the command line let Plinth complete its first setup process.