### PR TITLE
tt-rss: Restricted access to 'news' group

### DIFF
--- a/data/etc/apache2/conf-available/tt-rss-plinth.conf
+++ b/data/etc/apache2/conf-available/tt-rss-plinth.conf
@@ -8,7 +8,7 @@ Alias /tt-rss-app /usr/share/tt-rss/www
 <Location /tt-rss>
     Include includes/freedombox-single-sign-on.conf
     <IfModule mod_auth_pubtkt.c>
-        TKTAuthToken "feed-reader" "admin"
+        TKTAuthToken "admin" "news"
     </IfModule>
 </Location>
 

--- a/plinth/modules/ttrss/__init__.py
+++ b/plinth/modules/ttrss/__init__.py
@@ -28,7 +28,7 @@ from plinth import cfg
 from plinth import frontpage
 from plinth import service as service_module
 from plinth.menu import main_menu
-from plinth.modules.users import register_group
+from plinth.modules.users import register_group, create_group
 from .manifest import clients
 
 
@@ -42,6 +42,8 @@ managed_packages = ['tt-rss', 'postgresql', 'dbconfig-pgsql',
 name = _('Tiny Tiny RSS')
 
 short_description = _('News Feed Reader')
+
+group = ('news', _('Read and subscribe to news feeds'))
 
 description = [
     _('Tiny Tiny RSS is a news feed (RSS/Atom) reader and aggregator, '
@@ -61,7 +63,6 @@ description = [
 
 clients = clients
 
-group = ('feed-reader', _('Read and subscribe to news feeds'))
 
 service = None
 


### PR DESCRIPTION
- Add news group
- Add validation in tt-rss-plinth configuration

*Tested on UI by enabling and disabling group access to users
This adresses the issue #955 
Signed-off-by: Shubham Agarwal <shubhama@thoughtworks.com>

