### PR TITLE
bind: rework configuration

### DIFF
--- a/actions/bind
+++ b/actions/bind
@@ -24,7 +24,7 @@ import argparse
 
 from plinth import action_utils
 from plinth.modules.bind import CONFIG_FILE, DEFAULT_CONFIG
-from plinth.modules.bind import set_forwarding, enable_dnssec, set_forwarders
+from plinth.modules.bind import set_forwarders, set_dnssec
 
 
 def parse_arguments():
@@ -34,13 +34,10 @@ def parse_arguments():
     subparsers.add_parser('setup', help='Setup for BIND')
 
     configure = subparsers.add_parser('configure', help='Configure BIND')
-    configure.add_argument('--set-forwarding', choices=['true', 'false'],
-                           help='Set forwarding true/false')
-    configure.add_argument('--enable-dnssec', choices=['true', 'false'],
-                           help='Set DNSSEC true/false')
-
-    dns = subparsers.add_parser('dns', help='Set DNS forwarders')
-    dns.add_argument('--set', help='List of IP addresses, separated by space')
+    configure.add_argument('--forwarders',
+                           help='List of IP addresses, separated by space')
+    configure.add_argument('--dnssec', choices=['enable', 'disable'],
+                           help='Enable or disable DNSSEC')
 
     subparsers.required = True
     return parser.parse_args()
@@ -54,22 +51,10 @@ def subcommand_setup(_):
     action_utils.service_restart('bind9')
 
 
-def subcommand_dns(arguments):
-    """Setting DNS servers"""
-    if arguments.set:
-        set_forwarders(arguments.set)
-
-    action_utils.service_restart('bind9')
-
-
 def subcommand_configure(arguments):
     """Configure BIND."""
-    if arguments.set_forwarding:
-        set_forwarding(arguments.set_forwarding)
-
-    if arguments.enable_dnssec:
-        enable_dnssec(arguments.enable_dnssec)
-
+    set_forwarders(arguments.forwarders)
+    set_dnssec(arguments.dnssec)
     action_utils.service_restart('bind9')
 
 

