### PR TITLE
debian: Add e2fsprogs as explicit dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,6 +9,7 @@
    augeas-tools \
    dblatex \
    docbook-utils \
+   e2fsprogs \
    gettext \
    gir1.2-glib-2.0 \
    gir1.2-nm-1.0 \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+plinth (0.21.0) UNRELEASED; urgency=medium
+
+  [ Sunil Mohan Adapa ]
+  * Add explicit dependency on e2fsprogs (Closes: #887223).
+
+ -- Sunil Mohan Adapa <sunil@medhas.org>  Mon, 15 Jan 2018 13:22:08 +0530
+
 plinth (0.20.0) unstable; urgency=high
 
   [ James Valleroy ]

--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends: debhelper (>= 10~)
  , dblatex
  , dh-python
  , docbook-utils
+ , e2fsprogs
  , gir1.2-nm-1.0
  , libjs-bootstrap
  , python3-all
@@ -49,6 +50,7 @@ Depends: ${python3:Depends}
  , ${plinth:Depends}
  , adduser
  , augeas-tools
+ , e2fsprogs
  , gettext
  , gir1.2-glib-2.0
  , gir1.2-nm-1.0


### PR DESCRIPTION
- To Build-Depends list as tests depend on it.
- To Depends list as storage action needs it.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>