### PR TITLE
diagnostics: Enable button when enabled but not running

### DIFF
--- a/plinth/modules/openvpn/templates/openvpn.html
+++ b/plinth/modules/openvpn/templates/openvpn.html
@@ -111,7 +111,7 @@
       {% endif %}
     </p>
 
-    {% include "diagnostics_button.html" with module="openvpn" enabled=status.is_running %}
+    {% include "diagnostics_button.html" with module="openvpn" enabled=status.is_enabled %}
 
     <h3>{% trans "Configuration" %}</h3>
 

--- a/plinth/modules/tor/templates/tor.html
+++ b/plinth/modules/tor/templates/tor.html
@@ -55,7 +55,7 @@
       {% endif %}
     </p>
 
-    {% include "diagnostics_button.html" with module="tor" enabled=status.is_running %}
+    {% include "diagnostics_button.html" with module="tor" enabled=status.is_enabled %}
 
     {% if status.hs_enabled %}
       <div class="row">

--- a/plinth/templates/service.html
+++ b/plinth/templates/service.html
@@ -59,7 +59,7 @@
 
   {% block diagnostics %}
     {% if diagnostics_module_name %}
-      {% include "diagnostics_button.html" with module=diagnostics_module_name enabled=service.is_running %}
+      {% include "diagnostics_button.html" with module=diagnostics_module_name enabled=service.is_enabled %}
     {% endif %}
   {% endblock %}
 


### PR DESCRIPTION
This commit fixes the diagnostics issue by disabling button only when service is not enabled.
#1181 