--- a/actions/bind
+++ b/actions/bind
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 Configuration helper for BIND server.
 """
@@ -24,32 +23,8 @@ Configuration helper for BIND server.
 import argparse
 
 from plinth import action_utils
-
-
-CONFIG_FILE = '/etc/bind/named.conf.options'
-
-DEFAULT_CONFIG = '''
-acl goodclients {
-    localnets;
-};
-options {
-directory "/var/cache/bind";
-
-recursion yes;
-allow-query { goodclients; };
-
-forwarders {
-8.8.8.8; 8.8.4.4;
-};
-forward first;
-
-dnssec-enable yes;
-dnssec-validation auto;
-
-auth-nxdomain no;    # conform to RFC1035
-listen-on-v6 { any; };
-};
-'''
+from plinth.modules.bind import CONFIG_FILE, DEFAULT_CONFIG
+from plinth.modules.bind import set_forwarding, enable_dnssec, set_forwarders
 
 
 def parse_arguments():
@@ -96,81 +71,6 @@ def subcommand_configure(arguments):
         enable_dnssec(arguments.enable_dnssec)
 
     action_utils.service_restart('bind9')
-
-
-def set_forwarding(choice):
-    """Enable or disable DNS forwarding."""
-    data = [line.strip() for line in open(CONFIG_FILE, 'r')]
-    flag = 0
-    if choice == "false":
-        if 'forwarders {' in data and not '// forwarders {' in data:
-            conf_file = open(CONFIG_FILE, 'w')
-            for line in data:
-                if 'forwarders {' in line and not '// forwarders {' in line:
-                    flag = 1
-                if flag == 1:
-                    line = '	// ' + line
-                if 'forward first' in line:
-                    flag = 0
-                if "0.0.0.0" not in line:
-                    conf_file.write(line + '\n')
-            conf_file.close()
-
-    else:
-        if '// forwarders {' in data:
-            conf_file = open(CONFIG_FILE, 'w')
-            for line in data:
-                if '// forwarders {' in line:
-                    flag = 1
-                if flag == 1:
-                    line = line[2:]
-                if 'forward first' in line:
-                    flag = 0
-                if "0.0.0.0" not in line:
-                    conf_file.write(line + '\n')
-            conf_file.close()
-
-
-def enable_dnssec(choice):
-    """Enable or disable DNSSEC."""
-    data = [line.strip() for line in open(CONFIG_FILE, 'r')]
-    if choice == "false":
-        if '//dnssec-enable yes;' not in data:
-            conf_file = open(CONFIG_FILE, 'w')
-            for line in data:
-                if 'dnssec-enable yes;' in line:
-                    line = '//' + line
-                conf_file.write(line+'\n')
-            conf_file.close()
-
-    else:
-        if '//dnssec-enable yes;' in data:
-            conf_file = open(CONFIG_FILE, 'w')
-            for line in data:
-                if '//dnssec-enable yes;' in line:
-                    line = line[2:]
-                conf_file.write(line + '\n')
-            conf_file.close()
-
-
-def set_forwarders(forwarders):
-    """Set DNS forwarders."""
-    flag = 0
-    data = [line.strip() for line in open(CONFIG_FILE, 'r')]
-    conf_file = open(CONFIG_FILE, 'w')
-    for line in data:
-        if 'forwarders {' in line:
-            conf_file.write(line + '\n')
-            for dns in forwarders.split():
-                conf_file.write(dns + '; ')
-            conf_file.write('\n')
-            flag = 1
-        elif '};' in line and flag == 1:
-            conf_file.write(line + '\n')
-            flag = 0
-        elif flag == 0:
-            conf_file.write(line + '\n')
-    conf_file.close()
 
 
 def main():

--- a/plinth/modules/bind/__init__.py
+++ b/plinth/modules/bind/__init__.py
@@ -121,13 +121,11 @@ def get_config():
     """Get current configuration"""
     data = [line.strip() for line in open(CONFIG_FILE, 'r')]
 
-    forwarding_enabled = False
-    dnssec_enabled = False
     forwarders = ''
+    dnssec_enabled = False
     flag = False
     for line in data:
         if re.match(r'^\s*forwarders\s+{', line):
-            forwarding_enabled = True
             flag = True
         elif re.match(r'^\s*dnssec-enable\s+yes;', line):
             dnssec_enabled = True
@@ -136,60 +134,10 @@ def get_config():
             flag = False
 
     conf = {
-        'set_forwarding': forwarding_enabled,
+        'forwarders': forwarders,
         'enable_dnssec': dnssec_enabled,
-        'forwarders': forwarders
     }
     return conf
-
-
-def set_forwarding(choice):
-    """Enable or disable DNS forwarding."""
-    data = [line.strip() for line in open(CONFIG_FILE, 'r')]
-    flag = 0
-    if choice == "false":
-        conf_file = open(CONFIG_FILE, 'w')
-        for line in data:
-            if re.match(r'^\s*forwarders\s+{', line):
-                flag = 1
-            if flag == 1:
-                line = '// ' + line
-            if re.match(r'forward\s+first', line):
-                flag = 0
-            conf_file.write(line + '\n')
-        conf_file.close()
-
-    else:
-        conf_file = open(CONFIG_FILE, 'w')
-        for line in data:
-            if re.match(r'//\s*forwarders\s+{', line):
-                flag = 1
-            if flag == 1:
-                line = line.lstrip('/')
-            if re.match(r'forward\s+first', line):
-                flag = 0
-            conf_file.write(line + '\n')
-        conf_file.close()
-
-
-def enable_dnssec(choice):
-    """Enable or disable DNSSEC."""
-    data = [line.strip() for line in open(CONFIG_FILE, 'r')]
-    if choice == "false":
-        conf_file = open(CONFIG_FILE, 'w')
-        for line in data:
-            if re.match(r'^\s*dnssec-enable\s+yes;', line):
-                line = '//' + line
-            conf_file.write(line + '\n')
-        conf_file.close()
-
-    else:
-        conf_file = open(CONFIG_FILE, 'w')
-        for line in data:
-            if re.match(r'//\s*dnssec-enable\s+yes;', line):
-                line = line.lstrip('/')
-            conf_file.write(line + '\n')
-        conf_file.close()
 
 
 def set_forwarders(forwarders):
@@ -210,3 +158,24 @@ def set_forwarders(forwarders):
         elif flag == 0:
             conf_file.write(line + '\n')
     conf_file.close()
+
+
+def set_dnssec(choice):
+    """Enable or disable DNSSEC."""
+    data = [line.strip() for line in open(CONFIG_FILE, 'r')]
+
+    if choice == 'enable':
+        conf_file = open(CONFIG_FILE, 'w')
+        for line in data:
+            if re.match(r'//\s*dnssec-enable\s+yes;', line):
+                line = line.lstrip('/')
+            conf_file.write(line + '\n')
+        conf_file.close()
+
+    if choice == 'disable':
+        conf_file = open(CONFIG_FILE, 'w')
+        for line in data:
+            if re.match(r'^\s*dnssec-enable\s+yes;', line):
+                line = '//' + line
+            conf_file.write(line + '\n')
+        conf_file.close()

--- a/plinth/modules/bind/__init__.py
+++ b/plinth/modules/bind/__init__.py
@@ -58,7 +58,7 @@ recursion yes;
 allow-query { goodclients; };
 
 forwarders {
-8.8.8.8; 8.8.4.4;
+
 };
 forward first;
 

--- a/plinth/modules/bind/forms.py
+++ b/plinth/modules/bind/forms.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 Forms for BIND module.
 """
