### PR TITLE
Complete some of the pending changing in renaming some files to .md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -28,7 +28,7 @@ The entire setup is automatic and requires about 4.5 GB of disk space.
 
 ## Installing Dependencies
 
-Apart from dependencies listing in INSTALL file, Plinth may have additional
+Apart from dependencies listing in INSTALL.md file, Plinth may have additional
 dependencies required by modules of Plinth.  To install these, run:
 
     $ sudo apt install -y $(plinth --list-dependencies)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ the [FreedomBox Wiki](https://wiki.debian.org/FreedomBox/) and the
 
 # Getting Started
 
-See the INSTALL file for additional details and dependencies. To install run:
+See the INSTALL.md file for additional details and dependencies. To install run:
 
     $ sudo python3 setup.py install
 

--- a/debian/plinth.docs
+++ b/debian/plinth.docs
@@ -1,5 +1,5 @@
 README.md
-HACKING
+HACKING.md
 doc/*.html
 doc/*.pdf
 doc/images

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ setuptools.setup(
                            exclude=['*.templates']),
     scripts=['bin/plinth'],
     test_suite='plinth.tests.runtests.run_tests',
-    license='COPYING',
+    license='COPYING.md',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',


### PR DESCRIPTION
In commit d4b4791, four files were renamed by adding a file extension .md
The files are CONTRIBUTING, COPYING, HACKING and INSTALL
This commit fixes the pending tasks and especially the bug where HACKING.md is
wrongly listed as HACKING in debian/plinth.docs and cause build failure for the
Debian package of Plinth

Signed-off-by: Joseph Nuthalapati <njoseph@thoughtworks.com>