### PR TITLE
User: Consistent listing of groups

### DIFF
--- a/plinth/modules/deluge/__init__.py
+++ b/plinth/modules/deluge/__init__.py
@@ -26,7 +26,7 @@ from plinth import action_utils
 from plinth import frontpage
 from plinth import service as service_module
 from plinth.menu import main_menu
-from plinth.modules.users import create_group, register_group
+from plinth.modules.users import register_group
 from .manifest import clients
 
 
@@ -63,6 +63,7 @@ def init():
     menu = main_menu.get('apps')
     menu.add_urlname(name, 'glyphicon-magnet',
                      'deluge:index', short_description)
+    register_group(group)
 
     global service
     setup_helper = globals()['setup_helper']
@@ -74,7 +75,6 @@ def init():
 
         if is_enabled():
             add_shortcut()
-            register_group(group)
 
 
 def setup(helper, old_version=None):
@@ -89,7 +89,6 @@ def setup(helper, old_version=None):
             disable=disable)
     helper.call('post', service.notify_enabled, None, True)
     helper.call('post', add_shortcut)
-    create_group(group[0])
 
 
 def add_shortcut():

--- a/plinth/modules/ikiwiki/__init__.py
+++ b/plinth/modules/ikiwiki/__init__.py
@@ -28,7 +28,7 @@ from plinth import cfg
 from plinth import frontpage
 from plinth import service as service_module
 from plinth.menu import main_menu
-from plinth.modules.users import create_group, register_group
+from plinth.modules.users import register_group
 from .manifest import clients
 
 
@@ -69,6 +69,7 @@ def init():
     """Initialize the ikiwiki module."""
     menu = main_menu.get('apps')
     menu.add_urlname(name, 'glyphicon-edit', 'ikiwiki:index', short_description)
+    register_group(group)
 
     global service
     setup_helper = globals()['setup_helper']
@@ -79,7 +80,6 @@ def init():
 
         if is_enabled():
             add_shortcuts()
-            register_group(group)
 
 
 def setup(helper, old_version=None):
@@ -93,7 +93,6 @@ def setup(helper, old_version=None):
             is_enabled=is_enabled, enable=enable, disable=disable)
     helper.call('post', service.notify_enabled, None, True)
     helper.call('post', add_shortcuts)
-    create_group(group[0])
 
 
 def add_shortcuts():

--- a/plinth/modules/transmission/__init__.py
+++ b/plinth/modules/transmission/__init__.py
@@ -25,7 +25,7 @@ from django.utils.translation import ugettext_lazy as _
 from plinth import service as service_module
 from plinth import action_utils, actions, frontpage
 from plinth.menu import main_menu
-from plinth.modules.users import create_group, register_group
+from plinth.modules.users import register_group
 from .manifest import clients
 
 version = 2
@@ -59,6 +59,7 @@ def init():
     menu = main_menu.get('apps')
     menu.add_urlname(name, 'glyphicon-save', 'transmission:index',
                      short_description)
+    register_group(group)
 
     global service
     setup_helper = globals()['setup_helper']
@@ -70,7 +71,7 @@ def init():
 
         if is_enabled():
             add_shortcut()
-            register_group(group)
+
 
 
 def setup(helper, old_version=None):
@@ -94,7 +95,6 @@ def setup(helper, old_version=None):
                                          disable=disable)
     helper.call('post', service.notify_enabled, None, True)
     helper.call('post', add_shortcut)
-    create_group(group[0])
 
 
 def add_shortcut():

--- a/plinth/modules/ttrss/__init__.py
+++ b/plinth/modules/ttrss/__init__.py
@@ -28,7 +28,7 @@ from plinth import cfg
 from plinth import frontpage
 from plinth import service as service_module
 from plinth.menu import main_menu
-from plinth.modules.users import create_group, register_group
+from plinth.modules.users import register_group
 from .manifest import clients
 
 
@@ -71,6 +71,7 @@ def init():
     menu = main_menu.get('apps')
     menu.add_urlname(name, 'glyphicon-envelope', 'ttrss:index',
                      short_description)
+    register_group(group)
 
     global service
     setup_helper = globals()['setup_helper']
@@ -82,7 +83,6 @@ def init():
 
         if is_enabled():
             add_shortcut()
-            register_group(group)
 
 
 def setup(helper, old_version=None):
@@ -98,7 +98,6 @@ def setup(helper, old_version=None):
             is_enabled=is_enabled, enable=enable, disable=disable)
     helper.call('post', service.notify_enabled, None, True)
     helper.call('post', add_shortcut)
-    create_group(group[0])
 
 
 def add_shortcut():

--- a/plinth/modules/users/__init__.py
+++ b/plinth/modules/users/__init__.py
@@ -96,7 +96,6 @@ def _diagnose_ldap_entry(search_item):
 def create_group(group):
     """Add an LDAP group."""
     actions.superuser_run('users', options=['create-group', group])
-    register_group(group)
 
 
 def remove_group(group):

--- a/plinth/modules/users/forms.py
+++ b/plinth/modules/users/forms.py
@@ -39,7 +39,6 @@ def get_group_choices():
     choices = {(g[0], ('{} ({})'.format(g[1], g[0]))) for g in users.groups}
     return sorted(list(choices), key=lambda g: g[0])
 
-
 class ValidNewUsernameCheckMixin(object):
     """Mixin to check if a username is valid for created new user."""
 
@@ -109,6 +108,7 @@ class CreateUserForm(ValidNewUsernameCheckMixin, UserCreationForm):
 
             for group in self.cleaned_data['groups']:
                 try:
+                    users.create_group(group)
                     actions.superuser_run('users', [
                         'add-user-to-group',
                         user.get_username(), group
@@ -205,6 +205,7 @@ class UserUpdateForm(ValidNewUsernameCheckMixin, forms.ModelForm):
             for new_group in new_groups:
                 if new_group not in old_groups:
                     try:
+                        users.create_group(new_group)
                         actions.superuser_run('users', [
                             'add-user-to-group',
                             user.get_username(), new_group

--- a/plinth/modules/users/tests/test_group.py
+++ b/plinth/modules/users/tests/test_group.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+#
+# This file is part of Plinth.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test module to exercise group registration.
+
+It is recommended to run this module with root privileges in a virtual machine.
+"""
+
+import unittest
+from plinth.modules import users
+
+class TestGroups(unittest.TestCase):
+
+    def test_register_group(self):
+        """Test for multi addition of same group"""
+        groupname = "TestGroup"
+        users.register_group(groupname)
+        users.register_group(groupname)
+        self.assertEqual(len(users.groups),1, "Duplicate entries for same group generated!")
+        return users.groups


### PR DESCRIPTION
- Remove conditional registration of groups on module initialization
- Create uninitialized groups on addition/update of groups for user
- Remove group creation on setup/installation of a module

Tested for:
- Multi registration of groups
- Manual UI test to check visibility of groups irrespective of whether module is installed/enabled
Signed-off-by: Aakanksha Saini <aakanksa@thoughtworks.com>