@@ -34,17 +33,11 @@ def validate_ips(ips):
 
 class BindForm(ServiceForm):
     """BIND configuration form"""
-    set_forwarding = forms.BooleanField(
-        label=_('Enable forwarding'),
-        required=False,
-        help_text=_('Enable forwarding on your BIND server'))
+    forwarders = forms.CharField(
+        required=False, validators=[validate_ips], help_text=_(
+            'A list DNS servers, separated by space, to which '
+            'requests will be forwarded'))
 
     enable_dnssec = forms.BooleanField(
-        label=_('Enable DNSSEC'),
-        required=False,
+        label=_('Enable DNSSEC'), required=False,
         help_text=_('Enable Domain Name System Security Extensions'))
-
-    forwarders = forms.CharField(
-        required=False,
-        validators=[validate_ips],
-        help_text=_('A list of IP addresses, separated by space'))

--- a/plinth/modules/bind/tests/test_bind.py
+++ b/plinth/modules/bind/tests/test_bind.py
@@ -1,0 +1,62 @@
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test actions for configuring bind
+"""
+
+import tempfile
+import unittest
+
+from plinth.modules import bind
+
+
+class TestBind(unittest.TestCase):
+    """Test actions for configuring bind."""
+
+    def setUp(self):
+        self.conf_file = tempfile.NamedTemporaryFile()
+        with open(self.conf_file.name, 'w') as conf:
+            conf.write(bind.DEFAULT_CONFIG)
+
+        bind.CONFIG_FILE = self.conf_file.name
+
+    def test_set_forwarding(self):
+        bind.set_forwarding("true")
+        conf = bind.get_config()
+        self.assertEqual(conf['set_forwarding'], True)
+
+        bind.set_forwarding("false")
+        conf = bind.get_config()
+        self.assertEqual(conf['set_forwarding'], False)
+
+    def test_enable_dnssec(self):
+        bind.enable_dnssec("true")
+        conf = bind.get_config()
+        self.assertEqual(conf['enable_dnssec'], True)
+
+        bind.enable_dnssec("false")
+        conf = bind.get_config()
+        self.assertEqual(conf['enable_dnssec'], False)
+
+    def test_set_forwarders(self):
+        bind.set_forwarders('8.8.8.8 8.8.4.4')
+        conf = bind.get_config()
+        self.assertEqual(conf['forwarders'], '8.8.8.8 8.8.4.4')
+
+        bind.set_forwarders('')
+        conf = bind.get_config()
+        self.assertEqual(conf['forwarders'], '')

--- a/plinth/modules/bind/tests/test_bind.py
+++ b/plinth/modules/bind/tests/test_bind.py
@@ -34,24 +34,6 @@ class TestBind(unittest.TestCase):
 
         bind.CONFIG_FILE = self.conf_file.name
 
-    def test_set_forwarding(self):
-        bind.set_forwarding("true")
-        conf = bind.get_config()
-        self.assertEqual(conf['set_forwarding'], True)
-
-        bind.set_forwarding("false")
-        conf = bind.get_config()
-        self.assertEqual(conf['set_forwarding'], False)
-
-    def test_enable_dnssec(self):
-        bind.enable_dnssec("true")
-        conf = bind.get_config()
-        self.assertEqual(conf['enable_dnssec'], True)
-
-        bind.enable_dnssec("false")
-        conf = bind.get_config()
-        self.assertEqual(conf['enable_dnssec'], False)
-
     def test_set_forwarders(self):
         bind.set_forwarders('8.8.8.8 8.8.4.4')
         conf = bind.get_config()
@@ -60,3 +42,12 @@ class TestBind(unittest.TestCase):
         bind.set_forwarders('')
         conf = bind.get_config()
         self.assertEqual(conf['forwarders'], '')
+
+    def test_enable_dnssec(self):
+        bind.set_dnssec('enable')
+        conf = bind.get_config()
+        self.assertEqual(conf['enable_dnssec'], True)
+
+        bind.set_dnssec('disable')
+        conf = bind.get_config()
+        self.assertEqual(conf['enable_dnssec'], False)

--- a/plinth/modules/bind/views.py
+++ b/plinth/modules/bind/views.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 Views for BIND module.
 """
