### PR TITLE
openvpn: Upgrade to the new Debian way

### DIFF
--- a/actions/openvpn
+++ b/actions/openvpn
@@ -32,7 +32,11 @@ KEYS_DIRECTORY = '/etc/openvpn/freedombox-keys'
 
 DH_KEY = '/etc/openvpn/freedombox-keys/dh4096.pem'
 
-SERVER_CONFIGURATION_PATH = '/etc/openvpn/freedombox.conf'
+OLD_SERVER_CONFIGURATION_PATH = '/etc/openvpn/freedombox.conf'
+SERVER_CONFIGURATION_PATH = '/etc/openvpn/server/freedombox.conf'
+
+OLD_SERVICE_NAME = 'openvpn@freedombox'
+SERVICE_NAME = 'openvpn-server@freedombox'
 
 CA_CERTIFICATE_PATH = KEYS_DIRECTORY + '/ca.crt'
 USER_CERTIFICATE_PATH = KEYS_DIRECTORY + '/{username}.crt'
@@ -99,6 +103,9 @@ def parse_arguments():
 
     subparsers.add_parser('is-setup', help='Return whether setup is completed')
     subparsers.add_parser('setup', help='Setup OpenVPN server configuration')
+    subparsers.add_parser(
+        'upgrade',
+        help='Upgrade OpenVPN server configuration from older configuration')
 
     get_profile = subparsers.add_parser(
         'get-profile', help='Return the OpenVPN profile of a user')
@@ -120,8 +127,21 @@ def subcommand_setup(_):
     _create_server_config()
     _create_certificates()
     _setup_firewall()
-    action_utils.service_enable('openvpn@freedombox')
-    action_utils.service_restart('openvpn@freedombox')
+    action_utils.service_enable(SERVICE_NAME)
+    action_utils.service_restart(SERVICE_NAME)
+
+
+def subcommand_upgrade(_):
+    """Upgrade from an older version if configured.
+
+    Otherwise do nothing.
+    """
+    if os.path.exists(OLD_SERVER_CONFIGURATION_PATH):
+        os.rename(OLD_SERVER_CONFIGURATION_PATH, SERVER_CONFIGURATION_PATH)
+
+    if action_utils.service_is_enabled(OLD_SERVICE_NAME):
+        action_utils.service_disable(OLD_SERVICE_NAME)
+        action_utils.service_enable(SERVICE_NAME)
 
 
 def _create_server_config():

