### PR TITLE
help: also show menu on smaller screens

### DIFF
--- a/plinth/modules/help/templates/help_base.html
+++ b/plinth/modules/help/templates/help_base.html
@@ -22,6 +22,13 @@
 {% load firstboot_extras %}
 {% load static %}
 
+{% block submenu %}
+  {% if submenu %}
+    <div class="sidebar">
+      {% include "submenu.html" with menu=submenu %}
+    </div>
+  {% endif %}
+{% endblock %}
 
 {# Adapt mainmenu-links during firstboot #}
 {% block mainmenu_left %}


### PR DESCRIPTION
This should fix issue #1185, by applying the same code snippet to Help page as in commit f069f66.
(I'm still not understanding 100% how this works, honestly.)