@@ -25,12 +24,11 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import actions
 from plinth.views import ServiceView
 
-
-from . import description, managed_services, get_default
+from . import description, managed_services, get_config
 from .forms import BindForm
 
 
-class BindServiceView(ServiceView): # pylint: disable=too-many-ancestors
+class BindServiceView(ServiceView):  # pylint: disable=too-many-ancestors
     """A specialized view for configuring Bind."""
     service_id = managed_services[0]
     diagnostics_module_name = "bind"
@@ -41,35 +39,31 @@ class BindServiceView(ServiceView): # pylint: disable=too-many-ancestors
     def get_initial(self):
         """Return the values to fill in the form."""
         initial = super().get_initial()
-        initial.update(get_default())
+        initial.update(get_config())
         return initial
 
     def form_valid(self, form):
         """Change the configurations of Bind service."""
         data = form.cleaned_data
-        old_config = get_default()
+        old_config = get_config()
 
         if old_config['set_forwarding'] != data['set_forwarding']:
             value = 'true' if data['set_forwarding'] else 'false'
-            actions.superuser_run(
-                'bind',
-                ['configure', '--set-forwarding', value])
+            actions.superuser_run('bind',
+                                  ['configure', '--set-forwarding', value])
             messages.success(self.request,
                              _('Set forwarding configuration updated'))
 
         if old_config['enable_dnssec'] != data['enable_dnssec']:
             value = 'true' if data['enable_dnssec'] else 'false'
-            actions.superuser_run(
-                'bind',
-                ['configure', '--enable-dnssec', value])
+            actions.superuser_run('bind',
+                                  ['configure', '--enable-dnssec', value])
             messages.success(self.request,
                              _('Enable DNSSEC configuration updated'))
 
         if old_config['forwarders'] != data['forwarders'] \
            and old_config['forwarders'] is not '':
-            actions.superuser_run(
-                'bind',
-                ['dns', '--set', data['forwarders']])
+            actions.superuser_run('bind', ['dns', '--set', data['forwarders']])
             messages.success(self.request,
                              _('DNS server configuration updated'))
         elif old_config['forwarders'] is '' \

--- a/plinth/modules/bind/views.py
+++ b/plinth/modules/bind/views.py
@@ -47,29 +47,13 @@ class BindServiceView(ServiceView):  # pylint: disable=too-many-ancestors
         data = form.cleaned_data
         old_config = get_config()
 
-        if old_config['set_forwarding'] != data['set_forwarding']:
-            value = 'true' if data['set_forwarding'] else 'false'
-            actions.superuser_run('bind',
-                                  ['configure', '--set-forwarding', value])
-            messages.success(self.request,
-                             _('Set forwarding configuration updated'))
-
-        if old_config['enable_dnssec'] != data['enable_dnssec']:
-            value = 'true' if data['enable_dnssec'] else 'false'
-            actions.superuser_run('bind',
-                                  ['configure', '--enable-dnssec', value])
-            messages.success(self.request,
-                             _('Enable DNSSEC configuration updated'))
-
         if old_config['forwarders'] != data['forwarders'] \
-           and old_config['forwarders'] is not '':
-            actions.superuser_run('bind', ['dns', '--set', data['forwarders']])
-            messages.success(self.request,
-                             _('DNS server configuration updated'))
-        elif old_config['forwarders'] is '' \
-             and old_config['forwarders'] != data['forwarders']:
-            messages.error(
-                self.request,
-                _('Enable forwarding to set forwarding DNS servers'))
+           or old_config['enable_dnssec'] != data['enable_dnssec']:
+            dnssec_setting = 'enable' if data['enable_dnssec'] else 'disable'
+            actions.superuser_run('bind', [
+                'configure', '--forwarders', data['forwarders'], '--dnssec',
+                dnssec_setting
+            ])
+            messages.success(self.request, _('BIND configuration updated'))
 
         return super().form_valid(form)


### PR DESCRIPTION
- Remove option to enable DNS forwarding. This is controlled simply by adding or clearing the list of forwarders.
- Use empty forwarders list by default (#1158).
- Add tests for changing config.