--- a/actions/openvpn
+++ b/actions/openvpn
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 Configuration helper for OpenVPN server.
 """
@@ -92,8 +91,7 @@ CERTIFICATE_CONFIGURATION = {
     'KEY_NAME': 'FreedomBox'
 }
 
-COMMON_ARGS = {'env': CERTIFICATE_CONFIGURATION,
-               'cwd': KEYS_DIRECTORY}
+COMMON_ARGS = {'env': CERTIFICATE_CONFIGURATION, 'cwd': KEYS_DIRECTORY}
 
 
 def parse_arguments():
@@ -155,10 +153,12 @@ def _create_server_config():
 
 def _setup_firewall():
     """Add TUN device to internal zone in firewalld."""
-    subprocess.call(['firewall-cmd', '--zone', 'internal',
-                     '--add-interface', 'tun+'])
-    subprocess.call(['firewall-cmd', '--permanent', '--zone', 'internal',
-                     '--add-interface', 'tun+'])
+    subprocess.call(
+        ['firewall-cmd', '--zone', 'internal', '--add-interface', 'tun+'])
+    subprocess.call([
+        'firewall-cmd', '--permanent', '--zone', 'internal', '--add-interface',
+        'tun+'
+    ])
 
 
 def _create_certificates():
@@ -171,8 +171,8 @@ def _create_certificates():
     subprocess.check_call(['/usr/share/easy-rsa/clean-all'], **COMMON_ARGS)
     subprocess.check_call(['/usr/share/easy-rsa/pkitool', '--initca'],
                           **COMMON_ARGS)
-    subprocess.check_call(['/usr/share/easy-rsa/pkitool', '--server',
-                           'server'], **COMMON_ARGS)
+    subprocess.check_call(
+        ['/usr/share/easy-rsa/pkitool', '--server', 'server'], **COMMON_ARGS)
     subprocess.check_call(['/usr/share/easy-rsa/build-dh'], **COMMON_ARGS)
 
 
@@ -224,8 +224,8 @@ def _is_non_empty_file(filepath):
 
 def load_augeas():
     """Initialize Augeas."""
-    aug = augeas.Augeas(flags=augeas.Augeas.NO_LOAD +
-                        augeas.Augeas.NO_MODL_AUTOLOAD)
+    aug = augeas.Augeas(
+        flags=augeas.Augeas.NO_LOAD + augeas.Augeas.NO_MODL_AUTOLOAD)
 
     # shell-script config file lens
     aug.set('/augeas/load/Simplevars/lens', 'Simplevars.lns')

--- a/plinth/modules/openvpn/__init__.py
+++ b/plinth/modules/openvpn/__init__.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 """
 Plinth module to configure OpenVPN server.
 """
@@ -57,13 +56,14 @@ description = [
 def init():
     """Initialize the OpenVPN module."""
     menu = main_menu.get('apps')
-    menu.add_urlname(name, 'glyphicon-lock', 'openvpn:index', short_description)
+    menu.add_urlname(name, 'glyphicon-lock', 'openvpn:index',
+                     short_description)
 
     global service
     setup_helper = globals()['setup_helper']
     if setup_helper.get_state() != 'needs-setup':
-        service = service_module.Service(
-            managed_services[0], name, ports=['openvpn'], is_external=True)
+        service = service_module.Service(managed_services[0], name,
+                                         ports=['openvpn'], is_external=True)
 
         if service.is_enabled() and is_setup():
             add_shortcut()
@@ -75,9 +75,9 @@ def setup(helper, old_version=None):
     helper.call('post', actions.superuser_run, 'openvpn', ['upgrade'])
     global service
     if service is None:
-        service = service_module.Service(
-            managed_services[0], name, ports=['openvpn'], is_external=True,
-            enable=enable, disable=disable)
+        service = service_module.Service(managed_services[0], name,
+                                         ports=['openvpn'], is_external=True,
+                                         enable=enable, disable=disable)
 
 
 def add_shortcut():
@@ -86,11 +86,10 @@ def add_shortcut():
         format_lazy(_('<a class="btn btn-primary btn-sm" href="{link}">'
                       'Download Profile</a>'),
                     link=reverse_lazy('openvpn:profile'))
-    frontpage.add_shortcut('openvpn', name,
-                           short_description=short_description,
-                           details=description + [download_profile],
-                           configure_url=reverse_lazy('openvpn:index'),
-                           login_required=True)
+    frontpage.add_shortcut(
+        'openvpn', name, short_description=short_description,
+        details=description + [download_profile],
+        configure_url=reverse_lazy('openvpn:index'), login_required=True)
 
 
 def is_setup():

--- a/plinth/modules/openvpn/__init__.py
+++ b/plinth/modules/openvpn/__init__.py
@@ -30,12 +30,11 @@ from plinth import service as service_module
 from plinth.menu import main_menu
 from plinth.utils import format_lazy
 
-
-version = 1
+version = 2
 
 service = None
 
-managed_services = ['openvpn@freedombox']
+managed_services = ['openvpn-server@freedombox']
 
 managed_packages = ['openvpn', 'easy-rsa']
 
@@ -73,6 +72,7 @@ def init():
 def setup(helper, old_version=None):
     """Install and configure the module."""
     helper.install(managed_packages)
+    helper.call('post', actions.superuser_run, 'openvpn', ['upgrade'])
     global service
     if service is None:
         service = service_module.Service(


### PR DESCRIPTION
Earlier only openvpn@.service file was available. Currently, Debian is using
openvpn-server@.service and openvpn-client@.service. Start using this and
upgrade our current users to this approach. This fixes the problem with
incorrect enabling/disabling of OpenVPN app in Plinth.

Tested primarily three cases:

- Install version 2 of the app directly. Make sure daemon runs,
  enabling/disabling the app works.

- Install version 1 of the app. Disable it. Upgrade to version 2 make sure
  everything is upgraded but disabled. Enabling make the app work properly.

- Install version 1 of the app. Enable it. Upgrade to version 2 make sure
  everything is upgraded, app is enabled and running.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>